### PR TITLE
Updated signing logic

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/scinfu/SwiftSoup.git",
       "state" : {
-        "revision" : "028487d4a8a291b2fe1b4392b5425b6172056148",
-        "version" : "2.7.2"
+        "revision" : "0837db354faf9c9deb710dc597046edaadf5360f",
+        "version" : "2.7.6"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -47,10 +47,6 @@ let package = Package(
           package: "SwiftyJSON"
         ),
         .product(
-          name: "JOSESwift",
-          package: "JOSESwift"
-        ),
-        .product(
           name: "SwiftSoup",
           package: "SwiftSoup"
         )

--- a/Sources/DPoP/DPoPConstructor.swift
+++ b/Sources/DPoP/DPoPConstructor.swift
@@ -18,7 +18,7 @@ import JOSESwift
 import CryptoKit
 
 public protocol DPoPConstructorType {
-  func jwt(endpoint: URL, accessToken: String?) throws -> String
+  func jwt(endpoint: URL, accessToken: String?) async throws -> String
 }
 
 public class DPoPConstructor: DPoPConstructorType {
@@ -36,15 +36,18 @@ public class DPoPConstructor: DPoPConstructorType {
 
   public let algorithm: JWSAlgorithm
   public let jwk: JWK
-  public let privateKey: SecKey
+  public let privateKey: PrivateKeyProxy
 
-  public init(algorithm: JWSAlgorithm, jwk: JWK, privateKey: SecKey) {
+  public init(algorithm: JWSAlgorithm, jwk: JWK, privateKey: PrivateKeyProxy) {
     self.algorithm = algorithm
     self.jwk = jwk
     self.privateKey = privateKey
   }
 
-  public func jwt(endpoint: URL, accessToken: String?) throws -> String {
+  public func jwt(
+    endpoint: URL,
+    accessToken: String?
+  ) async throws -> String {
 
     let header = try JWSHeader(parameters: [
       "typ": "dpop+jwt",
@@ -71,13 +74,13 @@ public class DPoPConstructor: DPoPConstructorType {
       throw CredentialIssuanceError.cryptographicAlgorithmNotSupported
     }
 
-    guard let signer = Signer(
-      signatureAlgorithm: signatureAlgorithm,
-      key: privateKey
-    ) else {
-      throw ValidationError.error(reason: "Unable to create JWS signer")
-    }
-
+    let signer = try await BindingKey.createSigner(
+      with: header,
+      and: payload,
+      for: privateKey,
+      and: signatureAlgorithm
+    )
+    
     let jws = try JWS(
       header: header,
       payload: payload,

--- a/Sources/DPoP/DPoPConstructor.swift
+++ b/Sources/DPoP/DPoPConstructor.swift
@@ -36,9 +36,9 @@ public class DPoPConstructor: DPoPConstructorType {
 
   public let algorithm: JWSAlgorithm
   public let jwk: JWK
-  public let privateKey: PrivateKeyProxy
+  public let privateKey: SigningKeyProxy
 
-  public init(algorithm: JWSAlgorithm, jwk: JWK, privateKey: PrivateKeyProxy) {
+  public init(algorithm: JWSAlgorithm, jwk: JWK, privateKey: SigningKeyProxy) {
     self.algorithm = algorithm
     self.jwk = jwk
     self.privateKey = privateKey

--- a/Sources/Entities/Encryption/BindingKey.swift
+++ b/Sources/Entities/Encryption/BindingKey.swift
@@ -16,6 +16,11 @@
 import Foundation
 import JOSESwift
 
+public enum PrivateKeyProxy {
+  case custom(any AsyncSignerProtocol)
+  case secKey(SecKey)
+}
+
 public enum BindingKey {
 
   // JWK Binding Key
@@ -31,11 +36,6 @@ public enum BindingKey {
 
   // X509 Binding Key
   case x509(certificate: X509Certificate)
-
-  public enum PrivateKeyProxy {
-    case custom(any AsyncSignerProtocol)
-    case secKey(SecKey)
-  }
 }
 
 public extension BindingKey {
@@ -89,17 +89,13 @@ public extension BindingKey {
         guard let signatureAlgorithm = SignatureAlgorithm(rawValue: algorithm.name) else {
           throw CredentialIssuanceError.cryptographicAlgorithmNotSupported
         }
-        let signer: Signer
-        if case let .secKey(secKey) = privateKey, let secKeySigner = Signer(signatureAlgorithm: signatureAlgorithm, key: secKey) {
-          signer = secKeySigner
-        } else if case let .custom(customAsyncSigner) = privateKey {
-					let signingInput = [header as DataConvertible, payload as DataConvertible].map { $0.data().base64URLEncodedString() }.joined(separator: ".").data(using: .ascii)!
-					let signature = try await customAsyncSigner.signAsync(signingInput)
-					let customSigner = PrecomputedSigner(signature: signature, algorithm: signatureAlgorithm)
-          signer = Signer(customSigner: customSigner)
-        } else {
-          throw ValidationError.error(reason: "Unable to create JWS signer")
-        }
+        
+        let signer: Signer = try await Self.createSigner(
+          with: header,
+          and: payload,
+          for: privateKey,
+          and: signatureAlgorithm
+        )
 
         let jws = try JWS(
           header: header,
@@ -119,13 +115,6 @@ public extension BindingKey {
         guard proofs else {
           throw CredentialIssuanceError.proofTypeNotSupported
         }
-
-        /*
-        let bindings = spec.cryptographicBindingMethodsSupported.contains { $0  == .jwk }
-        guard bindings else {
-          throw CredentialIssuanceError.cryptographicBindingMethodNotSupported
-        }
-         */
 
         let aud = issuanceRequester.issuerMetadata.credentialIssuerIdentifier.url.absoluteString
 
@@ -153,12 +142,12 @@ public extension BindingKey {
           throw CredentialIssuanceError.cryptographicAlgorithmNotSupported
         }
 
-        guard let signer = Signer(
-          signatureAlgorithm: signatureAlgorithm,
-          key: privateKey
-        ) else {
-          throw ValidationError.error(reason: "Unable to create JWS signer")
-        }
+        let signer: Signer = try await Self.createSigner(
+          with: header,
+          and: payload,
+          for: privateKey,
+          and: signatureAlgorithm
+        )
 
         let jws = try JWS(
           header: header,
@@ -179,11 +168,48 @@ public extension BindingKey {
   }
 }
 
-private extension BindingKey {
+extension BindingKey {
 
+  static func createSigner(
+    with header: JWSHeader,
+    and payload: Payload,
+    for privateKey: PrivateKeyProxy,
+    and signatureAlgorithm: SignatureAlgorithm
+  ) async throws -> Signer {
+
+    if case let .secKey(secKey) = privateKey,
+       let secKeySigner = Signer(
+        signatureAlgorithm: signatureAlgorithm,
+        key: secKey
+       ) {
+      return secKeySigner
+      
+    } else if case let .custom(customAsyncSigner) = privateKey {
+      let signingInput: Data? = [
+        header as DataConvertible,
+        payload as DataConvertible
+      ].map {
+        $0.data().base64URLEncodedString()
+      }
+      .joined(separator: ".").data(using: .ascii)
+      
+      guard let signingInput = signingInput else {
+        throw ValidationError.error(reason: "Invalid signing input fopr signing data")
+      }
+      
+      let signature = try await customAsyncSigner.signAsync(signingInput)
+      let customSigner = PrecomputedSigner(
+        signature: signature,
+        algorithm: signatureAlgorithm
+      )
+      return Signer(customSigner: customSigner)
+      
+    } else {
+      throw ValidationError.error(reason: "Unable to create JWS signer")
+    }
+  }
 }
 
-// we need this because secure are signer is async
 class PrecomputedSigner: JOSESwift.SignerProtocol {
 	var algorithm: JOSESwift.SignatureAlgorithm
 	let signature: Data

--- a/Sources/Entities/Encryption/BindingKey.swift
+++ b/Sources/Entities/Encryption/BindingKey.swift
@@ -16,7 +16,7 @@
 import Foundation
 import JOSESwift
 
-public enum PrivateKeyProxy {
+public enum SigningKeyProxy {
   case custom(any AsyncSignerProtocol)
   case secKey(SecKey)
 }
@@ -27,7 +27,7 @@ public enum BindingKey {
   case jwk(
     algorithm: JWSAlgorithm,
     jwk: JWK,
-    privateKey: PrivateKeyProxy,
+    privateKey: SigningKeyProxy,
     issuer: String? = nil
   )
 
@@ -173,7 +173,7 @@ extension BindingKey {
   static func createSigner(
     with header: JWSHeader,
     and payload: Payload,
-    for privateKey: PrivateKeyProxy,
+    for privateKey: SigningKeyProxy,
     and signatureAlgorithm: SignatureAlgorithm
   ) async throws -> Signer {
 

--- a/Sources/Entities/IssuanceAccessToken.swift
+++ b/Sources/Entities/IssuanceAccessToken.swift
@@ -63,13 +63,14 @@ public extension IssuanceAccessToken {
   func dPoPOrBearerAuthorizationHeader(
     dpopConstructor: DPoPConstructorType?,
     endpoint: URL?
-  ) throws -> [String: String] {
+  ) async throws -> [String: String] {
     if tokenType == TokenType.bearer {
       return ["Authorization": "\(TokenType.bearer.rawValue) \(accessToken)"]
     } else if let dpopConstructor, tokenType == TokenType.dpop, let endpoint {
+      let jwt = try await dpopConstructor.jwt(endpoint: endpoint, accessToken: accessToken)
       return [
         "Authorization": "\(TokenType.dpop.rawValue) \(accessToken)",
-        TokenType.dpop.rawValue: try dpopConstructor.jwt(endpoint: endpoint, accessToken: accessToken)
+        TokenType.dpop.rawValue: jwt
       ]
     }
     return ["Authorization": "\(TokenType.bearer.rawValue) \(accessToken)"]

--- a/Sources/Issuers/IssuanceRequester.swift
+++ b/Sources/Issuers/IssuanceRequester.swift
@@ -69,7 +69,7 @@ public actor IssuanceRequester: IssuanceRequesterType {
     let endpoint = issuerMetadata.credentialEndpoint.url
     
     do {
-      let authorizationHeader: [String: String] = try accessToken.dPoPOrBearerAuthorizationHeader(
+      let authorizationHeader: [String: String] = try await accessToken.dPoPOrBearerAuthorizationHeader(
         dpopConstructor: dpopConstructor,
         endpoint: endpoint
       )
@@ -192,7 +192,7 @@ public actor IssuanceRequester: IssuanceRequesterType {
     }
     
     do {
-      let authorizationHeader: [String: Any] = try accessToken.dPoPOrBearerAuthorizationHeader(
+      let authorizationHeader: [String: Any] = try await accessToken.dPoPOrBearerAuthorizationHeader(
         dpopConstructor: dpopConstructor,
         endpoint: endpoint
       )
@@ -224,7 +224,7 @@ public actor IssuanceRequester: IssuanceRequesterType {
       throw CredentialError.issuerDoesNotSupportDeferredIssuance
     }
     
-    let authorizationHeader: [String: String] = try accessToken.dPoPOrBearerAuthorizationHeader(
+    let authorizationHeader: [String: String] = try await accessToken.dPoPOrBearerAuthorizationHeader(
       dpopConstructor: dpopConstructor,
       endpoint: deferredCredentialEndpoint.url
     )
@@ -298,7 +298,7 @@ public actor IssuanceRequester: IssuanceRequesterType {
       }
       
       let endpoint = notificationEndpoint.url
-      let authorizationHeader: [String: String] = try accessToken.dPoPOrBearerAuthorizationHeader(
+      let authorizationHeader: [String: String] = try await accessToken.dPoPOrBearerAuthorizationHeader(
         dpopConstructor: dpopConstructor,
         endpoint: endpoint
       )

--- a/Sources/Main/Authorisers/AuthorizationServerClient.swift
+++ b/Sources/Main/Authorisers/AuthorizationServerClient.swift
@@ -351,9 +351,10 @@ public actor AuthorizationServerClient: AuthorizationServerClientType {
 
 private extension AuthorizationServerClient {
   
-  func tokenEndPointHeaders() throws -> [String: String] {
+  func tokenEndPointHeaders() async throws -> [String: String] {
     if let dpopConstructor {
-      return ["DPoP": try dpopConstructor.jwt(endpoint: tokenEndpoint, accessToken: nil)]
+      let jwt = try await dpopConstructor.jwt(endpoint: tokenEndpoint, accessToken: nil)
+      return ["DPoP": jwt]
     } else {
       return [:]
     }

--- a/Tests/Constants/TestsConstants.swift
+++ b/Tests/Constants/TestsConstants.swift
@@ -22,7 +22,7 @@ let PID_MsoMdoc_config_id = "eu.europa.ec.eudi.pid_mso_mdoc"
 let PID_SdJwtVC_config_id = "eu.europa.ec.eudi.pid_vc_sd_jwt"
 
 //let CREDENTIAL_ISSUER_PUBLIC_URL = "https://dev.issuer.eudiw.dev"
-//let PID_SdJwtVC_config_id = "eu.europa.ec.eudi.mdl_jwt_vc_json"
+//let PID_SdJwtVC_config_id = "eu.europa.ec.eudi.pid_jwt_vc_json"
 //let PID_MsoMdoc_config_id = "eu.europa.ec.eudi.pid_mdoc"
 //let MDL_config_id = "eu.europa.ec.eudi.mdl_mdoc"
 

--- a/Tests/Issuance/IssuanceAuthorizationTest.swift
+++ b/Tests/Issuance/IssuanceAuthorizationTest.swift
@@ -528,6 +528,7 @@ class IssuanceAuthorizationTest: XCTestCase {
     let privateKey = try KeyController.generateECDHPrivateKey()
     let publicKey = try KeyController.generateECDHPublicKey(from: privateKey)
     
+    let privateKeyProxy: PrivateKeyProxy = .secKey(privateKey)
     let alg = JWSAlgorithm(.ES256)
     let jwk = try ECPublicKey(
       publicKey: publicKey,
@@ -540,7 +541,7 @@ class IssuanceAuthorizationTest: XCTestCase {
     let dpopConstructor: DPoPConstructor = .init(
       algorithm: alg,
       jwk: jwk,
-      privateKey: privateKey
+      privateKey: privateKeyProxy
     )
     
     let offer: CredentialOffer = try resolution.get()

--- a/Tests/Issuance/IssuanceAuthorizationTest.swift
+++ b/Tests/Issuance/IssuanceAuthorizationTest.swift
@@ -528,7 +528,7 @@ class IssuanceAuthorizationTest: XCTestCase {
     let privateKey = try KeyController.generateECDHPrivateKey()
     let publicKey = try KeyController.generateECDHPublicKey(from: privateKey)
     
-    let privateKeyProxy: PrivateKeyProxy = .secKey(privateKey)
+    let privateKeyProxy: SigningKeyProxy = .secKey(privateKey)
     let alg = JWSAlgorithm(.ES256)
     let jwk = try ECPublicKey(
       publicKey: publicKey,

--- a/Tests/Issuance/IssuanceAuthorizationTest.swift
+++ b/Tests/Issuance/IssuanceAuthorizationTest.swift
@@ -452,6 +452,7 @@ class IssuanceAuthorizationTest: XCTestCase {
       XCTAssert(false, "Unexpected grant type")
     }
 
+    /// Change the transaction code with the one obtained https://dev.tester.issuer.eudiw.dev/
     let result = await issuer.authorizeWithPreAuthorizationCode(
       credentialOffer: offer,
       authorizationCode: try .init(

--- a/Tests/Issuance/IssuanceAuthorizationTest.swift
+++ b/Tests/Issuance/IssuanceAuthorizationTest.swift
@@ -383,7 +383,7 @@ class IssuanceAuthorizationTest: XCTestCase {
     let bindingKey: BindingKey = .jwk(
       algorithm: alg,
       jwk: publicKeyJWK,
-      privateKey: privateKey,
+      privateKey: .secKey(privateKey),
       issuer: "218232426"
     )
     
@@ -477,7 +477,7 @@ class IssuanceAuthorizationTest: XCTestCase {
     let bindingKey: BindingKey = .jwk(
       algorithm: alg,
       jwk: publicKeyJWK,
-      privateKey: privateKey,
+      privateKey: .secKey(privateKey),
       issuer: "218232426"
     )
 
@@ -576,7 +576,7 @@ class IssuanceAuthorizationTest: XCTestCase {
     let bindingKey: BindingKey = .jwk(
       algorithm: alg,
       jwk: jwk,
-      privateKey: privateKey,
+      privateKey: .secKey(privateKey),
       issuer: "218232426"
     )
     

--- a/Tests/Issuance/IssuanceBatchRequestTest.swift
+++ b/Tests/Issuance/IssuanceBatchRequestTest.swift
@@ -201,7 +201,7 @@ class IssuanceBatchRequestTest: XCTestCase {
     let bindingKey: BindingKey = .jwk(
       algorithm: alg,
       jwk: publicKeyJWK,
-      privateKey: privateKey
+      privateKey: .secKey(privateKey)
     )
 
     let wallet = Wallet(

--- a/Tests/Wallet/VCIFlowNoOffer.swift
+++ b/Tests/Wallet/VCIFlowNoOffer.swift
@@ -55,7 +55,7 @@ class VCIFlowNoOffer: XCTestCase {
     let bindingKey: BindingKey = .jwk(
       algorithm: alg,
       jwk: publicKeyJWK,
-      privateKey: privateKey
+      privateKey: .secKey(privateKey)
     )
     
     let user = ActingUser(
@@ -100,7 +100,7 @@ class VCIFlowNoOffer: XCTestCase {
     let bindingKey: BindingKey = .jwk(
       algorithm: alg,
       jwk: publicKeyJWK,
-      privateKey: privateKey
+      privateKey: .secKey(privateKey)
     )
     
     let user = ActingUser(
@@ -144,7 +144,7 @@ class VCIFlowNoOffer: XCTestCase {
     let bindingKey: BindingKey = .jwk(
       algorithm: alg,
       jwk: publicKeyJWK,
-      privateKey: privateKey
+      privateKey: .secKey(privateKey)
     )
     
     let user = ActingUser(

--- a/Tests/Wallet/VCIFlowWithOffer.swift
+++ b/Tests/Wallet/VCIFlowWithOffer.swift
@@ -266,10 +266,11 @@ class VCIFlowWithOffer: XCTestCase {
         "kid": UUID().uuidString
       ])
     
+    let privateKeyProxy: PrivateKeyProxy = .secKey(privateKey)
     let bindingKey: BindingKey = .jwk(
       algorithm: alg,
       jwk: publicKeyJWK,
-      privateKey: .secKey(privateKey)
+      privateKey: privateKeyProxy
     )
     
     let user = ActingUser(
@@ -283,7 +284,7 @@ class VCIFlowWithOffer: XCTestCase {
       dPoPConstructor: DPoPConstructor(
         algorithm: alg,
         jwk: publicKeyJWK,
-        privateKey: privateKey
+        privateKey: privateKeyProxy
       )
     )
     

--- a/Tests/Wallet/VCIFlowWithOffer.swift
+++ b/Tests/Wallet/VCIFlowWithOffer.swift
@@ -46,7 +46,7 @@ class VCIFlowWithOffer: XCTestCase {
     let bindingKey: BindingKey = .jwk(
       algorithm: alg,
       jwk: publicKeyJWK,
-      privateKey: privateKey
+      privateKey: .secKey(privateKey)
     )
     
     let user = ActingUser(
@@ -91,7 +91,7 @@ class VCIFlowWithOffer: XCTestCase {
     let bindingKey: BindingKey = .jwk(
       algorithm: alg,
       jwk: publicKeyJWK,
-      privateKey: privateKey
+      privateKey: .secKey(privateKey)
     )
     
     let user = ActingUser(
@@ -135,7 +135,7 @@ class VCIFlowWithOffer: XCTestCase {
     let bindingKey: BindingKey = .jwk(
       algorithm: alg,
       jwk: publicKeyJWK,
-      privateKey: privateKey
+      privateKey: .secKey(privateKey)
     )
     
     let user = ActingUser(
@@ -179,7 +179,7 @@ class VCIFlowWithOffer: XCTestCase {
     let bindingKey: BindingKey = .jwk(
       algorithm: alg,
       jwk: publicKeyJWK,
-      privateKey: privateKey
+      privateKey: .secKey(privateKey)
     )
     
     let user = ActingUser(
@@ -224,7 +224,7 @@ class VCIFlowWithOffer: XCTestCase {
     let bindingKey: BindingKey = .jwk(
       algorithm: alg,
       jwk: publicKeyJWK,
-      privateKey: privateKey
+      privateKey: .secKey(privateKey)
     )
     
     let user = ActingUser(
@@ -269,7 +269,7 @@ class VCIFlowWithOffer: XCTestCase {
     let bindingKey: BindingKey = .jwk(
       algorithm: alg,
       jwk: publicKeyJWK,
-      privateKey: privateKey
+      privateKey: .secKey(privateKey)
     )
     
     let user = ActingUser(

--- a/Tests/Wallet/VCIFlowWithOffer.swift
+++ b/Tests/Wallet/VCIFlowWithOffer.swift
@@ -266,7 +266,7 @@ class VCIFlowWithOffer: XCTestCase {
         "kid": UUID().uuidString
       ])
     
-    let privateKeyProxy: PrivateKeyProxy = .secKey(privateKey)
+    let privateKeyProxy: SigningKeyProxy = .secKey(privateKey)
     let bindingKey: BindingKey = .jwk(
       algorithm: alg,
       jwk: publicKeyJWK,


### PR DESCRIPTION
# Description of change

The BindingKey jwk case now accepts SigningKeyProxy instead of a SecKey as an associated value.
This is a breaking change and to continue using keys please use .secKey(your_key) instead of just your_key when creating a BindingKey.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes