### PR TITLE
Change Credential Issuer Metadata URL handling

### DIFF
--- a/Tests/Resolver/CredentialOfferResolverTests.swift
+++ b/Tests/Resolver/CredentialOfferResolverTests.swift
@@ -210,4 +210,47 @@ class CredentialOfferResolverTests: XCTestCase {
       XCTAssert(false, error.localizedDescription)
     }
   }
+  
+  
+  func testBuildWellKnownURL_withoutPath() async throws {
+      let resolver = CredentialIssuerMetadataResolver()
+      let input = URL(string: "https://issuer.example.com")!
+      
+      let result = try await resolver.buildWellKnownCredentialIssuerURL(from: input)
+      
+      XCTAssertEqual(
+        result.absoluteString,
+        "https://issuer.example.com/.well-known/openid-credential-issuer"
+      )
+    }
+    
+  func testBuildWellKnownURL_withPath() async throws {
+      let resolver = CredentialIssuerMetadataResolver()
+      let input = URL(string: "https://issuer.example.com/tenant")!
+      
+      let result = try await resolver.buildWellKnownCredentialIssuerURL(from: input)
+      
+      XCTAssertEqual(
+        result.absoluteString,
+        "https://issuer.example.com/.well-known/openid-credential-issuer/tenant"
+      )
+    }
+    
+  func testBuildWellKnownURL_invalidUrl() async {
+      let resolver = CredentialIssuerMetadataResolver()
+      let input = URL(string: "http://")! // deliberately invalid
+
+      do {
+          _ = try await resolver.buildWellKnownCredentialIssuerURL(from: input)
+      } catch let error as FetchError {
+          switch error {
+          case .invalidUrl:
+            XCTAssert(true)
+          default:
+              XCTFail("Unexpected FetchError case: \(error)")
+          }
+      } catch {
+          XCTFail("Unexpected error type: \(error)")
+      }
+  }
 }


### PR DESCRIPTION
Refactors the creation of the well-known URL for
credential issuer metadata


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [ ] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes