### PR TITLE
Fix/Added decoding of credentials_supported key  to parsing.

### DIFF
--- a/Sources/Entities/CredentialIssuer/CredentialIssuerMetadata.swift
+++ b/Sources/Entities/CredentialIssuer/CredentialIssuerMetadata.swift
@@ -44,6 +44,7 @@ public struct CredentialIssuerMetadata: Decodable, Equatable {
     case display = "display"
     case credentialResponseEncryption = "credential_response_encryption"
     case signedMetadata = "signed_metadata"
+    case credentialsSupported = "credentials_supported"
     case credentialIdentifiersSupported = "credential_identifiers_supported"
   }
   
@@ -93,8 +94,9 @@ public struct CredentialIssuerMetadata: Decodable, Equatable {
     notificationEndpoint = try container.decodeIfPresent(CredentialIssuerEndpoint.self, forKey: .notificationEndpoint)
     
     credentialResponseEncryption = (try? container.decode(CredentialResponseEncryption.self, forKey: .credentialResponseEncryption)) ?? .notRequired
-    
-    let json = try container.decodeIfPresent(JSON.self, forKey: .credentialConfigurationsSupported) ?? []
+
+    let supportedCredentials = try container.decodeIfPresent(JSON.self, forKey: .credentialsSupported) ?? []
+    let json = try container.decodeIfPresent(JSON.self, forKey: .credentialConfigurationsSupported) ?? supportedCredentials
     var mapIdentifierCredential: [CredentialConfigurationIdentifier: CredentialSupported] = [:]
     for (key, value): (String, JSON) in json {
       if let dictionary = value.dictionary,


### PR DESCRIPTION
# Description of change

When testing walletKit on main branches, I noticed that issuing a PID or MDL stopped working.

Tested with EUDI demo issuer: https://issuer.eudiw.dev/oidc

Issue was that wrong key was provided based on issuer response:

```
{
  "credential_endpoint": "https://issuer.eudiw.dev/oidc/credential",
  "credential_issuer": "https://issuer.eudiw.dev/oidc",
  "credentials_supported": {
    "eu.europa.ec.eudiw.mdl_jwt_vc_json": {
      "credential_definition": {
        "credentialSubject": {
          "administrative_number": {
            "display": [
              {
                "locale": "en",
                "name": "An audit control number assigned by the issuing authority"
              }
            ],
            "mandatory": false
          }
```

Now app tries to decode credential_configurations_supported first. If this fails it will try to decode also credentials_supported

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Parameter credentials_supported now decodes as it should

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes