### PR TITLE
Fix Bearer authorization token spelling

### DIFF
--- a/Sources/Entities/IssuanceAccessToken.swift
+++ b/Sources/Entities/IssuanceAccessToken.swift
@@ -53,7 +53,7 @@ public struct IssuanceAccessToken: Codable {
 
 public extension IssuanceAccessToken {
   var authorizationHeader: [String: String] {
-    ["Authorization": "BEARER \(accessToken)"]
+    ["Authorization": "\(TokenType.bearer.rawValue) \(accessToken)"]
   }
   
   func dPoPOrBearerAuthorizationHeader(
@@ -61,13 +61,13 @@ public extension IssuanceAccessToken {
     endpoint: URL?
   ) throws -> [String: String] {
     if tokenType == TokenType.bearer {
-      return ["Authorization": "BEARER \(accessToken)"]
+      return ["Authorization": "\(TokenType.bearer.rawValue) \(accessToken)"]
     } else if let dpopConstructor, tokenType == TokenType.dpop, let endpoint {
       return [
-        "Authorization": "DPoP \(accessToken)",
-        "DPoP": try dpopConstructor.jwt(endpoint: endpoint, accessToken: accessToken)
+        "Authorization": "\(TokenType.dpop.rawValue) \(accessToken)",
+        TokenType.dpop.rawValue: try dpopConstructor.jwt(endpoint: endpoint, accessToken: accessToken)
       ]
     }
-    return ["Authorization": "BEARER \(accessToken)"]
+    return ["Authorization": "\(TokenType.bearer.rawValue) \(accessToken)"]
   }
 }


### PR DESCRIPTION
# Description of change

The bearer prefix for the token should be spelled excactly as "Bearer", see https://datatracker.ietf.org/doc/html/rfc6750#section-2.1. The misspelled token was rejected by the Finnish EUDIWallet backend.

Fixes #52.

## Implementation notes
Use TokenType.rawValue to produce string value of the token prefix to have the correct values defined in a single place.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

* Automated tests in this repository pass
* The fixed token is accepted by the Finnish EUDIWallet backend

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes