### PR TITLE
[refactor] Remove credential response property "format"

### DIFF
--- a/Sources/Entities/Issuance/SubmittedRequest.swift
+++ b/Sources/Entities/Issuance/SubmittedRequest.swift
@@ -21,7 +21,7 @@ public struct CredentialIssuanceResponse: Codable {
   
   public enum Result: Codable {
     case deferred(transactionId: TransactionId)
-    case issued(format: String?, credential: String, notificationId: NotificationId?)
+    case issued(credential: String, notificationId: NotificationId?)
   }
   
   public init(credentialResponses: [Result], cNonce: CNonce?) {
@@ -40,7 +40,7 @@ public enum SubmittedRequest {
     case .success(let response):
       response.credentialResponses.compactMap { result in
         switch result {
-        case .issued(_, let credential, _):
+        case .issued(let credential, _):
           credential
         default:
           nil

--- a/Sources/Entities/Profiles/SingleIssuanceSuccessResponse.swift
+++ b/Sources/Entities/Profiles/SingleIssuanceSuccessResponse.swift
@@ -16,7 +16,6 @@
 import Foundation
 
 public struct SingleIssuanceSuccessResponse: Codable {
-  public let format: String?
   public let credential: String?
   public let transactionId: String?
   public let notificationId: String?
@@ -24,7 +23,6 @@ public struct SingleIssuanceSuccessResponse: Codable {
   public let cNonceExpiresInSeconds: Int?
   
   enum CodingKeys: String, CodingKey {
-    case format
     case credential
     case transactionId = "transaction_id"
     case notificationId = "notification_id"
@@ -33,14 +31,12 @@ public struct SingleIssuanceSuccessResponse: Codable {
   }
   
   public init(
-    format: String?,
     credential: String?,
     transactionId: String?,
     notificationId: String?,
     cNonce: String?,
     cNonceExpiresInSeconds: Int?
   ) {
-    self.format = format
     self.credential = credential
     self.transactionId = transactionId
     self.notificationId = notificationId
@@ -59,7 +55,7 @@ public extension SingleIssuanceSuccessResponse {
       )
     } else if let credential = credential {
       return CredentialIssuanceResponse(
-        credentialResponses: [.issued(format: format ?? "", credential: credential, notificationId: nil)],
+        credentialResponses: [.issued(credential: credential, notificationId: nil)],
         cNonce: CNonce(value: cNonce, expiresInSeconds: cNonceExpiresInSeconds)
       )
     } else {

--- a/Sources/Entities/Types/DeferredCredentialIssuanceResponse.swift
+++ b/Sources/Entities/Types/DeferredCredentialIssuanceResponse.swift
@@ -16,13 +16,12 @@
 import Foundation
 
 public enum DeferredCredentialIssuanceResponse: Codable {
-  case issued(format: String?, credential: String)
+  case issued(credential: String)
   case issuancePending(transactionId: TransactionId)
   case errored(error: String?, errorDescription: String?)
   
   private enum CodingKeys: String, CodingKey {
     case type
-    case format
     case credential
     case transactionId = "transaction_id"
     case error
@@ -31,19 +30,10 @@ public enum DeferredCredentialIssuanceResponse: Codable {
   
   public init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
-    if let format = try? container.decode(String.self, forKey: .format),
-       let credential = try? container.decode(String.self, forKey: .credential) {
-      self = .issued(format: format, credential: credential)
-      
-    } else if let transactionId = try? container.decode(String.self, forKey: .transactionId) {
+    if let transactionId = try? container.decode(String.self, forKey: .transactionId) {
       self = .issuancePending(transactionId: try .init(value: transactionId))
-      
     } else if let credential = try? container.decode(String.self, forKey: .credential) {
-       self = .issued(
-        format: nil,
-        credential: credential
-       )
-       
+       self = .issued(credential: credential)
      } else {
       self = .errored(
         error: try? container.decode(String.self, forKey: .error),
@@ -56,9 +46,8 @@ public enum DeferredCredentialIssuanceResponse: Codable {
     var container = encoder.container(keyedBy: CodingKeys.self)
     
     switch self {
-    case let .issued(format, credential):
+    case let .issued(credential):
       try container.encode("issued", forKey: .type)
-      try container.encode(format, forKey: .format)
       try container.encode(credential, forKey: .credential)
       
     case let .issuancePending(transactionId):

--- a/Sources/Issuers/IssuanceRequester.swift
+++ b/Sources/Issuers/IssuanceRequester.swift
@@ -357,7 +357,7 @@ private extension SingleIssuanceSuccessResponse {
   func toSingleIssuanceResponse() throws -> CredentialIssuanceResponse {
     if let credential = credential {
       return CredentialIssuanceResponse(
-        credentialResponses: [.issued(format: format ?? "", credential: credential, notificationId: nil)],
+        credentialResponses: [.issued(credential: credential, notificationId: nil)],
         cNonce: CNonce(value: cNonce, expiresInSeconds: cNonceExpiresInSeconds)
       )
     } else if let transactionId = transactionId {
@@ -376,9 +376,9 @@ private extension BatchIssuanceSuccessResponse {
     func mapResults() throws -> [CredentialIssuanceResponse.Result] {
       return try credentialResponses.map { response in
         if let transactionId = response.transactionId {
-          return CredentialIssuanceResponse.Result.deferred(transactionId: try .init(value: transactionId))
+          return .deferred(transactionId: try .init(value: transactionId))
         } else if let credential = response.credential {
-          return CredentialIssuanceResponse.Result.issued(format: nil, credential: credential, notificationId: nil)
+          return .issued(credential: credential, notificationId: nil)
         } else {
           throw CredentialIssuanceError.responseUnparsable("Got success response for issuance but response misses 'transaction_id' and 'certificate' parameters")
         }

--- a/Tests/Helpers/Wallet.swift
+++ b/Tests/Helpers/Wallet.swift
@@ -491,7 +491,7 @@ extension Wallet {
                 authorized: noProofRequiredState,
                 transactionId: transactionId
               )
-            case .issued(_, let credential, _):
+            case .issued(let credential, _):
               return credential
             }
           } else {
@@ -551,7 +551,7 @@ extension Wallet {
               authorized: authorized,
               transactionId: transactionId
             )
-          case .issued(_, let credential, _):
+          case .issued(let credential, _):
             return credential
           }
         } else {
@@ -581,7 +581,7 @@ extension Wallet {
     switch deferredRequestResponse {
     case .success(let response):
       switch response {
-      case .issued(_, let credential):
+      case .issued(let credential):
         return credential
       case .issuancePending(let transactionId):
         throw ValidationError.error(reason: "Credential not ready yet. Try after \(transactionId.interval ?? 0)")

--- a/Tests/Issuance/IssuanceBatchRequestTest.swift
+++ b/Tests/Issuance/IssuanceBatchRequestTest.swift
@@ -152,7 +152,7 @@ class IssuanceBatchRequestTest: XCTestCase {
                 switch result {
                 case .deferred:
                   XCTAssert(false, "Unexpected deferred")
-                case .issued(_, let credential, _):
+                case .issued(let credential, _):
                   XCTAssert(true, "credential: \(credential)")
                   return
                 }
@@ -307,7 +307,7 @@ class IssuanceBatchRequestTest: XCTestCase {
               switch result {
               case .deferred:
                 XCTAssert(false, "Unexpected deferred")
-              case .issued(_, let credential, _):
+              case .issued(let credential, _):
                 XCTAssert(true, "credential: \(credential)")
                 return
               }
@@ -350,7 +350,7 @@ class IssuanceBatchRequestTest: XCTestCase {
               switch result {
               case .deferred:
                 XCTAssert(false, "Unexpected deferred")
-              case .issued(_, let credential, _):
+              case .issued(let credential, _):
                 XCTAssert(true, "credential: \(credential)")
                 return
               }

--- a/Tests/Issuance/IssuanceDeferredRequestTest.swift
+++ b/Tests/Issuance/IssuanceDeferredRequestTest.swift
@@ -128,7 +128,7 @@ class IssuanceDeferredRequestTest: XCTestCase {
                 case .deferred(let transactionId):
                   XCTAssert(true, "transaction_id: \(transactionId)")
                   return
-                case .issued(_, let credential, _):
+                case .issued(let credential, _):
                   XCTAssert(false, "credential: \(credential)")
                 }
               } else {

--- a/Tests/Issuance/IssuanceNotificationTest.swift
+++ b/Tests/Issuance/IssuanceNotificationTest.swift
@@ -134,7 +134,7 @@ class IssuanceNotificationTest: XCTestCase {
                 switch result {
                 case .deferred:
                   XCTAssert(false, "Unexpected deferred")
-                case .issued(_, let credential, _):
+                case .issued(let credential, _):
                   XCTAssert(true, "credential: \(credential)")
                   
                   let result = try await issuer.notify(
@@ -277,7 +277,7 @@ class IssuanceNotificationTest: XCTestCase {
                 switch result {
                 case .deferred:
                   XCTAssert(false, "Unexpected deferred")
-                case .issued(_, let credential, _):
+                case .issued(let credential, _):
                   XCTAssert(true, "credential: \(credential)")
                   
                   let result = try await issuer.notify(

--- a/Tests/Issuance/IssuanceSingleRequestTest.swift
+++ b/Tests/Issuance/IssuanceSingleRequestTest.swift
@@ -137,7 +137,7 @@ class IssuanceSingleRequestTest: XCTestCase {
                 switch result {
                 case .deferred:
                   XCTAssert(false, "Unexpected deferred")
-                case .issued(_, let credential, _):
+                case .issued(let credential, _):
                   XCTAssert(true, "credential: \(credential)")
                   return
                 }
@@ -270,7 +270,7 @@ class IssuanceSingleRequestTest: XCTestCase {
               switch result {
               case .deferred:
                 XCTAssert(false, "Unexpected deferred")
-              case .issued(_, let credential, _):
+              case .issued(let credential, _):
                 XCTAssert(true, "credential: \(credential)")
                 return
               }
@@ -398,7 +398,7 @@ class IssuanceSingleRequestTest: XCTestCase {
                 switch result {
                 case .deferred:
                   XCTAssert(false, "Unexpected deferred")
-                case .issued(_, let credential, _):
+                case .issued(let credential, _):
                   XCTAssert(true, "credential: \(credential)")
                   return
                 }


### PR DESCRIPTION
"format" is not a specified parameter of OpenID4VCI Credential Response: https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-credential-response.

Fixes #71.

# Description of change

Remove unspecified optional property "format" from data structures that decode credential responses. The property value was always `nil` and it was not used for anything.

## Type of change

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

- Project's automated test suite passes.

# Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [X] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes