### PR TITLE
Fix dpop-nonce format, use nonce in authorizeCode request in Issuer

### DIFF
--- a/Sources/Entities/CredentialSupported/CredentialSupported.swift
+++ b/Sources/Entities/CredentialSupported/CredentialSupported.swift
@@ -71,8 +71,7 @@ public extension CredentialSupported {
           }
         }
       }
-     
-      return try credentialConfiguration.toIssuanceRequest(
+        return try credentialConfiguration.toIssuanceRequest(
         responseEncryptionSpec: issuerEncryption.notRequired ? nil : responseEncryptionSpec,
         claimSet: claimSet,
         proofs: proofs

--- a/Sources/Utilities/Constants.swift
+++ b/Sources/Utilities/Constants.swift
@@ -32,6 +32,6 @@ public struct Constants {
     
   public static let url = "https://a.bc"
   
-  public static let DPOP_NONCE_HEADER = "DPoP-Nonce"
+  public static let DPOP_NONCE_HEADER = "dpop-nonce"
   public static let USE_DPOP_NONCE = "use_dpop_nonce"
 }


### PR DESCRIPTION
# Description of change

I was getting error for invalid_dpop_proof as dpopNonce was not being passed in authorizeWithAuthorizationCode.
After making above fixes, it was still failing because of incorrect format of DPOP_NONCE_HEADER in Constant.swift file

## Type of change

Please delete options that are not relevant.

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [ x ] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes