### PR TITLE
Return CNonce with AuthorizedRequest in refresh token

### DIFF
--- a/Sources/Issuers/Issuer.swift
+++ b/Sources/Issuers/Issuer.swift
@@ -69,7 +69,7 @@ public protocol IssuerType {
     clientId: String,
     authorizedRequest: AuthorizedRequest,
     dPopNonce: Nonce?
-  ) async -> Result<AuthorizedRequest, Error>
+  ) async -> Result<(AuthorizedRequest, CNonce?), Error>
 }
 
 public actor Issuer: IssuerType {
@@ -862,7 +862,7 @@ public extension Issuer {
     clientId: String,
     authorizedRequest: AuthorizedRequest,
     dPopNonce: Nonce? = nil
-  ) async -> Result<AuthorizedRequest, Error> {
+  ) async -> Result<(AuthorizedRequest, CNonce?), Error> {
     
     if  let refreshToken = authorizedRequest.refreshToken {
       do {
@@ -873,10 +873,11 @@ public extension Issuer {
           retry: true
         )
         switch token {
-        case .success((let accessToken, _, _, _, let timeStamp, _)):
-          return .success(authorizedRequest.replacing(
+        case .success((let accessToken, let cnonce, _, _, let timeStamp, _)):
+          return .success((authorizedRequest.replacing(
             accessToken: accessToken,
             timeStamp: timeStamp?.asTimeInterval ?? .zero
+          ),cnonce
           )
         )
         case .failure(let error):
@@ -886,7 +887,7 @@ public extension Issuer {
         return .failure(error)
       }
     }
-    return .success(authorizedRequest)
+    return .success((authorizedRequest, nil))
   }
 }
 


### PR DESCRIPTION
# Description of change

refresh function in Issuer should also return Nonce so that it can be used to create a proofRequired call with following function: 
```
func request(
    proofRequest: AuthorizedRequest,
    bindingKeys: [BindingKey],
    requestPayload: IssuanceRequestPayload,
    responseEncryptionSpecProvider: (_ issuerResponseEncryptionMetadata: CredentialResponseEncryption) -> IssuanceResponseEncryptionSpec?
  ) async throws -> Result<SubmittedRequest, Error>

```
Updated function:
```
func refresh(
    clientId: String,
    authorizedRequest: AuthorizedRequest,
    dPopNonce: Nonce?
  ) async -> Result<(AuthorizedRequest, CNonce?), Error>
```

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes