### PR TITLE
[refactor]: update to use a library that support all encryptions

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,12 +1,30 @@
 {
   "pins" : [
     {
-      "identity" : "joseswift",
+      "identity" : "cryptoswift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/niscy-eudiw/JOSESwift.git",
+      "location" : "https://github.com/krzyzanowskim/CryptoSwift.git",
       "state" : {
-        "revision" : "518cedba79ef18867191811b161471298b6cb7c8",
-        "version" : "2.4.1-gcm"
+        "revision" : "678d442c6f7828def400a70ae15968aef67ef52d",
+        "version" : "1.8.3"
+      }
+    },
+    {
+      "identity" : "jose-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/beatt83/jose-swift.git",
+      "state" : {
+        "revision" : "9f26041f31698a6349bfa1271704d4d719749d2c",
+        "version" : "3.3.1"
+      }
+    },
+    {
+      "identity" : "secp256k1.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/GigaBitcoin/secp256k1.swift.git",
+      "state" : {
+        "revision" : "4c77c7384768acf1093d66ccaacf298d322b10b7",
+        "version" : "0.15.0"
       }
     },
     {
@@ -23,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SwiftyJSON/SwiftyJSON.git",
       "state" : {
-        "revision" : "2b6054efa051565954e1d2b9da831680026cd768",
-        "version" : "4.3.0"
+        "revision" : "af76cf3ef710b6ca5f8c05f3a31307d44a3c5828",
+        "version" : "5.0.2"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -13,24 +13,18 @@ let package = Package(
     ),
   ],
   dependencies: [
-    .package(url: "https://github.com/SwiftyJSON/SwiftyJSON.git", from: "4.0.0"),
+    .package(url: "https://github.com/SwiftyJSON/SwiftyJSON.git", from: "5.0.1"),
     .package(url: "https://github.com/scinfu/SwiftSoup.git", from: "2.6.0"),
-    .package(
-      url: "https://github.com/niscy-eudiw/JOSESwift.git",
-      exact: "2.4.1-gcm"
-    ),
+    .package(url: "https://github.com/beatt83/jose-swift.git", .upToNextMajor(from: "3.3.1")),
   ],
   targets: [
     .target(
       name: "OpenID4VCI",
       dependencies: [
+        "jose-swift",
         .product(
           name: "SwiftyJSON",
           package: "SwiftyJSON"
-        ),
-        .product(
-          name: "JOSESwift",
-          package: "JOSESwift"
         )
       ],
       path: "Sources",
@@ -42,13 +36,10 @@ let package = Package(
       name: "OpenID4VCITests",
       dependencies: [
         "OpenID4VCI",
+        "jose-swift",
         .product(
           name: "SwiftyJSON",
           package: "SwiftyJSON"
-        ),
-        .product(
-          name: "JOSESwift",
-          package: "JOSESwift"
         ),
         .product(
           name: "SwiftSoup",

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ involved, follow the guidelines found in [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ### Third-party component licenses
 
-* JOSE Support: [JOSESwift](https://github.com/niscy-eudiw/JOSESwift)
+* JOSE Support: [jose-swift](https://github.com/beatt83/jose-swift)
 * JSON Support: [SwiftyJSON](https://github.com/SwiftyJSON/SwiftyJSON)
 
 ### License details

--- a/Sources/Entities/CredentialIssuer/CredentialIssuerMetadata.swift
+++ b/Sources/Entities/CredentialIssuer/CredentialIssuerMetadata.swift
@@ -15,7 +15,6 @@
  */
 import Foundation
 import SwiftyJSON
-import JOSESwift
 
 public struct CredentialIssuerMetadata: Decodable, Equatable {
   public let credentialIssuerIdentifier: CredentialIssuerId

--- a/Sources/Entities/CredentialIssuer/RequestedCredentialResponseEncryption.swift
+++ b/Sources/Entities/CredentialIssuer/RequestedCredentialResponseEncryption.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import Foundation
-import JOSESwift
+import JSONWebKey
 
 public enum RequestedCredentialResponseEncryption {
   
@@ -52,7 +52,7 @@ public enum RequestedCredentialResponseEncryption {
   
   // Validate key is for encryption operation
   private static func validateKeyUse(_ encryptionJwk: JWK?) throws {
-    guard encryptionJwk?.parameters["use"] == "enc" else {
+      guard encryptionJwk?.publicKeyUse == .encryption else {
       throw ValidationError.error(reason: "Provided key use is not encryption")
     }
   }

--- a/Sources/Entities/Errors/JOSEError.swift
+++ b/Sources/Entities/Errors/JOSEError.swift
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import Foundation
-import JOSESwift
 
 /*
 This enum represents a set of JOSE (Javascript Object Signing and Encryption) errors.
@@ -30,6 +29,7 @@ public enum JOSEError: LocalizedError {
   case invalidVerifier
   case invalidDidIdentifier
   case invalidObjectType
+  case invalidAlgorithm
 
   // A computed property to provide a description for each error case
   public var errorDescription: String? {
@@ -50,68 +50,70 @@ public enum JOSEError: LocalizedError {
       return ".invalidDidIdentifier"
     case .invalidObjectType:
       return ".invalidObjectType"
+    case .invalidAlgorithm:
+      return ".invalidAlgorithm"
     }
   }
 }
 
-extension JOSESwiftError: LocalizedError {
-  
-  public var errorDescription: String? {
-    switch self {
-    case .signingFailed(let description):
-      return ".signingFailed: \(description)"
-    case .verifyingFailed(let description):
-      return ".verifyingFailed: \(description)"
-    case .signatureInvalid:
-      return ".signatureInvalid"
-    case .encryptingFailed(let description):
-      return ".encryptingFailed: \(description)"
-    case .decryptingFailed:
-      return ".decryptingFailed"
-    case .wrongDataEncoding:
-      return ".wrongDataEncoding"
-    case .invalidCompactSerializationComponentCount(let count):
-      return ".invalidCompactSerializationComponentCount: \(count)"
-    case .componentNotValidBase64URL(let component):
-      return ".componentNotValidBase64URL: \(component)"
-    case .componentCouldNotBeInitializedFromData:
-      return ".componentCouldNotBeInitializedFromData"
-    case .couldNotConstructJWK:
-      return ".couldNotConstructJWK"
-    case .modulusNotBase64URLUIntEncoded:
-      return ".modulusNotBase64URLUIntEncoded"
-    case .exponentNotBase64URLUIntEncoded:
-      return ".exponentNotBase64URLUIntEncoded"
-    case .privateExponentNotBase64URLUIntEncoded:
-      return ""
-    case .symmetricKeyNotBase64URLEncoded:
-      return ".symmetricKeyNotBase64URLEncoded"
-    case .xNotBase64URLUIntEncoded:
-      return ".xNotBase64URLUIntEncoded"
-    case .yNotBase64URLUIntEncoded:
-      return ".yNotBase64URLUIntEncoded"
-    case .privateKeyNotBase64URLUIntEncoded:
-      return ".privateKeyNotBase64URLUIntEncoded"
-    case .invalidCurveType:
-      return ".invalidCurveType"
-    case .compressedCurvePointsUnsupported:
-      return ".compressedCurvePointsUnsupported"
-    case .invalidCurvePointOctetLength:
-      return ".invalidCurvePointOctetLength"
-    case .localAuthenticationFailed(let errorCode):
-      return ".localAuthenticationFailed: \(errorCode)"
-    case .compressionFailed:
-      return ".compressionFailed"
-    case .decompressionFailed:
-      return ".decompressionFailed"
-    case .compressionAlgorithmNotSupported:
-      return ".compressionAlgorithmNotSupported"
-    case .rawDataMustBeGreaterThanZero:
-      return ".rawDataMustBeGreaterThanZero"
-    case .compressedDataMustBeGreaterThanZero:
-      return ".compressedDataMustBeGreaterThanZero"
-    case .thumbprintSerialization:
-      return ".thumbprintSerialization"
-    }
-  }
-}
+//extension JOSESwiftError: LocalizedError {
+//  
+//  public var errorDescription: String? {
+//    switch self {
+//    case .signingFailed(let description):
+//      return ".signingFailed: \(description)"
+//    case .verifyingFailed(let description):
+//      return ".verifyingFailed: \(description)"
+//    case .signatureInvalid:
+//      return ".signatureInvalid"
+//    case .encryptingFailed(let description):
+//      return ".encryptingFailed: \(description)"
+//    case .decryptingFailed:
+//      return ".decryptingFailed"
+//    case .wrongDataEncoding:
+//      return ".wrongDataEncoding"
+//    case .invalidCompactSerializationComponentCount(let count):
+//      return ".invalidCompactSerializationComponentCount: \(count)"
+//    case .componentNotValidBase64URL(let component):
+//      return ".componentNotValidBase64URL: \(component)"
+//    case .componentCouldNotBeInitializedFromData:
+//      return ".componentCouldNotBeInitializedFromData"
+//    case .couldNotConstructJWK:
+//      return ".couldNotConstructJWK"
+//    case .modulusNotBase64URLUIntEncoded:
+//      return ".modulusNotBase64URLUIntEncoded"
+//    case .exponentNotBase64URLUIntEncoded:
+//      return ".exponentNotBase64URLUIntEncoded"
+//    case .privateExponentNotBase64URLUIntEncoded:
+//      return ""
+//    case .symmetricKeyNotBase64URLEncoded:
+//      return ".symmetricKeyNotBase64URLEncoded"
+//    case .xNotBase64URLUIntEncoded:
+//      return ".xNotBase64URLUIntEncoded"
+//    case .yNotBase64URLUIntEncoded:
+//      return ".yNotBase64URLUIntEncoded"
+//    case .privateKeyNotBase64URLUIntEncoded:
+//      return ".privateKeyNotBase64URLUIntEncoded"
+//    case .invalidCurveType:
+//      return ".invalidCurveType"
+//    case .compressedCurvePointsUnsupported:
+//      return ".compressedCurvePointsUnsupported"
+//    case .invalidCurvePointOctetLength:
+//      return ".invalidCurvePointOctetLength"
+//    case .localAuthenticationFailed(let errorCode):
+//      return ".localAuthenticationFailed: \(errorCode)"
+//    case .compressionFailed:
+//      return ".compressionFailed"
+//    case .decompressionFailed:
+//      return ".decompressionFailed"
+//    case .compressionAlgorithmNotSupported:
+//      return ".compressionAlgorithmNotSupported"
+//    case .rawDataMustBeGreaterThanZero:
+//      return ".rawDataMustBeGreaterThanZero"
+//    case .compressedDataMustBeGreaterThanZero:
+//      return ".compressedDataMustBeGreaterThanZero"
+//    case .thumbprintSerialization:
+//      return ".thumbprintSerialization"
+//    }
+//  }
+//}

--- a/Sources/Entities/IssuanceFlows/CredentialIssuanceRequest.swift
+++ b/Sources/Entities/IssuanceFlows/CredentialIssuanceRequest.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import Foundation
-import JOSESwift
+import JSONWebKey
 import SwiftyJSON
 
 public let FORMAT_MSO_MDOC = "mso_mdoc"

--- a/Sources/Entities/JOSE/JOSEAlgorithm.swift
+++ b/Sources/Entities/JOSE/JOSEAlgorithm.swift
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import Foundation
+import JSONWebAlgorithms
 
 public class JOSEAlgorithm: Codable, Hashable {
 
@@ -56,5 +57,14 @@ public extension JOSEAlgorithm {
     case RECOMMENDED
     case OPTIONAL
   }
+}
+
+extension JWSAlgorithm {
+    func parseToJoseLibrary() throws -> SigningAlgorithm {
+        guard let alg = SigningAlgorithm(rawValue: name) else {
+            throw JOSEError.invalidAlgorithm
+        }
+        return alg
+    }
 }
 

--- a/Sources/Entities/JOSE/JOSEEncryptionMethod.swift
+++ b/Sources/Entities/JOSE/JOSEEncryptionMethod.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import Foundation
-import JOSESwift
+import JSONWebAlgorithms
 
 public class JOSEEncryptionMethod: JOSEAlgorithm {
   
@@ -65,6 +65,7 @@ public extension JOSEEncryptionMethod {
     case A128GCM = "A128GCM"
     case A192GCM = "A192GCM"
     case A256GCM = "A256GCM"
+    case C20P = "C20P"
     case XC20P = "XC20P"
     
     var name: String {
@@ -85,6 +86,8 @@ public extension JOSEEncryptionMethod {
         return (.OPTIONAL, 192)
       case .A256GCM:
         return (.RECOMMENDED, 256)
+      case .C20P:
+        return (.OPTIONAL, 256)
       case .XC20P:
         return (.OPTIONAL, 256)
       }
@@ -101,6 +104,7 @@ public extension JOSEEncryptionMethod.Family {
   enum JoseEncryptionMethodFamilyType {
     case AES_CBC_HMAC_SHA
     case AES_GCM
+    case CHA_CHA_POLY
   }
   
   static func parse(_ type: JoseEncryptionMethodFamilyType) -> JOSEEncryptionMethod.Family {
@@ -116,6 +120,11 @@ public extension JOSEEncryptionMethod.Family {
         .init(.A128GCM),
         .init(.A192GCM),
         .init(.A256GCM)
+      )
+    case .CHA_CHA_POLY:
+      return .init(
+        .init(.C20P),
+        .init(.XC20P)
       )
     }
   }

--- a/Sources/Entities/JOSE/JWEAlgorithm.swift
+++ b/Sources/Entities/JOSE/JWEAlgorithm.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import Foundation
-import JOSESwift
+import JSONWebAlgorithms
 
 public class JWEAlgorithm: JOSEAlgorithm {
 

--- a/Sources/Entities/Profiles/MsoMdocFormat.swift
+++ b/Sources/Entities/Profiles/MsoMdocFormat.swift
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 import Foundation
+import JSONWebKey
 import SwiftyJSON
-import JOSESwift
 
 public struct MsoMdocFormat: FormatProfile {
   static let FORMAT = "mso_mdoc"
@@ -91,13 +91,7 @@ public extension MsoMdocFormat {
     public func encode(to encoder: Encoder) throws {
       var container = encoder.container(keyedBy: CodingKeys.self)
       try container.encode(proof, forKey: .proof)
-      
-      if let credentialEncryptionJwk = credentialEncryptionJwk as? RSAPublicKey {
-        try container.encode(credentialEncryptionJwk, forKey: .credentialEncryptionJwk)
-      } else if let credentialEncryptionJwk = credentialEncryptionJwk as? ECPublicKey {
-        try container.encode(credentialEncryptionJwk, forKey: .credentialEncryptionJwk)
-      }
-      
+      try container.encode(credentialEncryptionJwk, forKey: .credentialEncryptionJwk)
       try container.encode(credentialResponseEncryptionAlg, forKey: .credentialResponseEncryptionAlg)
       try container.encode(credentialResponseEncryptionMethod, forKey: .credentialResponseEncryptionMethod)
       try container.encode(claimSet, forKey: .claimSet)

--- a/Sources/Entities/Profiles/SdJwtVcFormat.swift
+++ b/Sources/Entities/Profiles/SdJwtVcFormat.swift
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 import Foundation
+import JSONWebKey
 import SwiftyJSON
-import JOSESwift
 
 public struct SdJwtVcFormat: FormatProfile {
   
@@ -95,13 +95,7 @@ public extension SdJwtVcFormat {
     public func encode(to encoder: Encoder) throws {
       var container = encoder.container(keyedBy: CodingKeys.self)
       try container.encode(proof, forKey: .proof)
-      
-      if let credentialEncryptionJwk = credentialEncryptionJwk as? RSAPublicKey {
-        try container.encode(credentialEncryptionJwk, forKey: .credentialEncryptionJwk)
-      } else if let credentialEncryptionJwk = credentialEncryptionJwk as? ECPublicKey {
-        try container.encode(credentialEncryptionJwk, forKey: .credentialEncryptionJwk)
-      }
-      
+      try container.encode(credentialEncryptionJwk, forKey: .credentialEncryptionJwk)
       try container.encode(credentialResponseEncryptionAlg, forKey: .credentialResponseEncryptionAlg)
       try container.encode(credentialResponseEncryptionMethod, forKey: .credentialResponseEncryptionMethod)
       

--- a/Sources/Entities/Types/Types.swift
+++ b/Sources/Entities/Types/Types.swift
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 import Foundation
+import JSONWebKey
 import SwiftyJSON
-import JOSESwift
 
-public typealias JWT = String
+public typealias JWTString = String
 
 public struct IssuanceResponseEncryptionSpec {
   public let jwk: JWK?
@@ -39,7 +39,7 @@ public struct IssuanceResponseEncryptionSpec {
 }
 
 public enum Proof: Codable {
-  case jwt(JWT)
+  case jwt(JWTString)
   case cwt(String)
   
   public func type() -> ProofType {
@@ -56,7 +56,7 @@ public enum Proof: Codable {
   public init(from decoder: Decoder) throws {
     let container = try decoder.singleValueContainer()
     
-    if let jwt = try? container.decode(JWT.self) {
+    if let jwt = try? container.decode(JWTString.self) {
       self = .jwt(jwt)
     } else if let cwt = try? container.decode(String.self) {
       self = .cwt(cwt)

--- a/Sources/Issuers/Issuer.swift
+++ b/Sources/Issuers/Issuer.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import Foundation
-import JOSESwift
+import JSONWebKey
 
 public protocol IssuerType {
   
@@ -765,27 +765,21 @@ public extension Issuer {
       privateKey = try? KeyController.generateRSAPrivateKey()
       if let privateKey,
          let publicKey = try? KeyController.generateRSAPublicKey(from: privateKey) {
-        jwk = try? RSAPublicKey(
-          publicKey: publicKey,
-          additionalParameters: [
-            "use": "enc",
-            "kid": UUID().uuidString,
-            "alg": algorithm.name
-          ]
-        )
+          var publicKeyJWK = try? publicKey.jwk
+          publicKeyJWK?.publicKeyUse = .encryption
+          publicKeyJWK?.keyID = UUID().uuidString
+          publicKeyJWK?.algorithm = algorithm.name
+          jwk = publicKeyJWK
       }
     } else if JWEAlgorithm.Family.parse(.ECDH_ES).contains(algorithm) {
       privateKey = try? KeyController.generateECDHPrivateKey()
       if let privateKey,
          let publicKey = try? KeyController.generateECDHPublicKey(from: privateKey) {
-        jwk = try? ECPublicKey(
-          publicKey: publicKey,
-          additionalParameters: [
-            "use": "enc",
-            "kid": UUID().uuidString,
-            "alg": algorithm.name
-          ]
-        )
+          var publicKeyJWK = try? publicKey.jwk
+          publicKeyJWK?.publicKeyUse = .encryption
+          publicKeyJWK?.keyID = UUID().uuidString
+          publicKeyJWK?.algorithm = algorithm.name
+          jwk = publicKeyJWK
       }
     } else {
       privateKey = nil

--- a/Tests/Issuance/IssuanceAuthorizationTest.swift
+++ b/Tests/Issuance/IssuanceAuthorizationTest.swift
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 import Foundation
+import JSONWebKey
 import XCTest
-import JOSESwift
 
 @testable import OpenID4VCI
 
@@ -372,13 +372,10 @@ class IssuanceAuthorizationTest: XCTestCase {
     let publicKey = try KeyController.generateRSAPublicKey(from: privateKey)
     
     let alg = JWSAlgorithm(.RS256)
-    let publicKeyJWK = try RSAPublicKey(
-      publicKey: publicKey,
-      additionalParameters: [
-        "alg": alg.name,
-        "use": "sig",
-        "kid": UUID().uuidString
-      ])
+    var publicKeyJWK = try publicKey.jwk
+    publicKeyJWK.algorithm = alg.name
+    publicKeyJWK.publicKeyUse = .signature
+    publicKeyJWK.keyID = UUID().uuidString
     
     let bindingKey: BindingKey = .jwk(
       algorithm: alg,
@@ -466,13 +463,10 @@ class IssuanceAuthorizationTest: XCTestCase {
     let publicKey = try KeyController.generateECDHPublicKey(from: privateKey)
 
     let alg = JWSAlgorithm(.ES256)
-    let publicKeyJWK = try ECPublicKey(
-      publicKey: publicKey,
-      additionalParameters: [
-        "alg": alg.name,
-        "use": "sig",
-        "kid": UUID().uuidString
-    ])
+    var publicKeyJWK = try publicKey.jwk
+    publicKeyJWK.algorithm = alg.name
+    publicKeyJWK.publicKeyUse = .signature
+    publicKeyJWK.keyID = UUID().uuidString
 
     let bindingKey: BindingKey = .jwk(
       algorithm: alg,
@@ -529,14 +523,11 @@ class IssuanceAuthorizationTest: XCTestCase {
     let publicKey = try KeyController.generateECDHPublicKey(from: privateKey)
     
     let alg = JWSAlgorithm(.ES256)
-    let jwk = try ECPublicKey(
-      publicKey: publicKey,
-      additionalParameters: [
-        "alg": alg.name,
-        "use": "sig",
-        "kid": UUID().uuidString
-      ])
-    
+    var jwk = try publicKey.jwk
+    jwk.algorithm = alg.name
+    jwk.publicKeyUse = .signature
+    jwk.keyID = UUID().uuidString
+
     let dpopConstructor: DPoPConstructor = .init(
       algorithm: alg,
       jwk: jwk,

--- a/Tests/Issuance/IssuanceBatchRequestTest.swift
+++ b/Tests/Issuance/IssuanceBatchRequestTest.swift
@@ -15,7 +15,6 @@
  */
 import Foundation
 import XCTest
-import JOSESwift
 import SwiftyJSON
 
 @testable import OpenID4VCI
@@ -49,14 +48,11 @@ class IssuanceBatchRequestTest: XCTestCase {
     let publicKey = try KeyController.generateRSAPublicKey(from: privateKey)
     
     let alg = JWSAlgorithm(.RS256)
-    let publicKeyJWK = try RSAPublicKey(
-      publicKey: publicKey,
-      additionalParameters: [
-        "alg": alg.name,
-        "use": "enc",
-        "kid": UUID().uuidString
-      ])
-    
+    var publicKeyJWK = try publicKey.jwk
+    publicKeyJWK.algorithm = alg.name
+    publicKeyJWK.publicKeyUse = .encryption
+    publicKeyJWK.keyID = UUID().uuidString
+
     let spec = IssuanceResponseEncryptionSpec(
       jwk: publicKeyJWK,
       privateKey: privateKey,
@@ -190,13 +186,10 @@ class IssuanceBatchRequestTest: XCTestCase {
     let publicKey = try KeyController.generateRSAPublicKey(from: privateKey)
 
     let alg = JWSAlgorithm(.RS256)
-    let publicKeyJWK = try RSAPublicKey(
-      publicKey: publicKey,
-      additionalParameters: [
-        "alg": alg.name,
-        "use": "enc",
-        "kid": UUID().uuidString
-    ])
+    var publicKeyJWK = try publicKey.jwk
+    publicKeyJWK.algorithm = alg.name
+    publicKeyJWK.publicKeyUse = .encryption
+    publicKeyJWK.keyID = UUID().uuidString
 
     let bindingKey: BindingKey = .jwk(
       algorithm: alg,

--- a/Tests/Issuance/IssuanceDeferredRequestTest.swift
+++ b/Tests/Issuance/IssuanceDeferredRequestTest.swift
@@ -15,7 +15,6 @@
  */
 import Foundation
 import XCTest
-import JOSESwift
 
 @testable import OpenID4VCI
 
@@ -47,14 +46,11 @@ class IssuanceDeferredRequestTest: XCTestCase {
     let publicKey = try KeyController.generateRSAPublicKey(from: privateKey)
     
     let alg = JWSAlgorithm(.RS256)
-    let publicKeyJWK = try RSAPublicKey(
-      publicKey: publicKey,
-      additionalParameters: [
-        "alg": alg.name,
-        "use": "enc",
-        "kid": UUID().uuidString
-      ])
-    
+    var publicKeyJWK = try publicKey.jwk
+    publicKeyJWK.algorithm = alg.name
+    publicKeyJWK.publicKeyUse = .encryption
+    publicKeyJWK.keyID = UUID().uuidString
+
     let spec = IssuanceResponseEncryptionSpec(
       jwk: publicKeyJWK,
       privateKey: privateKey,

--- a/Tests/Issuance/IssuanceEncryptionTest.swift
+++ b/Tests/Issuance/IssuanceEncryptionTest.swift
@@ -15,7 +15,6 @@
  */
 import Foundation
 import XCTest
-import JOSESwift
 
 @testable import OpenID4VCI
 
@@ -42,14 +41,11 @@ class IssuanceEncryptionTest: XCTestCase {
     let publicKey = try KeyController.generateRSAPublicKey(from: privateKey)
     
     let alg = JWSAlgorithm(.RS256)
-    let publicKeyJWK = try RSAPublicKey(
-      publicKey: publicKey,
-      additionalParameters: [
-        "alg": alg.name,
-        "use": "sig",
-        "kid": UUID().uuidString
-      ])
-    
+    var publicKeyJWK = try publicKey.jwk
+    publicKeyJWK.algorithm = alg.name
+    publicKeyJWK.publicKeyUse = .signature
+    publicKeyJWK.keyID = UUID().uuidString
+
     let spec = IssuanceResponseEncryptionSpec(
       jwk: publicKeyJWK,
       privateKey: privateKey,
@@ -95,14 +91,11 @@ class IssuanceEncryptionTest: XCTestCase {
     let publicKey = try KeyController.generateRSAPublicKey(from: privateKey)
 
     let alg = JWSAlgorithm.init(name: "PBES2-HS512+A256KW")
-    let publicKeyJWK = try RSAPublicKey(
-      publicKey: publicKey,
-      additionalParameters: [
-        "alg": alg.name,
-        "use": "sig",
-        "kid": UUID().uuidString
-      ])
-    
+    var publicKeyJWK = try publicKey.jwk
+    publicKeyJWK.algorithm = alg.name
+    publicKeyJWK.publicKeyUse = .signature
+    publicKeyJWK.keyID = UUID().uuidString
+
     let spec = IssuanceResponseEncryptionSpec(
       jwk: publicKeyJWK,
       privateKey: privateKey,

--- a/Tests/Issuance/IssuanceNotificationTest.swift
+++ b/Tests/Issuance/IssuanceNotificationTest.swift
@@ -15,7 +15,6 @@
  */
 import Foundation
 import XCTest
-import JOSESwift
 
 @testable import OpenID4VCI
 
@@ -48,14 +47,11 @@ class IssuanceNotificationTest: XCTestCase {
     let publicKey = try KeyController.generateRSAPublicKey(from: privateKey)
     
     let alg = JWSAlgorithm(.RS256)
-    let publicKeyJWK = try RSAPublicKey(
-      publicKey: publicKey,
-      additionalParameters: [
-        "alg": alg.name,
-        "use": "enc",
-        "kid": UUID().uuidString
-      ])
-    
+    var publicKeyJWK = try publicKey.jwk
+    publicKeyJWK.algorithm = alg.name
+    publicKeyJWK.publicKeyUse = .encryption
+    publicKeyJWK.keyID = UUID().uuidString
+
     let spec = IssuanceResponseEncryptionSpec(
       jwk: publicKeyJWK,
       privateKey: privateKey,
@@ -190,14 +186,11 @@ class IssuanceNotificationTest: XCTestCase {
     let publicKey = try KeyController.generateRSAPublicKey(from: privateKey)
     
     let alg = JWSAlgorithm(.RS256)
-    let publicKeyJWK = try RSAPublicKey(
-      publicKey: publicKey,
-      additionalParameters: [
-        "alg": alg.name,
-        "use": "enc",
-        "kid": UUID().uuidString
-      ])
-    
+    var publicKeyJWK = try publicKey.jwk
+    publicKeyJWK.algorithm = alg.name
+    publicKeyJWK.publicKeyUse = .encryption
+    publicKeyJWK.keyID = UUID().uuidString
+
     let spec = IssuanceResponseEncryptionSpec(
       jwk: publicKeyJWK,
       privateKey: privateKey,

--- a/Tests/Issuance/IssuanceSingleRequestTest.swift
+++ b/Tests/Issuance/IssuanceSingleRequestTest.swift
@@ -15,7 +15,6 @@
  */
 import Foundation
 import XCTest
-import JOSESwift
 
 @testable import OpenID4VCI
 
@@ -48,14 +47,11 @@ class IssuanceSingleRequestTest: XCTestCase {
     let publicKey = try KeyController.generateRSAPublicKey(from: privateKey)
     
     let alg = JWSAlgorithm(.RS256)
-    let publicKeyJWK = try RSAPublicKey(
-      publicKey: publicKey,
-      additionalParameters: [
-        "alg": alg.name,
-        "use": "enc",
-        "kid": UUID().uuidString
-      ])
-    
+    var publicKeyJWK = try publicKey.jwk
+    publicKeyJWK.algorithm = alg.name
+    publicKeyJWK.publicKeyUse = .encryption
+    publicKeyJWK.keyID = UUID().uuidString
+
     let spec = IssuanceResponseEncryptionSpec(
       jwk: publicKeyJWK,
       privateKey: privateKey,
@@ -181,14 +177,11 @@ class IssuanceSingleRequestTest: XCTestCase {
     let publicKey = try KeyController.generateRSAPublicKey(from: privateKey)
     
     let alg = JWSAlgorithm(.RS256)
-    let publicKeyJWK = try RSAPublicKey(
-      publicKey: publicKey,
-      additionalParameters: [
-        "alg": alg.name,
-        "use": "enc",
-        "kid": UUID().uuidString
-      ])
-    
+    var publicKeyJWK = try publicKey.jwk
+    publicKeyJWK.algorithm = alg.name
+    publicKeyJWK.publicKeyUse = .encryption
+    publicKeyJWK.keyID = UUID().uuidString
+
     let spec = IssuanceResponseEncryptionSpec(
       jwk: publicKeyJWK,
       privateKey: privateKey,
@@ -309,14 +302,11 @@ class IssuanceSingleRequestTest: XCTestCase {
     let publicKey = try KeyController.generateRSAPublicKey(from: privateKey)
     
     let alg = JWSAlgorithm(.RS256)
-    let publicKeyJWK = try RSAPublicKey(
-      publicKey: publicKey,
-      additionalParameters: [
-        "alg": alg.name,
-        "use": "enc",
-        "kid": UUID().uuidString
-      ])
-    
+    var publicKeyJWK = try publicKey.jwk
+    publicKeyJWK.algorithm = alg.name
+    publicKeyJWK.publicKeyUse = .encryption
+    publicKeyJWK.keyID = UUID().uuidString
+
     let spec = IssuanceResponseEncryptionSpec(
       jwk: publicKeyJWK,
       privateKey: privateKey,

--- a/Tests/Wallet/VCIFlowNoOffer.swift
+++ b/Tests/Wallet/VCIFlowNoOffer.swift
@@ -15,7 +15,6 @@
  */
 import Foundation
 import XCTest
-import JOSESwift
 
 @testable import OpenID4VCI
 
@@ -44,14 +43,11 @@ class VCIFlowNoOffer: XCTestCase {
     let publicKey = try KeyController.generateECDHPublicKey(from: privateKey)
     
     let alg = JWSAlgorithm(.ES256)
-    let publicKeyJWK = try ECPublicKey(
-      publicKey: publicKey,
-      additionalParameters: [
-        "alg": alg.name,
-        "use": "sig",
-        "kid": UUID().uuidString
-      ])
-    
+    var publicKeyJWK = try publicKey.jwk
+    publicKeyJWK.algorithm = alg.name
+    publicKeyJWK.publicKeyUse = .signature
+    publicKeyJWK.keyID = UUID().uuidString
+
     let bindingKey: BindingKey = .jwk(
       algorithm: alg,
       jwk: publicKeyJWK,
@@ -89,14 +85,11 @@ class VCIFlowNoOffer: XCTestCase {
     let publicKey = try KeyController.generateECDHPublicKey(from: privateKey)
     
     let alg = JWSAlgorithm(.ES256)
-    let publicKeyJWK = try ECPublicKey(
-      publicKey: publicKey,
-      additionalParameters: [
-        "alg": alg.name,
-        "use": "sig",
-        "kid": UUID().uuidString
-      ])
-    
+    var publicKeyJWK = try publicKey.jwk
+    publicKeyJWK.algorithm = alg.name
+    publicKeyJWK.publicKeyUse = .signature
+    publicKeyJWK.keyID = UUID().uuidString
+
     let bindingKey: BindingKey = .jwk(
       algorithm: alg,
       jwk: publicKeyJWK,
@@ -133,14 +126,11 @@ class VCIFlowNoOffer: XCTestCase {
     let publicKey = try KeyController.generateECDHPublicKey(from: privateKey)
     
     let alg = JWSAlgorithm(.ES256)
-    let publicKeyJWK = try ECPublicKey(
-      publicKey: publicKey,
-      additionalParameters: [
-        "alg": alg.name,
-        "use": "sig",
-        "kid": UUID().uuidString
-      ])
-    
+    var publicKeyJWK = try publicKey.jwk
+    publicKeyJWK.algorithm = alg.name
+    publicKeyJWK.publicKeyUse = .signature
+    publicKeyJWK.keyID = UUID().uuidString
+
     let bindingKey: BindingKey = .jwk(
       algorithm: alg,
       jwk: publicKeyJWK,

--- a/Tests/Wallet/VCIFlowWithOffer.swift
+++ b/Tests/Wallet/VCIFlowWithOffer.swift
@@ -15,7 +15,6 @@
  */
 import Foundation
 import XCTest
-import JOSESwift
 
 @testable import OpenID4VCI
 
@@ -35,14 +34,11 @@ class VCIFlowWithOffer: XCTestCase {
     let publicKey = try KeyController.generateECDHPublicKey(from: privateKey)
     
     let alg = JWSAlgorithm(.ES256)
-    let publicKeyJWK = try ECPublicKey(
-      publicKey: publicKey,
-      additionalParameters: [
-        "alg": alg.name,
-        "use": "sig",
-        "kid": UUID().uuidString
-      ])
-    
+    var publicKeyJWK = try publicKey.jwk
+    publicKeyJWK.algorithm = alg.name
+    publicKeyJWK.publicKeyUse = .signature
+    publicKeyJWK.keyID = UUID().uuidString
+
     let bindingKey: BindingKey = .jwk(
       algorithm: alg,
       jwk: publicKeyJWK,
@@ -80,14 +76,11 @@ class VCIFlowWithOffer: XCTestCase {
     let publicKey = try KeyController.generateECDHPublicKey(from: privateKey)
     
     let alg = JWSAlgorithm(.ES256)
-    let publicKeyJWK = try ECPublicKey(
-      publicKey: publicKey,
-      additionalParameters: [
-        "alg": alg.name,
-        "use": "sig",
-        "kid": UUID().uuidString
-      ])
-    
+    var publicKeyJWK = try publicKey.jwk
+    publicKeyJWK.algorithm = alg.name
+    publicKeyJWK.publicKeyUse = .signature
+    publicKeyJWK.keyID = UUID().uuidString
+
     let bindingKey: BindingKey = .jwk(
       algorithm: alg,
       jwk: publicKeyJWK,
@@ -124,14 +117,11 @@ class VCIFlowWithOffer: XCTestCase {
     let publicKey = try KeyController.generateECDHPublicKey(from: privateKey)
     
     let alg = JWSAlgorithm(.ES256)
-    let publicKeyJWK = try ECPublicKey(
-      publicKey: publicKey,
-      additionalParameters: [
-        "alg": alg.name,
-        "use": "sig",
-        "kid": UUID().uuidString
-      ])
-    
+    var publicKeyJWK = try publicKey.jwk
+    publicKeyJWK.algorithm = alg.name
+    publicKeyJWK.publicKeyUse = .signature
+    publicKeyJWK.keyID = UUID().uuidString
+
     let bindingKey: BindingKey = .jwk(
       algorithm: alg,
       jwk: publicKeyJWK,
@@ -168,14 +158,11 @@ class VCIFlowWithOffer: XCTestCase {
     let publicKey = try KeyController.generateECDHPublicKey(from: privateKey)
     
     let alg = JWSAlgorithm(.ES256)
-    let publicKeyJWK = try ECPublicKey(
-      publicKey: publicKey,
-      additionalParameters: [
-        "alg": alg.name,
-        "use": "sig",
-        "kid": UUID().uuidString
-      ])
-    
+    var publicKeyJWK = try publicKey.jwk
+    publicKeyJWK.algorithm = alg.name
+    publicKeyJWK.publicKeyUse = .signature
+    publicKeyJWK.keyID = UUID().uuidString
+
     let bindingKey: BindingKey = .jwk(
       algorithm: alg,
       jwk: publicKeyJWK,
@@ -213,14 +200,11 @@ class VCIFlowWithOffer: XCTestCase {
     let publicKey = try KeyController.generateECDHPublicKey(from: privateKey)
     
     let alg = JWSAlgorithm(.ES256)
-    let publicKeyJWK = try ECPublicKey(
-      publicKey: publicKey,
-      additionalParameters: [
-        "alg": alg.name,
-        "use": "sig",
-        "kid": UUID().uuidString
-      ])
-    
+    var publicKeyJWK = try publicKey.jwk
+    publicKeyJWK.algorithm = alg.name
+    publicKeyJWK.publicKeyUse = .signature
+    publicKeyJWK.keyID = UUID().uuidString
+
     let bindingKey: BindingKey = .jwk(
       algorithm: alg,
       jwk: publicKeyJWK,
@@ -258,14 +242,11 @@ class VCIFlowWithOffer: XCTestCase {
     let publicKey = try KeyController.generateECDHPublicKey(from: privateKey)
     
     let alg = JWSAlgorithm(.ES256)
-    let publicKeyJWK = try ECPublicKey(
-      publicKey: publicKey,
-      additionalParameters: [
-        "alg": alg.name,
-        "use": "sig",
-        "kid": UUID().uuidString
-      ])
-    
+    var publicKeyJWK = try publicKey.jwk
+    publicKeyJWK.algorithm = alg.name
+    publicKeyJWK.publicKeyUse = .signature
+    publicKeyJWK.keyID = UUID().uuidString
+
     let bindingKey: BindingKey = .jwk(
       algorithm: alg,
       jwk: publicKeyJWK,


### PR DESCRIPTION
# Description of change

This PR will support the Jose library (Jose-swift)[https://github.com/beatt83/jose-swift] that was added on (sdjwt)[https://github.com/eu-digital-identity-wallet/eudi-lib-sdjwt-swift], this library already provides all the encoding requirements without the need to fork the library causing dependency conflicts.

The `BindingKey.jwk` now allows support for `KeyRepresentable` this adds support for different type of keys besides `SecKey` as the privateKey parameter.
This means you can pass any of the following key struct/enum/classes `JWK`, `RSA`, `P256`, `P384`, `P512`, `Curve25519`, `secp256k1`, `SecKey`.

Also adds support for c20p

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

It runs all the tests correctly with this library without any changes on the behaviour of the logic code. So no tests were added and all the tests run successfully.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes