### PR TITLE
Refresh token for attestation clients

### DIFF
--- a/Sources/Issuers/Issuer.swift
+++ b/Sources/Issuers/Issuer.swift
@@ -134,6 +134,19 @@ public protocol IssuerType: Sendable {
     dPopNonce: Nonce?
   ) async -> Result<AuthorizedRequest, Error>
   
+  /// Refreshes an authorized request.
+  ///
+  /// - Parameters:
+  ///   - clientId: The Client requesting a refresh.
+  ///   - authorizedRequest: The existing authorized request to be refreshed.
+  ///   - dPopNonce: An optional nonce for DPoP security.
+  /// - Returns: A result containing either a new `AuthorizedRequest` if successful or an `Error` otherwise.
+  func refresh(
+    client: Client,
+    authorizedRequest: AuthorizedRequest,
+    dPopNonce: Nonce?
+  ) async -> Result<AuthorizedRequest, Error>
+  
   /// Sets the deferred response encryption specification to be used for issuance responses.
   ///
   /// - Parameter deferredResponseEncryptionSpec:
@@ -205,7 +218,14 @@ public actor Issuer: IssuerType {
     self.issuerMetadata = issuerMetadata
     self.config = config
     
+    if let challengeEndpoint = authorizationServerMetadata.challengeEndpointURI {
+      challenger = ChallengeEndpointClient(challengeEndpoint: challengeEndpoint)
+    } else {
+      challenger = nil
+    }
+    
     authorizer = try AuthorizationServerClient(
+      challenger: challenger,
       parPoster: Poster(session: session),
       tokenPoster: Poster(session: session),
       config: config,
@@ -213,12 +233,6 @@ public actor Issuer: IssuerType {
       credentialIssuerIdentifier: issuerMetadata.credentialIssuerIdentifier,
       dpopConstructor: config.useDpopIfSupported ? dpopConstructor : nil
     )
-    
-    if let challengeEndpoint = authorizationServerMetadata.challengeEndpointURI {
-      challenger = ChallengeEndpointClient(challengeEndpoint: challengeEndpoint)
-    } else {
-      challenger = nil
-    }
     
     authorizeIssuance = AuthorizeIssuance(
       config: config,
@@ -271,15 +285,6 @@ public actor Issuer: IssuerType {
     self.issuerMetadata = issuerMetadata
     self.config = config
     
-    authorizer = try AuthorizationServerClient(
-      parPoster: parPoster,
-      tokenPoster: tokenPoster,
-      config: config,
-      authorizationServerMetadata: authorizationServerMetadata,
-      credentialIssuerIdentifier: issuerMetadata.credentialIssuerIdentifier,
-      dpopConstructor: dpopConstructor
-    )
-    
     if let challengeEndpoint = authorizationServerMetadata.challengeEndpointURI {
       challenger = ChallengeEndpointClient(
         poster: challengePoster,
@@ -288,6 +293,16 @@ public actor Issuer: IssuerType {
     } else {
       challenger = nil
     }
+    
+    authorizer = try AuthorizationServerClient(
+      challenger: challenger,
+      parPoster: parPoster,
+      tokenPoster: tokenPoster,
+      config: config,
+      authorizationServerMetadata: authorizationServerMetadata,
+      credentialIssuerIdentifier: issuerMetadata.credentialIssuerIdentifier,
+      dpopConstructor: dpopConstructor
+    )
     
     authorizeIssuance = AuthorizeIssuance(
       config: config,
@@ -875,6 +890,39 @@ public extension Issuer {
       do {
         let token = try await authorizer.refreshAccessToken(
           clientId: clientId,
+          refreshToken: refreshToken,
+          dpopNonce: dPopNonce,
+          retry: true
+        )
+        switch token {
+        case .success(
+          (let accessToken, _, _, let timeStamp, _)
+        ):
+          return .success(authorizedRequest.replacing(
+            accessToken: accessToken,
+            timeStamp: timeStamp?.asTimeInterval ?? .zero
+          )
+          )
+        case .failure(let error):
+          return .failure(error)
+        }
+      } catch {
+        return .failure(error)
+      }
+    }
+    return .success(authorizedRequest)
+  }
+  
+  func refresh(
+    client: Client,
+    authorizedRequest: AuthorizedRequest,
+    dPopNonce: Nonce?
+  ) async -> Result<AuthorizedRequest, Error> {
+    
+    if  let refreshToken = authorizedRequest.refreshToken {
+      do {
+        let token = try await authorizer.refreshAccessToken(
+          client: client,
           refreshToken: refreshToken,
           dpopNonce: dPopNonce,
           retry: true

--- a/Sources/Main/AttestationBasedClient/Client.swift
+++ b/Sources/Main/AttestationBasedClient/Client.swift
@@ -54,6 +54,15 @@ public enum Client: Sendable {
     
     self = .attested(attestationJWT: attestationJWT, popJwtSpec: popJwtSpec)
   }
+  
+  internal var attested: (attestationJWT: ClientAttestationJWT, popJwtSpec: ClientAttestationPoPJWTSpec)? {
+    return switch self {
+    case .public:
+      nil
+    case .attested(let attestationJWT, let popJwtSpec):
+      (attestationJWT, popJwtSpec)
+    }
+  }
 }
 
 extension JWK {

--- a/Sources/Main/Authorisers/AuthorizationServerClient.swift
+++ b/Sources/Main/Authorisers/AuthorizationServerClient.swift
@@ -145,6 +145,27 @@ protocol AuthorizationServerClientType: Sendable {
     Int?,
     Nonce?
   ), Error>
+  
+  /// Refreshes an access token using a refresh token.
+  ///
+  /// - Parameters:
+  ///   - client: The client used for authentication.
+  ///   - refreshToken: The refresh token issued previously.
+  ///   - dpopNonce: An optional nonce for DPoP.
+  ///   - retry: A flag indicating whether to retry on failure.
+  /// - Returns: A result containing the new access token, authorization details, token type, expiration time, and an optional nonce, or an error if the operation fails.
+  func refreshAccessToken(
+    client: Client,
+    refreshToken: IssuanceRefreshToken,
+    dpopNonce: Nonce?,
+    retry: Bool
+  ) async throws -> Result<(
+    IssuanceAccessToken,
+    AuthorizationDetailsIdentifiers?,
+    TokenType?,
+    Int?,
+    Nonce?
+  ), Error>
 }
 
 internal actor AuthorizationServerClient: AuthorizationServerClientType {
@@ -161,6 +182,7 @@ internal actor AuthorizationServerClient: AuthorizationServerClientType {
   public let authorizationServerMetadata: IdentityAndAccessManagementMetadata
   public let credentialIssuerIdentifier: CredentialIssuerId
   public let dpopConstructor: DPoPConstructorType?
+  public let challenger: ChallengeEndpointClientType?
   
   static let responseType = "code"
   static let grantAuthorizationCode = "authorization_code"
@@ -168,6 +190,7 @@ internal actor AuthorizationServerClient: AuthorizationServerClientType {
   
   public init(
     service: AuthorisationServiceType = AuthorisationService(),
+    challenger: ChallengeEndpointClientType?,
     parPoster: PostingType = Poster(),
     tokenPoster: PostingType = Poster(),
     config: OpenId4VCIConfig,
@@ -176,6 +199,8 @@ internal actor AuthorizationServerClient: AuthorizationServerClientType {
     dpopConstructor: DPoPConstructorType? = nil
   ) throws {
     self.service = service
+    self.challenger = challenger
+    
     self.parPoster = parPoster
     self.tokenPoster = tokenPoster
     self.config = config
@@ -598,6 +623,93 @@ internal actor AuthorizationServerClient: AuthorizationServerClientType {
     }
   }
   
+  public func refreshAccessToken(
+    client: Client,
+    refreshToken: IssuanceRefreshToken,
+    dpopNonce: Nonce?,
+    retry: Bool
+  ) async throws -> Result<(
+    IssuanceAccessToken,
+    AuthorizationDetailsIdentifiers?,
+    TokenType?,
+    Int?,
+    Nonce?
+  ), Error> {
+    let parameters: JSON = JSON([
+      Constants.CLIENT_ID_PARAM: client.id,
+      Constants.GRANT_TYPE_PARAM: Constants.REFRESH_TOKEN,
+      Constants.REFRESH_TOKEN_PARAM: refreshToken.refreshToken
+    ].compactMapValues { $0 })
+    
+    let attestationHeaders = try await makeAttestationHeadersIfNeeded(
+      for: client,
+      clock: Clock()
+    )
+    
+    do {
+      let headers = try await tokenEndPointHeaders(url: tokenEndpoint, dpopNonce: dpopNonce) + attestationHeaders
+      let response: ResponseWithHeaders<AccessTokenRequestResponse> = try await service.formPost(
+        poster: tokenPoster,
+        url: tokenEndpoint,
+        headers: headers,
+        parameters: parameters.toDictionary().convertToDictionaryOfStrings()
+      )
+      
+      switch response.body {
+      case .success(
+        let tokenType,
+        let accessToken,
+        _,
+        let expiresIn,
+        _,
+        let identifiers
+      ):
+        return .success(
+          (
+            try .init(
+              accessToken: accessToken,
+              tokenType: .init(
+                value: tokenType
+              ),
+              expiresIn: TimeInterval(expiresIn)
+            ),
+            identifiers,
+            TokenType(
+              value: tokenType
+            ),
+            expiresIn,
+            response.dpopNonce()
+          )
+        )
+      case .failure(let error, let errorDescription):
+        throw CredentialIssuanceError.pushedAuthorizationRequestFailed(
+          error: error,
+          errorDescription: errorDescription
+        )
+      }
+    } catch {
+      if let postError = error as? PostError {
+        switch postError {
+        case .useDpopNonce(let nonce):
+          if retry {
+            return try await refreshAccessToken(
+              client: client,
+              refreshToken: refreshToken,
+              dpopNonce: nonce,
+              retry: false
+            )
+          } else {
+            return .failure(ValidationError.retryFailedAfterDpopNonce)
+          }
+        default:
+          return .failure(error)
+        }
+      } else {
+        return .failure(error)
+      }
+    }
+  }
+  
   public func requestAccessTokenPreAuthFlow(
     preAuthorizedCode: String,
     txCode: TxCode?,
@@ -765,6 +877,42 @@ private extension AuthorizationServerClient {
       
       return (attestationJWT, popJWT)
     }
+  }
+  
+  private func makeAttestationHeadersIfNeeded(for client: Client, clock: ClockType) async throws -> [String: String] {
+    guard let attested = client.attested else {
+      return [:]
+    }
+
+    guard let clientAttestationPoPBuilder = config.clientAttestationPoPBuilder else {
+      throw ValidationError.error(reason: "No clientAttestationPoPBuilder configured")
+    }
+
+    guard
+      let issuer = authorizationServerMetadata.issuer,
+      let authServerId = URL(string: issuer)
+    else {
+      throw ValidationError.error(reason: "No authorization server metadata issuer")
+    }
+
+    guard let challengeEndpointURI = authorizationServerMetadata.challengeEndpointURI else {
+      throw ValidationError.error(reason: "No challenge endpoint")
+    }
+
+    let challenge = try await challenger?.getChallenge().get()
+
+    let popJWT = try await clientAttestationPoPBuilder.buildAttestationPoPJWT(
+      for: client,
+      algorithm: attested.1.signingAlgorithm,
+      clock: clock,
+      authServerId: authServerId,
+      challenge: challenge?.value
+    )
+
+    return [
+      Constants.OAUTH_CLIENT_ATTESTATION: attested.attestationJWT.jws.compactSerializedString,
+      Constants.OAUTH_CLIENT_ATTESTATION_POP: popJWT.jws.compactSerializedString
+    ]
   }
   
   func tokenEndPointHeaders(


### PR DESCRIPTION
# Description of change

Added missing functionality for refresh token for attestation clients.

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [ ] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes