### PR TITLE
[fix] Add resource parameter to pushed authorization code request

### DIFF
--- a/Sources/Entities/CredentialIssuer/CredentialIssuerMetadata.swift
+++ b/Sources/Entities/CredentialIssuer/CredentialIssuerMetadata.swift
@@ -19,7 +19,7 @@ import JOSESwift
 
 public struct CredentialIssuerMetadata: Decodable, Equatable {
   public let credentialIssuerIdentifier: CredentialIssuerId
-  public let authorizationServers: [URL]
+  public let authorizationServers: [URL]?
   public let credentialEndpoint: CredentialIssuerEndpoint
   public let batchCredentialEndpoint: CredentialIssuerEndpoint?
   public let deferredCredentialEndpoint: CredentialIssuerEndpoint?

--- a/Sources/Issuers/Issuer.swift
+++ b/Sources/Issuers/Issuer.swift
@@ -145,9 +145,13 @@ public actor Issuer: IssuerType {
     let authorizationServerSupportsPar = credentialOffer.authorizationServerMetadata.authorizationServerSupportsPar
 
     let state = StateValue().value
-    
+
     if authorizationServerSupportsPar {
       do {
+        let resource: String? = issuerMetadata.authorizationServers.map { _ in
+          credentialOffer.credentialIssuerIdentifier.url.absoluteString
+        }
+
         let result: (
           verifier: PKCEVerifier,
           code: GetAuthorizationCodeURL
@@ -155,7 +159,8 @@ public actor Issuer: IssuerType {
           scopes: scopes,
           credentialConfigurationIdentifiers: credentialConfogurationIdentifiers,
           state: state,
-          issuerState: issuerState
+          issuerState: issuerState,
+          resource: resource
         ).get()
         
         return .success(

--- a/Sources/Main/Authorisers/AuthorizationServerClient.swift
+++ b/Sources/Main/Authorisers/AuthorizationServerClient.swift
@@ -31,7 +31,8 @@ public protocol AuthorizationServerClientType {
     scopes: [Scope],
     credentialConfigurationIdentifiers: [CredentialConfigurationIdentifier],
     state: String,
-    issuerState: String?
+    issuerState: String?,
+    resource: String?
   ) async throws -> Result<(PKCEVerifier, GetAuthorizationCodeURL), Error>
   
   func requestAccessTokenAuthFlow(
@@ -181,7 +182,8 @@ public actor AuthorizationServerClient: AuthorizationServerClientType {
     scopes: [Scope],
     credentialConfigurationIdentifiers: [CredentialConfigurationIdentifier],
     state: String,
-    issuerState: String?
+    issuerState: String?,
+    resource: String? = nil
   ) async throws -> Result<(PKCEVerifier, GetAuthorizationCodeURL), Error> {
     guard !scopes.isEmpty else {
       throw ValidationError.error(reason: "No scopes provided. Cannot submit par with no scopes.")
@@ -197,6 +199,7 @@ public actor AuthorizationServerClient: AuthorizationServerClientType {
       state: state,
       codeChallenge: PKCEGenerator.generateCodeChallenge(codeVerifier: codeVerifier),
       codeChallengeMethod: CodeChallenge.sha256.rawValue,
+      resource: resource,
       issuerState: issuerState
     )
     

--- a/Sources/Main/Resolvers/CredentialOffer/CredentialOfferRequestResolver.swift
+++ b/Sources/Main/Resolvers/CredentialOffer/CredentialOfferRequestResolver.swift
@@ -86,7 +86,7 @@ public actor CredentialOfferRequestResolver {
           return .failure(ValidationError.error(reason: "Invalid credential metadata"))
         }
         
-        guard let authorizationServer = credentialIssuerMetadata.authorizationServers.first,
+        guard let authorizationServer = credentialIssuerMetadata.authorizationServers?.first,
               let authorizationServerMetadata = try? await authorizationServerMetadataResolver.resolve(url: authorizationServer).get() else {
           return .failure(ValidationError.error(reason: "Invalid authorization metadata"))
         }
@@ -107,7 +107,7 @@ public actor CredentialOfferRequestResolver {
             return .failure(ValidationError.error(reason: "Invalid credential metadata"))
           }
           
-          guard let authorizationServer = credentialIssuerMetadata.authorizationServers.first,
+          guard let authorizationServer = credentialIssuerMetadata.authorizationServers?.first,
                   let authorizationServerMetadata = try? await authorizationServerMetadataResolver.resolve(url: authorizationServer).get() else {
             return .failure(ValidationError.error(reason: "Invalid authorization metadata"))
           }

--- a/Tests/Helpers/Wallet.swift
+++ b/Tests/Helpers/Wallet.swift
@@ -66,7 +66,7 @@ extension Wallet {
     
     switch issuerMetadata {
     case .success(let metaData):
-      if let authorizationServer = metaData?.authorizationServers.first,
+      if let authorizationServer = metaData?.authorizationServers?.first,
          let metaData {
           let resolver = AuthorizationServerMetadataResolver(
             oidcFetcher: Fetcher(session: self.session),


### PR DESCRIPTION
# Description of change

The OpenID4VCI specification RECOMMENDs that `resource` parameter is added to authorization request when _"Credential Issuer metadata contains an authorization_servers property"_:

>If the Credential Issuer metadata contains an `authorization_servers` property, it is RECOMMENDED to use a `resource` parameter [[RFC8707](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#RFC8707)] whose value is the Credential Issuer's identifier value to allow the Authorization Server to differentiate Credential Issuers.

See https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#section-5.1.2-9.

This PR sets the resource property to the credential issuer identifier (URL) when credential issuer metadata has `authorization_servers` property and also changes the issuer metadata `authorization_servers` property to OPTIONAL as specified, see https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#section-11.2.3-2.2.

Fixes #57.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Tests in this package pass (except for tests that have been failing in the main branch since https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift/commit/054a2b2e484ae25f04fe3d1113b36d6a7fedf4a4)
- [x] Works against the Finnish EUDIWallet backend that requires the `resource` parameter to be present in authorization requests.

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (except for tests that have been failing in the main branch since https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift/commit/054a2b2e484ae25f04fe3d1113b36d6a7fedf4a4)