### PR TITLE
Enhance refresh token handling by including refreshToken in AuthorizedRequest and AuthorizationServerClient

### DIFF
--- a/Sources/Entities/Issuance/AuthorizedRequest.swift
+++ b/Sources/Entities/Issuance/AuthorizedRequest.swift
@@ -124,4 +124,21 @@ extension AuthorizedRequest {
       grantType: grantType
     )
   }
+	
+	/// Returns a copy of the current `AuthorizedRequest`, replacing the `accessToken`,  `refreshToken` and `timeStamp`
+	/// - Parameters:
+	///   - newAccessToken: The new `IssuanceAccessToken` to use.
+	///   - newRefreshToken: The new `IssuanceRefreshToken` to use.
+	///   - newTimeStamp: The new `TimeInterval` to use.
+	/// - Returns: A new `AuthorizedRequest` instance with the updated values.
+	func replacing(accessToken newAccessToken: IssuanceAccessToken, refreshToken newRefreshToken: IssuanceRefreshToken?, timeStamp newTimeStamp: TimeInterval) -> AuthorizedRequest {
+	  return .init(
+		accessToken: newAccessToken,
+		refreshToken: newRefreshToken,
+		credentialIdentifiers: credentialIdentifiers,
+		timeStamp: newTimeStamp,
+		dPopNonce: dPopNonce,
+		grantType: grantType
+	  )
+	}
 }

--- a/Sources/Issuers/Issuer.swift
+++ b/Sources/Issuers/Issuer.swift
@@ -872,7 +872,7 @@ public extension Issuer {
     dPopNonce: Nonce? = nil
   ) async throws -> AuthorizedRequest {
     if let refreshToken = authorizedRequest.refreshToken {
-        let (accessToken, _, _, timeStamp, _) = try await authorizer.refreshAccessToken(
+        let (accessToken, refreshToken, _, _, timeStamp, _) = try await authorizer.refreshAccessToken(
           clientId: clientId,
           refreshToken: refreshToken,
           dpopNonce: dPopNonce,
@@ -893,7 +893,7 @@ public extension Issuer {
     dPopNonce: Nonce?
   ) async throws -> AuthorizedRequest {
     if let refreshToken = authorizedRequest.refreshToken {
-        let (accessToken, _, _, timeStamp, _) = try await authorizer.refreshAccessToken(
+        let (accessToken, refreshToken, _, _, timeStamp, _) = try await authorizer.refreshAccessToken(
           client: client,
           refreshToken: refreshToken,
           dpopNonce: dPopNonce,
@@ -901,6 +901,7 @@ public extension Issuer {
         )
           return authorizedRequest.replacing(
             accessToken: accessToken,
+			refreshToken: refreshToken,
             timeStamp: timeStamp?.asTimeInterval ?? .zero
           )
     }

--- a/Sources/Main/Authorisers/AuthorizationServerClient.swift
+++ b/Sources/Main/Authorisers/AuthorizationServerClient.swift
@@ -140,6 +140,7 @@ protocol AuthorizationServerClientType: Sendable {
     maxRetries: Int
   ) async throws -> (
     IssuanceAccessToken,
+	IssuanceRefreshToken?,
     AuthorizationDetailsIdentifiers?,
     TokenType?,
     Int?,
@@ -161,6 +162,7 @@ protocol AuthorizationServerClientType: Sendable {
     maxRetries: Int
   ) async throws -> (
     IssuanceAccessToken,
+	IssuanceRefreshToken?,
     AuthorizationDetailsIdentifiers?,
     TokenType?,
     Int?,
@@ -555,6 +557,7 @@ internal actor AuthorizationServerClient: AuthorizationServerClientType {
     maxRetries: Int = Constants.MAX_RETRIES
   ) async throws -> (
     IssuanceAccessToken,
+	IssuanceRefreshToken?,
     AuthorizationDetailsIdentifiers?,
     TokenType?,
     Int?,
@@ -582,7 +585,7 @@ internal actor AuthorizationServerClient: AuthorizationServerClientType {
       case .success(
         let tokenType,
         let accessToken,
-        _,
+        let refreshToken,
         let expiresIn,
         _,
         let identifiers
@@ -595,6 +598,10 @@ internal actor AuthorizationServerClient: AuthorizationServerClientType {
               ),
               expiresIn: TimeInterval(expiresIn)
             ),
+			try .init(
+			  refreshToken: refreshToken,
+			  expiresIn: nil
+			),
             identifiers,
             TokenType(
               value: tokenType
@@ -629,6 +636,7 @@ internal actor AuthorizationServerClient: AuthorizationServerClientType {
     maxRetries: Int = Constants.MAX_RETRIES
   ) async throws -> (
     IssuanceAccessToken,
+	IssuanceRefreshToken?, 
     AuthorizationDetailsIdentifiers?,
     TokenType?,
     Int?,
@@ -658,7 +666,7 @@ internal actor AuthorizationServerClient: AuthorizationServerClientType {
       case .success(
         let tokenType,
         let accessToken,
-        _,
+        let refreshToken,
         let expiresIn,
         _,
         let identifiers
@@ -671,6 +679,10 @@ internal actor AuthorizationServerClient: AuthorizationServerClientType {
               ),
               expiresIn: TimeInterval(expiresIn)
             ),
+			try IssuanceRefreshToken(
+				refreshToken: refreshToken,
+			  expiresIn: nil
+			),
             identifiers,
             TokenType(
               value: tokenType


### PR DESCRIPTION
# Description of change

`refreshAccessToken` returns the new refresh token. Issuer `refresh` replaces the old refresh token

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Tested with reissue

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [ ] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes