### PR TITLE
Intermittent .networkError when requesting access token during Authorization Flow

### DIFF
--- a/Sources/Main/Authorisers/AuthorizationServerClient.swift
+++ b/Sources/Main/Authorisers/AuthorizationServerClient.swift
@@ -672,14 +672,6 @@ internal actor AuthorizationServerClient: AuthorizationServerClientType {
             } else {
               return .failure(ValidationError.retryFailedAfterDpopNonce)
             }
-          case .networkError:
-              return try await requestAccessTokenAuthFlow(
-                authorizationCode: authorizationCode,
-                codeVerifier: codeVerifier,
-                identifiers: identifiers,
-                dpopNonce: dpopNonce,
-                retry: false
-              )
           default:
             return .failure(error)
           }

--- a/Sources/Main/Authorisers/AuthorizationServerClient.swift
+++ b/Sources/Main/Authorisers/AuthorizationServerClient.swift
@@ -485,6 +485,14 @@ internal actor AuthorizationServerClient: AuthorizationServerClientType {
           } else {
             return .failure(ValidationError.retryFailedAfterDpopNonce)
           }
+        case .networkError:
+            return try await requestAccessTokenAuthFlow(
+                authorizationCode: authorizationCode,
+                codeVerifier: codeVerifier,
+                identifiers: identifiers,
+                dpopNonce: dpopNonce,
+                retry: false
+            )
         default:
           return .failure(error)
         }
@@ -664,6 +672,14 @@ internal actor AuthorizationServerClient: AuthorizationServerClientType {
             } else {
               return .failure(ValidationError.retryFailedAfterDpopNonce)
             }
+          case .networkError:
+              return try await requestAccessTokenAuthFlow(
+                authorizationCode: authorizationCode,
+                codeVerifier: codeVerifier,
+                identifiers: identifiers,
+                dpopNonce: dpopNonce,
+                retry: false
+              )
           default:
             return .failure(error)
           }


### PR DESCRIPTION
# Description of change

This change introduces a retry mechanism in the AuthorizationServerClient.swift class to address an intermittent .networkError occurring when requesting an access token during the authorization flow, even when there is no actual network disruption. 

We identified that this is a client-side issue, as the request fails without reaching the server.The retry logic aims to recover from these transient failures and improve reliability in the flow..

No new dependencies are introduced by this change

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

To verify this fix:

Added local testing by reproducing the .networkError scenario with simulated intermittent failures.

Confirmed that the retry logic successfully re-attempts the request and retrieves the access token without manual intervention.

Test Steps:

Simulate intermittent network errors during the authorization flow.

Observe that the retry mechanism triggers correctly.

Confirm that access token retrieval succeeds after retry.

 Manual testing in a local development environment.

 Verifying normal flow continues to work without regressions.

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
