### PR TITLE
Refactor/credential issuer metadata resolver api

### DIFF
--- a/Sources/Main/Resolvers/CredentialOffer/CredentialIssuerMetadataResolver.swift
+++ b/Sources/Main/Resolvers/CredentialOffer/CredentialIssuerMetadataResolver.swift
@@ -60,13 +60,9 @@ public actor CredentialIssuerMetadataResolver: CredentialIssuerMetadataType {
   ) async -> Result<CredentialIssuerMetadata, some Error> {
       switch source {
       case .credentialIssuer(let issuerId):
-          let pathComponent1 = ".well-known"
-          let pathComponent2 = "openid-credential-issuer"
-
           let url = issuerId.url
-              .appendingPathComponent(pathComponent1)
-              .appendingPathComponent(pathComponent2)
-
+              .appendingPathComponent(".well-known")
+              .appendingPathComponent("openid-credential-issuer")
           return await fetcher.fetch(url: url)
       }
   }

--- a/Sources/Main/Resolvers/CredentialOffer/CredentialIssuerMetadataResolver.swift
+++ b/Sources/Main/Resolvers/CredentialOffer/CredentialIssuerMetadataResolver.swift
@@ -35,7 +35,7 @@ public protocol CredentialIssuerMetadataType {
   ///   - source: The input source for resolving data.
   /// - Returns: An asynchronous result containing the resolved data or an error.
   func resolve(
-    source: InputType?
+    source: InputType
   ) async -> Result<OutputType?, ErrorType>
 }
 
@@ -56,7 +56,7 @@ public actor CredentialIssuerMetadataResolver: CredentialIssuerMetadataType {
   ///   - source: The input source for resolving metadata.
   /// - Returns: An asynchronous result containing the resolved metadata or an error of type ResolvingError.
   public func resolve(
-    source: CredentialIssuerSource?
+    source: CredentialIssuerSource
   ) async -> Result<CredentialIssuerMetadata?, Error> {
     switch source {
     case .credentialIssuer(let issuerId):
@@ -74,8 +74,6 @@ public actor CredentialIssuerMetadataResolver: CredentialIssuerMetadataType {
         return .success(metaData)
       }
       return .failure(ValidationError.error(reason: "Unable to retrieve metadata"))
-    case .none:
-      return .failure(CredentialError.genericError)
     }
   }
 }

--- a/Sources/Main/Resolvers/CredentialOffer/CredentialIssuerMetadataResolver.swift
+++ b/Sources/Main/Resolvers/CredentialOffer/CredentialIssuerMetadataResolver.swift
@@ -36,7 +36,7 @@ public protocol CredentialIssuerMetadataType {
   /// - Returns: An asynchronous result containing the resolved data or an error.
   func resolve(
     source: InputType
-  ) async -> Result<OutputType?, ErrorType>
+  ) async -> Result<OutputType, ErrorType>
 }
 
 public actor CredentialIssuerMetadataResolver: CredentialIssuerMetadataType {
@@ -57,7 +57,7 @@ public actor CredentialIssuerMetadataResolver: CredentialIssuerMetadataType {
   /// - Returns: An asynchronous result containing the resolved metadata or an error of type ResolvingError.
   public func resolve(
     source: CredentialIssuerSource
-  ) async -> Result<CredentialIssuerMetadata?, Error> {
+  ) async -> Result<CredentialIssuerMetadata, Error> {
     switch source {
     case .credentialIssuer(let issuerId):
 

--- a/Sources/Main/Resolvers/CredentialOffer/CredentialIssuerMetadataResolver.swift
+++ b/Sources/Main/Resolvers/CredentialOffer/CredentialIssuerMetadataResolver.swift
@@ -57,23 +57,17 @@ public actor CredentialIssuerMetadataResolver: CredentialIssuerMetadataType {
   /// - Returns: An asynchronous result containing the resolved metadata or an error of type ResolvingError.
   public func resolve(
     source: CredentialIssuerSource
-  ) async -> Result<CredentialIssuerMetadata, Error> {
-    switch source {
-    case .credentialIssuer(let issuerId):
+  ) async -> Result<CredentialIssuerMetadata, some Error> {
+      switch source {
+      case .credentialIssuer(let issuerId):
+          let pathComponent1 = ".well-known"
+          let pathComponent2 = "openid-credential-issuer"
 
-      let pathComponent1 = ".well-known"
-      let pathComponent2 = "openid-credential-issuer"
+          let url = issuerId.url
+              .appendingPathComponent(pathComponent1)
+              .appendingPathComponent(pathComponent2)
 
-      let url = issuerId.url
-        .appendingPathComponent(pathComponent1)
-        .appendingPathComponent(pathComponent2)
-
-      let result = await fetcher.fetch(url: url)
-      let metaData = try? result.get()
-      if let metaData = metaData {
-        return .success(metaData)
+          return await fetcher.fetch(url: url)
       }
-      return .failure(ValidationError.error(reason: "Unable to retrieve metadata"))
-    }
   }
 }

--- a/Tests/Helpers/Wallet.swift
+++ b/Tests/Helpers/Wallet.swift
@@ -66,8 +66,7 @@ extension Wallet {
     
     switch issuerMetadata {
     case .success(let metaData):
-      if let authorizationServer = metaData?.authorizationServers?.first,
-         let metaData {
+      if let authorizationServer = metaData.authorizationServers?.first {
           let resolver = AuthorizationServerMetadataResolver(
             oidcFetcher: Fetcher(session: self.session),
             oauthFetcher: Fetcher(session: self.session)


### PR DESCRIPTION
# Description of change

`CredentialIssuerSource` protocol has API issues that make it hard to use and its only implementation `CredentialIssuerMetadataResolver` can be improved too.

List of improvements I propose in this PR:
- a823c22: Change the `CredentialIssuerMetadataType.resolve(source:)` parameter type to non-optional. There is no value for it being optional as the implementation cannot do anything but return an error if the source is not defined.
- 999fb63: Change `CredentialIssuerMetadataType.resolve` function's `Success` result type to non-optional. The use of `Result` as the return type already provides a channel for errors and it is unclear what the result `.success(nil)` should even mean from the client perspective, but all clients had to handle the "empty" result anyway. Furthermore the only implementation `CredentialIssuerMetadataResolver.resolve` did not have a control flow that would have returned `.success(nil)` in any case.
- d71a97e: Do not mask `Fetcher` error in `CredentialIssuerMetadataResolver.resolve`. If there was an error fetching the metadata the error returned by the `Fetcher` was thrown away (converted to `nil` with `try? result.get()`) and a generic `(ValidationError.error(reason: "Unable to retrieve metadata")` was returned instead. This makes it hard to detect or debug what the actual error was when fetching the metadata and it is better not to mask the error and there is no reason to map it to some other error type either. Also `ValidationError` does not sound like a good match for e.g. a network error returned by the `Fetcher`. Omitting the error mapping also streamlines the `resolve` implementation significantly, as it can directly return the `Fetcher`'s result.
- c4f8444: Inline the locally defined URL path constants in `CredentialIssuerMetadataResolver.resolve`. The constants have only a single use site and inlining them makes it more obvious in the code in what order the components are appended to the path.

## Type of change

Please delete options that are not relevant.

- [X] Breaking change: clients of `CredentialIssuerMetadataType.resolve(source:)` need to remove the `nil` checking of success result.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ X] Passes the automated test suite of the project

# Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [X] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes