### PR TITLE
Default input_mode to numeric in tx_code

### DIFF
--- a/Sources/Entities/Types/Types.swift
+++ b/Sources/Entities/Types/Types.swift
@@ -264,6 +264,14 @@ public struct TxCode: Codable, Sendable {
     self.length = length
     self.description = description
   }
+  
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    
+    self.inputMode = try container.decodeIfPresent(TxCodeInputMode.self, forKey: .inputMode) ?? .numeric
+    self.length = try container.decodeIfPresent(Int.self, forKey: .length)
+    self.description = try container.decodeIfPresent(String.self, forKey: .description)
+  }
 }
 
 public enum InputModeTO: String, Codable {

--- a/Tests/Entities/TypesTests.swift
+++ b/Tests/Entities/TypesTests.swift
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Foundation
+import XCTest
+
+@testable import OpenID4VCI
+
+class TxCodeTests: XCTestCase {
+  func testTxCodeDefaultsToNumericWhenMissing() throws {
+    let json = """
+    {
+        "length": 4,
+        "description": "Enter code"
+    }
+    """.data(using: .utf8)!
+    
+    let txCode = try JSONDecoder().decode(TxCode.self, from: json)
+    
+    XCTAssertEqual(txCode.inputMode, .numeric, "Missing input_mode should default to numeric")
+    XCTAssertEqual(txCode.length, 4)
+    XCTAssertEqual(txCode.description, "Enter code")
+  }
+  
+  func testTxCodeParsesNumericExplicitly() throws {
+    let json = """
+    {
+        "input_mode": "numeric",
+        "length": 6,
+        "description": "Enter numeric code"
+    }
+    """.data(using: .utf8)!
+    
+    let txCode = try JSONDecoder().decode(TxCode.self, from: json)
+    
+    XCTAssertEqual(txCode.inputMode, .numeric)
+    XCTAssertEqual(txCode.length, 6)
+  }
+  
+  func testTxCodeParsesTextExplicitly() throws {
+    let json = """
+    {
+        "input_mode": "text",
+        "length": 8,
+        "description": "Enter text code"
+    }
+    """.data(using: .utf8)!
+    
+    let txCode = try JSONDecoder().decode(TxCode.self, from: json)
+    
+    XCTAssertEqual(txCode.inputMode, .text)
+    XCTAssertEqual(txCode.length, 8)
+  }
+  
+  func testTxCodeFailsOnInvalidInputMode() throws {
+    let json = """
+    {
+        "input_mode": "invalid_mode",
+        "length": 4,
+        "description": "Invalid mode test"
+    }
+    """.data(using: .utf8)!
+    
+    XCTAssertThrowsError(
+      try JSONDecoder().decode(TxCode.self, from: json),
+      "Decoding should fail if input_mode has an unsupported value"
+    ) { error in
+      
+      guard case DecodingError.dataCorrupted(let context) = error else {
+        XCTFail("Expected dataCorrupted error, got \(error)")
+        return
+      }
+      
+      XCTAssertTrue(context.debugDescription.contains("TxCodeInputMode"))
+    }
+  }
+}


### PR DESCRIPTION
# Description of change
Default `input_mode` for `tx_code` is now set to numeric when missing, according to the OIDC4VCI spec. This fixes decoding errors when `input_mode` is not provided in the JSON.

Addresses #151 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Unit tests have been added to verify default behavior as well as parsing of explicit `numeric` and `text` values.

- [x] Decoding JSON without `input_mode` 
- [x] Decoding JSON with `input_mode` : `numeric`
- [x] Decoding JSON with `input_mode` : `text`
- [x] Decoding JSON with invalid `input_mode`

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes