### PR TITLE
Update 3rd party dependency list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ involved, follow the guidelines found in [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ### Third-party component licenses
 
-* JOSE Support: [JOSESwift](https://github.com/niscy-eudiw/JOSESwift)
+* JOSE Support: [JOSESwift](https://github.com/airsidemobile/JOSESwift)
 * JSON Support: [SwiftyJSON](https://github.com/SwiftyJSON/SwiftyJSON)
 
 ### License details


### PR DESCRIPTION
The JOSESwift upstream was changed to [airsidemobile/JOSESwift](https://github.com/airsidemobile/JOSESwift) via https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift/pull/77.