### PR TITLE
Dpop updates

### DIFF
--- a/Sources/Entities/AccessManagement/AuthorizationServerMetadata.swift
+++ b/Sources/Entities/AccessManagement/AuthorizationServerMetadata.swift
@@ -26,7 +26,7 @@ public struct AuthorizationServerMetadata: Codable, Equatable, Sendable {
   public let requestParameterSupported, requestURIParameterSupported, requireRequestURIRegistration: Bool?
   public let codeChallengeMethodsSupported: [String]?
   public let tlsClientCertificateBoundAccessTokens: Bool?
-  public let dpopSigningAlgValuesSupported: [String]?
+  public let dpopSigningAlgValuesSupported: [JWSAlgorithm]
   public let revocationEndpoint: String?
   public let revocationEndpointAuthMethodsSupported, revocationEndpointAuthSigningAlgValuesSupported: [String]?
   public let deviceAuthorizationEndpoint: String?
@@ -104,7 +104,7 @@ public struct AuthorizationServerMetadata: Codable, Equatable, Sendable {
     requireRequestURIRegistration: Bool? = nil,
     codeChallengeMethodsSupported: [String]? = nil,
     tlsClientCertificateBoundAccessTokens: Bool? = nil,
-    dpopSigningAlgValuesSupported: [String]? = nil,
+    dpopSigningAlgValuesSupported: [JWSAlgorithm] = [],
     revocationEndpoint: String? = nil,
     revocationEndpointAuthMethodsSupported: [String]? = nil,
     revocationEndpointAuthSigningAlgValuesSupported: [String]? = nil,

--- a/Sources/Entities/AccessManagement/IdentityAndAccessManagementMetadata.swift
+++ b/Sources/Entities/AccessManagement/IdentityAndAccessManagementMetadata.swift
@@ -69,4 +69,13 @@ public enum IdentityAndAccessManagementMetadata: Sendable {
       return metaData.tokenEndpointAuthMethodsSupported ?? []
     }
   }
+  
+  var dpopSigningAlgValuesSupported: [JWSAlgorithm] {
+    switch self {
+    case .oidc(let metaData):
+      return metaData.dpopSigningAlgValuesSupported
+    case .oauth(let metaData):
+      return metaData.dpopSigningAlgValuesSupported
+    }
+  }
 }

--- a/Sources/Entities/AccessManagement/OIDCProviderMetadata.swift
+++ b/Sources/Entities/AccessManagement/OIDCProviderMetadata.swift
@@ -35,7 +35,7 @@ public struct OIDCProviderMetadata: Codable, Equatable, Sendable {
   public let requestParameterSupported, requestURIParameterSupported, requireRequestURIRegistration: Bool?
   public let codeChallengeMethodsSupported: [String]?
   public let tlsClientCertificateBoundAccessTokens: Bool?
-  public let dpopSigningAlgValuesSupported: [String]?
+  public let dpopSigningAlgValuesSupported: [JWSAlgorithm]
   public let revocationEndpoint: String?
   public let revocationEndpointAuthMethodsSupported, revocationEndpointAuthSigningAlgValuesSupported: [String]?
   public let backchannelLogoutSupported, backchannelLogoutSessionSupported: Bool?
@@ -106,7 +106,61 @@ public struct OIDCProviderMetadata: Codable, Equatable, Sendable {
     case authorizationResponseIssParameterSupported = "authorization_response_iss_parameter_supported"
   }
   
-  public init(issuer: String?, authorizationEndpoint: String?, tokenEndpoint: String?, introspectionEndpoint: String?, userinfoEndpoint: String?, endSessionEndpoint: String?, frontchannelLogoutSessionSupported: Bool?, frontchannelLogoutSupported: Bool?, jwksURI: String?, checkSessionIframe: String?, grantTypesSupported: [String]?, acrValuesSupported: [String]?, responseTypesSupported: [String]?, subjectTypesSupported: [String]?, idTokenSigningAlgValuesSupported: [String]?, idTokenEncryptionAlgValuesSupported: [String]?, idTokenEncryptionEncValuesSupported: [String]?, userinfoSigningAlgValuesSupported: [String]?, userinfoEncryptionAlgValuesSupported: [String]?, userinfoEncryptionEncValuesSupported: [String]?, requestObjectSigningAlgValuesSupported: [String]?, requestObjectEncryptionAlgValuesSupported: [String]?, requestObjectEncryptionEncValuesSupported: [String]?, responseModesSupported: [String]?, registrationEndpoint: String?, tokenEndpointAuthMethodsSupported: [String]?, tokenEndpointAuthSigningAlgValuesSupported: [String]?, introspectionEndpointAuthMethodsSupported: [String]?, introspectionEndpointAuthSigningAlgValuesSupported: [String]?, authorizationSigningAlgValuesSupported: [String]?, authorizationEncryptionAlgValuesSupported: [String]?, authorizationEncryptionEncValuesSupported: [String]?, claimsSupported: [String]?, claimTypesSupported: [String]?, claimsParameterSupported: Bool?, scopesSupported: [String]?, requestParameterSupported: Bool?, requestURIParameterSupported: Bool?, requireRequestURIRegistration: Bool?, codeChallengeMethodsSupported: [String]?, tlsClientCertificateBoundAccessTokens: Bool?, dpopSigningAlgValuesSupported: [String]?, revocationEndpoint: String?, revocationEndpointAuthMethodsSupported: [String]?, revocationEndpointAuthSigningAlgValuesSupported: [String]?, backchannelLogoutSupported: Bool?, backchannelLogoutSessionSupported: Bool?, deviceAuthorizationEndpoint: String?, backchannelTokenDeliveryModesSupported: [String]?, backchannelAuthenticationEndpoint: String?, backchannelAuthenticationRequestSigningAlgValuesSupported: [String]?, requirePushedAuthorizationRequests: Bool?, pushedAuthorizationRequestEndpoint: String?, mtlsEndpointAliases: MtlsEndpointAliases?, authorizationResponseIssParameterSupported: Bool?) {
+  public init(
+    issuer: String?,
+    authorizationEndpoint: String?,
+    tokenEndpoint: String?,
+    introspectionEndpoint: String?,
+    userinfoEndpoint: String?,
+    endSessionEndpoint: String?,
+    frontchannelLogoutSessionSupported: Bool?,
+    frontchannelLogoutSupported: Bool?,
+    jwksURI: String?,
+    checkSessionIframe: String?,
+    grantTypesSupported: [String]?,
+    acrValuesSupported: [String]?,
+    responseTypesSupported: [String]?,
+    subjectTypesSupported: [String]?,
+    idTokenSigningAlgValuesSupported: [String]?,
+    idTokenEncryptionAlgValuesSupported: [String]?,
+    idTokenEncryptionEncValuesSupported: [String]?,
+    userinfoSigningAlgValuesSupported: [String]?,
+    userinfoEncryptionAlgValuesSupported: [String]?,
+    userinfoEncryptionEncValuesSupported: [String]?,
+    requestObjectSigningAlgValuesSupported: [String]?,
+    requestObjectEncryptionAlgValuesSupported: [String]?,
+    requestObjectEncryptionEncValuesSupported: [String]?,
+    responseModesSupported: [String]?, registrationEndpoint: String?,
+    tokenEndpointAuthMethodsSupported: [String]?,
+    tokenEndpointAuthSigningAlgValuesSupported: [String]?,
+    introspectionEndpointAuthMethodsSupported: [String]?,
+    introspectionEndpointAuthSigningAlgValuesSupported: [String]?,
+    authorizationSigningAlgValuesSupported: [String]?,
+    authorizationEncryptionAlgValuesSupported: [String]?,
+    authorizationEncryptionEncValuesSupported: [String]?,
+    claimsSupported: [String]?,
+    claimTypesSupported: [String]?,
+    claimsParameterSupported: Bool?,
+    scopesSupported: [String]?,
+    requestParameterSupported: Bool?,
+    requestURIParameterSupported: Bool?,
+    requireRequestURIRegistration: Bool?,
+    codeChallengeMethodsSupported: [String]?,
+    tlsClientCertificateBoundAccessTokens: Bool?,
+    dpopSigningAlgValuesSupported: [JWSAlgorithm],
+    revocationEndpoint: String?,
+    revocationEndpointAuthMethodsSupported: [String]?,
+    revocationEndpointAuthSigningAlgValuesSupported: [String]?,
+    backchannelLogoutSupported: Bool?,
+    backchannelLogoutSessionSupported: Bool?,
+    deviceAuthorizationEndpoint: String?,
+    backchannelTokenDeliveryModesSupported: [String]?,
+    backchannelAuthenticationEndpoint: String?,
+    backchannelAuthenticationRequestSigningAlgValuesSupported: [String]?,
+    requirePushedAuthorizationRequests: Bool?,
+    pushedAuthorizationRequestEndpoint: String?,
+    mtlsEndpointAliases: MtlsEndpointAliases?,
+    authorizationResponseIssParameterSupported: Bool?) {
     self.issuer = issuer
     self.authorizationEndpoint = authorizationEndpoint
     self.tokenEndpoint = tokenEndpoint

--- a/Sources/Entities/JOSE/JWSAlgorithm.swift
+++ b/Sources/Entities/JOSE/JWSAlgorithm.swift
@@ -30,7 +30,9 @@ public class JWSAlgorithm: JOSEAlgorithm, @unchecked Sendable {
   }
   
   public required init(from decoder: Decoder) throws {
-    fatalError("init(from:) has not been implemented")
+    let container = try decoder.singleValueContainer()
+    let name = try container.decode(String.self)
+    super.init(name: name)
   }
 }
 

--- a/Sources/Entities/Wallet/Config.swift
+++ b/Sources/Entities/Wallet/Config.swift
@@ -44,9 +44,6 @@ public struct OpenId4VCIConfig: Sendable {
   /// Whether to use PAR.
   public let usePAR: Bool
   
-  /// An optional constructor for DPoP (Demonstration of Proof-of-Possession) tokens.
-  public let dPoPConstructor: DPoPConstructorType?
-  
   /// An optional builder for client attestation proof-of-possession tokens.
   public let clientAttestationPoPBuilder: ClientAttestationPoPBuilder?
   
@@ -59,7 +56,6 @@ public struct OpenId4VCIConfig: Sendable {
   ///   - authFlowRedirectionURI: The URI to which the authentication flow should redirect.
   ///   - authorizeIssuanceConfig: Specifies how issuance authorization should be handled (default: `.favorScopes`).
   ///   - usePAR: Whether to use Pushed Authorization Requests (default: `true`).
-  ///   - dPoPConstructor: An optional DPoP constructor (default: `nil`).
   ///   - clientAttestationPoPBuilder: An optional client attestation PoP builder (default: `nil`).
   ///   - issuerMetadataPolicy: Policy defining how issuer metadata should be handled (default: `.ignoreSigned`).
   public init(
@@ -67,7 +63,6 @@ public struct OpenId4VCIConfig: Sendable {
     authFlowRedirectionURI: URL,
     authorizeIssuanceConfig: AuthorizeIssuanceConfig = .favorScopes,
     usePAR: Bool = true,
-    dPoPConstructor: DPoPConstructorType? = nil,
     clientAttestationPoPBuilder: ClientAttestationPoPBuilder? = nil,
     issuerMetadataPolicy: IssuerMetadataPolicy = .ignoreSigned
   ) {
@@ -75,7 +70,6 @@ public struct OpenId4VCIConfig: Sendable {
     self.authFlowRedirectionURI = authFlowRedirectionURI
     self.authorizeIssuanceConfig = authorizeIssuanceConfig
     self.usePAR = usePAR
-    self.dPoPConstructor = dPoPConstructor
     self.clientAttestationPoPBuilder = clientAttestationPoPBuilder
     self.issuerMetadataPolicy = issuerMetadataPolicy
   }

--- a/Tests/Constants/TestsConstants.swift
+++ b/Tests/Constants/TestsConstants.swift
@@ -114,11 +114,6 @@ func dpopConfig() -> OpenId4VCIConfig {
     ])
 
   let privateKeyProxy: SigningKeyProxy = .secKey(privateKey)
-  let bindingKey: BindingKey = .jwk(
-    algorithm: alg,
-    jwk: publicKeyJWK,
-    privateKey: privateKeyProxy
-  )
 
   let dPoPClientConfig: OpenId4VCIConfig = .init(
     client: .public(id: "wallet-dev"),
@@ -131,14 +126,7 @@ func dpopConfig() -> OpenId4VCIConfig {
     )
   )
   
-  return .init(
-    client: try! selfSignedClient(
-      clientId: "wallet-dev",
-      privateKey: try KeyController.generateECDHPrivateKey()
-    ),
-    authFlowRedirectionURI: URL(string: "urn:ietf:wg:oauth:2.0:oob")!,
-    authorizeIssuanceConfig: .favorScopes
-  )
+  return dPoPClientConfig
 }
 
 public struct ActingUser {

--- a/Tests/Helpers/Wallet.swift
+++ b/Tests/Helpers/Wallet.swift
@@ -112,7 +112,8 @@ extension Wallet {
       tokenPoster: Poster(session: self.session),
       requesterPoster: Poster(session: self.session),
       deferredRequesterPoster: Poster(session: self.session),
-      notificationPoster: Poster(session: self.session)
+      notificationPoster: Poster(session: self.session),
+      dpopConstructor: config.dPoPConstructor
     )
     
     let authorized = try await authorizeRequestWithAuthCodeUseCase(

--- a/Tests/Helpers/Wallet.swift
+++ b/Tests/Helpers/Wallet.swift
@@ -113,7 +113,9 @@ extension Wallet {
       requesterPoster: Poster(session: self.session),
       deferredRequesterPoster: Poster(session: self.session),
       notificationPoster: Poster(session: self.session),
-      dpopConstructor: config.dPoPConstructor
+      dpopConstructor: dpopConstructor(
+        algorithms: offer.authorizationServerMetadata.dpopSigningAlgValuesSupported
+      )
     )
     
     let authorized = try await authorizeRequestWithAuthCodeUseCase(
@@ -149,6 +151,9 @@ extension Wallet {
       authorizationServerMetadata: offer.authorizationServerMetadata,
       issuerMetadata: offer.credentialIssuerMetadata,
       config: config,
+      dpopConstructor: dpopConstructor(
+        algorithms: offer.authorizationServerMetadata.dpopSigningAlgValuesSupported
+      ),
       session: self.session
     )
     
@@ -286,7 +291,10 @@ extension Wallet {
       tokenPoster: Poster(session: self.session),
       requesterPoster: Poster(session: self.session),
       deferredRequesterPoster: Poster(session: self.session),
-      notificationPoster: Poster(session: self.session)
+      notificationPoster: Poster(session: self.session),
+      dpopConstructor: dpopConstructor(
+        algorithms: offer.authorizationServerMetadata.dpopSigningAlgValuesSupported
+      )
     )
     
     let authorized = try await authorizeRequestWithAuthCodeUseCase(
@@ -321,7 +329,9 @@ extension Wallet {
       requesterPoster: Poster(session: self.session),
       deferredRequesterPoster: Poster(session: self.session),
       notificationPoster: Poster(session: self.session),
-      dpopConstructor: config.dPoPConstructor
+      dpopConstructor: dpopConstructor(
+        algorithms: offer.authorizationServerMetadata.dpopSigningAlgValuesSupported
+      )
     )
     
     let authorized = try await authorizeRequestWithAuthCodeUseCase(

--- a/Tests/Issuance/IssuanceAuthorizationTest.swift
+++ b/Tests/Issuance/IssuanceAuthorizationTest.swift
@@ -53,6 +53,9 @@ class IssuanceAuthorizationTest: XCTestCase {
           path: "pushed_authorization_request_response",
           extension: "json"
         )
+      ),
+      dpopConstructor: dpopConstructor(
+        algorithms: offer.authorizationServerMetadata.dpopSigningAlgValuesSupported
       )
     )
     
@@ -88,6 +91,9 @@ class IssuanceAuthorizationTest: XCTestCase {
           path: "test",
           extension: "json"
         )
+      ),
+      dpopConstructor: dpopConstructor(
+        algorithms: offer.authorizationServerMetadata.dpopSigningAlgValuesSupported
       )
     )
     
@@ -128,6 +134,9 @@ class IssuanceAuthorizationTest: XCTestCase {
           path: "access_token_request_response_no_proof",
           extension: "json"
         )
+      ),
+      dpopConstructor: dpopConstructor(
+        algorithms: offer.authorizationServerMetadata.dpopSigningAlgValuesSupported
       )
     )
     
@@ -180,6 +189,9 @@ class IssuanceAuthorizationTest: XCTestCase {
           path: "access_token_request_response",
           extension: "json"
         )
+      ),
+      dpopConstructor: dpopConstructor(
+        algorithms: offer.authorizationServerMetadata.dpopSigningAlgValuesSupported
       )
     )
     
@@ -231,6 +243,9 @@ class IssuanceAuthorizationTest: XCTestCase {
           path: "test",
           extension: "json"
         )
+      ),
+      dpopConstructor: dpopConstructor(
+        algorithms: offer.authorizationServerMetadata.dpopSigningAlgValuesSupported
       )
     )
     
@@ -283,6 +298,9 @@ class IssuanceAuthorizationTest: XCTestCase {
           path: "access_token_request_response_no_proof",
           extension: "json"
         )
+      ),
+      dpopConstructor: dpopConstructor(
+        algorithms: offer.authorizationServerMetadata.dpopSigningAlgValuesSupported
       )
     )
     
@@ -351,7 +369,10 @@ class IssuanceAuthorizationTest: XCTestCase {
     let issuer = try Issuer(
       authorizationServerMetadata: offer.authorizationServerMetadata,
       issuerMetadata: issuerMetadata,
-      config: config
+      config: config,
+      dpopConstructor: dpopConstructor(
+        algorithms: offer.authorizationServerMetadata.dpopSigningAlgValuesSupported
+      )
     )
     
     let grants = offer.grants
@@ -482,11 +503,6 @@ class IssuanceAuthorizationTest: XCTestCase {
       ),
       authFlowRedirectionURI: URL(string: "urn:ietf:wg:oauth:2.0:oob")!,
       authorizeIssuanceConfig: .favorScopes,
-      dPoPConstructor: DPoPConstructor(
-        algorithm: alg,
-        jwk: publicKeyJWK,
-        privateKey: privateKeyProxy
-      ),
       clientAttestationPoPBuilder: DefaultClientAttestationPoPBuilder()
     )
     
@@ -496,7 +512,9 @@ class IssuanceAuthorizationTest: XCTestCase {
       authorizationServerMetadata: offer.authorizationServerMetadata,
       issuerMetadata: issuerMetadata,
       config: attestationConfig,
-      dpopConstructor: attestationConfig.dPoPConstructor
+      dpopConstructor: dpopConstructor(
+        algorithms: offer.authorizationServerMetadata.dpopSigningAlgValuesSupported
+      )
     )
     
     let grants = offer.grants
@@ -582,7 +600,10 @@ class IssuanceAuthorizationTest: XCTestCase {
     let issuer = try Issuer(
       authorizationServerMetadata: offer.authorizationServerMetadata,
       issuerMetadata: issuerMetadata,
-      config: config
+      config: config,
+      dpopConstructor: dpopConstructor(
+        algorithms: offer.authorizationServerMetadata.dpopSigningAlgValuesSupported
+      )
     )
 
     let grants = offer.grants
@@ -699,19 +720,15 @@ class IssuanceAuthorizationTest: XCTestCase {
         "kid": UUID().uuidString
       ])
     
-    let dpopConstructor: DPoPConstructor = .init(
-      algorithm: alg,
-      jwk: jwk,
-      privateKey: privateKeyProxy
-    )
-    
     let offer: CredentialOffer = try resolution.get()
     let issuerMetadata = offer.credentialIssuerMetadata
     let issuer = try Issuer(
       authorizationServerMetadata: offer.authorizationServerMetadata,
       issuerMetadata: issuerMetadata,
       config: config,
-      dpopConstructor: dpopConstructor
+      dpopConstructor: dpopConstructor(
+        algorithms: offer.authorizationServerMetadata.dpopSigningAlgValuesSupported
+      )
     )
     
     let grants = offer.grants

--- a/Tests/Issuance/IssuanceBatchRequestTest.swift
+++ b/Tests/Issuance/IssuanceBatchRequestTest.swift
@@ -86,6 +86,9 @@ class IssuanceBatchRequestTest: XCTestCase {
           path: "batch_credential_issuance_success_response_credentials",
           extension: "json"
         )
+      ),
+      dpopConstructor: dpopConstructor(
+        algorithms: offer.authorizationServerMetadata.dpopSigningAlgValuesSupported
       )
     )
     

--- a/Tests/Issuance/IssuanceDeferredRequestTest.swift
+++ b/Tests/Issuance/IssuanceDeferredRequestTest.swift
@@ -84,6 +84,9 @@ class IssuanceDeferredRequestTest: XCTestCase {
           path: "single_issuance_success_response_deffered",
           extension: "json"
         )
+      ),
+      dpopConstructor: dpopConstructor(
+        algorithms: offer.authorizationServerMetadata.dpopSigningAlgValuesSupported
       )
     )
     

--- a/Tests/Issuance/IssuanceEncryptionTest.swift
+++ b/Tests/Issuance/IssuanceEncryptionTest.swift
@@ -206,8 +206,10 @@ extension IssuanceEncryptionTest {
           path: "access_token_request_response_no_proof",
           extension: "json"
         )
-      )
-    )
+      ),
+      dpopConstructor: dpopConstructor(
+        algorithms: offer.authorizationServerMetadata.dpopSigningAlgValuesSupported
+      )    )
 
     guard let parRequested = try? await issuer.prepareAuthorizationRequest(credentialOffer: offer).get() else {
       XCTAssert(false, "Unable to create request")
@@ -266,6 +268,9 @@ extension IssuanceEncryptionTest {
           path: "no_proof_generic_error_response",
           extension: "json"
         )
+      ),
+      dpopConstructor: dpopConstructor(
+        algorithms: offer.authorizationServerMetadata.dpopSigningAlgValuesSupported
       )
     )
 

--- a/Tests/Issuance/IssuanceNotificationTest.swift
+++ b/Tests/Issuance/IssuanceNotificationTest.swift
@@ -91,6 +91,9 @@ class IssuanceNotificationTest: XCTestCase {
           path: "empty_response",
           extension: "json"
         )
+      ),
+      dpopConstructor: dpopConstructor(
+        algorithms: offer.authorizationServerMetadata.dpopSigningAlgValuesSupported
       )
     )
     
@@ -234,6 +237,9 @@ class IssuanceNotificationTest: XCTestCase {
           extension: "json",
           statusCode: 400
         )
+      ),
+      dpopConstructor: dpopConstructor(
+        algorithms: offer.authorizationServerMetadata.dpopSigningAlgValuesSupported
       )
     )
     

--- a/Tests/Issuance/IssuanceSingleRequestTest.swift
+++ b/Tests/Issuance/IssuanceSingleRequestTest.swift
@@ -85,6 +85,9 @@ class IssuanceSingleRequestTest: XCTestCase {
           path: "single_issuance_success_response_credential",
           extension: "json"
         )
+      ),
+      dpopConstructor: dpopConstructor(
+        algorithms: offer.authorizationServerMetadata.dpopSigningAlgValuesSupported
       )
     )
     
@@ -206,6 +209,9 @@ class IssuanceSingleRequestTest: XCTestCase {
           path: "single_issuance_success_response_credential",
           extension: "json"
         )
+      ),
+      dpopConstructor: dpopConstructor(
+        algorithms: offer.authorizationServerMetadata.dpopSigningAlgValuesSupported
       )
     )
     
@@ -328,6 +334,9 @@ class IssuanceSingleRequestTest: XCTestCase {
           path: "single_issuance_success_response_credential",
           extension: "json"
         )
+      ),
+      dpopConstructor: dpopConstructor(
+        algorithms: offer.authorizationServerMetadata.dpopSigningAlgValuesSupported
       )
     )
     

--- a/Tests/Wallet/VCIFlowWithOffer.swift
+++ b/Tests/Wallet/VCIFlowWithOffer.swift
@@ -295,6 +295,50 @@ class VCIFlowWithOffer: XCTestCase {
     XCTAssert(true)
   }
   
+  func testWithTertiaryIssuerCredentialOfferURL() async throws {
+    
+    let privateKey = try KeyController.generateECDHPrivateKey()
+    let publicKey = try KeyController.generateECDHPublicKey(from: privateKey)
+    
+    let alg = JWSAlgorithm(.ES256)
+    let publicKeyJWK = try ECPublicKey(
+      publicKey: publicKey,
+      additionalParameters: [
+        "alg": alg.name,
+        "use": "sig",
+        "kid": UUID().uuidString
+      ])
+    
+    let bindingKey: BindingKey = .jwk(
+      algorithm: alg,
+      jwk: publicKeyJWK,
+      privateKey: .secKey(privateKey)
+    )
+    
+    let user = ActingUser(
+      username: "tneal",
+      password: "password"
+    )
+    
+    let wallet = Wallet(
+      actingUser: user,
+      bindingKeys: [bindingKey]
+    )
+    
+    do {
+      try await walletInitiatedIssuanceWithTertiaryOfferUrl(
+        wallet: wallet,
+        url: TERTIARY_CREDENTIAL_OFFER_QR_CODE_URL.removingPercentEncoding!
+      )
+    } catch {
+      
+      XCTExpectFailure()
+      XCTAssert(false, error.localizedDescription)
+    }
+    
+    XCTAssert(true)
+  }
+  
   func testWithOfferMDLDPoP() async throws {
     
     let privateKey = try KeyController.generateECDHPrivateKey()
@@ -580,6 +624,30 @@ private func walletInitiatedIssuanceWithOfferUrl(
   let credentials = try await wallet.issueByCredentialOfferUrlMultipleFormats(
     offerUri: url,
     config: clientConfig
+  )
+  
+  print("--> [ISSUANCE] Issued credentials:")
+  for credential in credentials {
+    print("\t [\(credential.0)]: \(credential.1)")
+  }
+}
+
+private func walletInitiatedIssuanceWithTertiaryOfferUrl(
+  wallet: Wallet,
+  url: String
+) async throws {
+  
+  guard !url.isEmpty else {
+    XCTExpectFailure()
+    XCTAssert(false, "No url provided")
+    return
+  }
+  
+  print("[[Scenario: Offer passed to wallet via url]] ")
+  
+  let credentials = try await wallet.issueByCredentialOfferUrlMultipleFormats(
+    offerUri: url,
+    config: dpopConfig()
   )
   
   print("--> [ISSUANCE] Issued credentials:")

--- a/Tests/Wallet/VCIFlowWithOffer.swift
+++ b/Tests/Wallet/VCIFlowWithOffer.swift
@@ -373,12 +373,7 @@ class VCIFlowWithOffer: XCTestCase {
     let dPoPClientConfig: OpenId4VCIConfig = .init(
       client: .public(id: "wallet-dev"),
       authFlowRedirectionURI: URL(string: "urn:ietf:wg:oauth:2.0:oob")!,
-      authorizeIssuanceConfig: .favorScopes,
-      dPoPConstructor: DPoPConstructor(
-        algorithm: alg,
-        jwk: publicKeyJWK,
-        privateKey: privateKeyProxy
-      )
+      authorizeIssuanceConfig: .favorScopes
     )
     
     do {
@@ -429,12 +424,7 @@ class VCIFlowWithOffer: XCTestCase {
     let dPoPClientConfig: OpenId4VCIConfig = .init(
       client: .public(id: "wallet-dev"),
       authFlowRedirectionURI: URL(string: "urn:ietf:wg:oauth:2.0:oob")!,
-      authorizeIssuanceConfig: .favorScopes,
-      dPoPConstructor: DPoPConstructor(
-        algorithm: alg,
-        jwk: publicKeyJWK,
-        privateKey: privateKeyProxy
-      )
+      authorizeIssuanceConfig: .favorScopes
     )
     
     do {
@@ -485,12 +475,7 @@ class VCIFlowWithOffer: XCTestCase {
     let dPoPClientConfig: OpenId4VCIConfig = .init(
       client: .public(id: "wallet-dev"),
       authFlowRedirectionURI: URL(string: "urn:ietf:wg:oauth:2.0:oob")!,
-      authorizeIssuanceConfig: .favorScopes,
-      dPoPConstructor: DPoPConstructor(
-        algorithm: alg,
-        jwk: publicKeyJWK,
-        privateKey: privateKeyProxy
-      )
+      authorizeIssuanceConfig: .favorScopes
     )
     
     do {
@@ -647,7 +632,7 @@ private func walletInitiatedIssuanceWithTertiaryOfferUrl(
   
   let credentials = try await wallet.issueByCredentialOfferUrlMultipleFormats(
     offerUri: url,
-    config: dpopConfig()
+    config: clientConfig
   )
   
   print("--> [ISSUANCE] Issued credentials:")


### PR DESCRIPTION
# Description of change

The library can determine if an authorization server supports dpop and create a dpop constructor.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes