### PR TITLE
Add JWS algorithm validation for Wallet Instance Attestation

### DIFF
--- a/Sources/Main/AttestationBasedClient/ClientAttestation.swift
+++ b/Sources/Main/AttestationBasedClient/ClientAttestation.swift
@@ -21,11 +21,19 @@ public struct ClientAttestationJWT: Sendable {
   public let jws: JWS
   private let payload: JSON
   
+  private static let allowedAlgorithms: Set<SignatureAlgorithm> = [
+    .ES256, .ES384, .ES512
+  ]
+  
   public init(jws: JWS, validateCnf: Bool = true) throws {
     self.jws = jws
     
-    guard jws.header.algorithm != nil else {
+    guard let algorithm = jws.header.algorithm else {
       throw ClientAttestationError.notSigned
+    }
+    
+    guard Self.allowedAlgorithms.contains(algorithm) else {
+      throw ClientAttestationError.invalidAlgorithm(allowedAlgorithms: Self.allowedAlgorithms.map { $0.rawValue})
     }
     
     let payloadData = jws.payload.data()

--- a/Sources/Main/AttestationBasedClient/ClientAttestationError.swift
+++ b/Sources/Main/AttestationBasedClient/ClientAttestationError.swift
@@ -17,6 +17,7 @@ import Foundation
 
 enum ClientAttestationError: Error, LocalizedError {
   case notSigned
+  case invalidAlgorithm(allowedAlgorithms:[String])
   case invalidPayload
   case invalidClientId
   case missingSubject
@@ -31,6 +32,9 @@ enum ClientAttestationError: Error, LocalizedError {
   var errorDescription: String? {
     switch self {
     case .notSigned: return "Invalid Attestation JWT. Not properly signed."
+    case .invalidAlgorithm(let allowed):
+      let list = allowed.sorted().joined(separator: ", ")
+      return "Invalid Attestation JWT. Signature algorithm must be one of: \(list)."
     case .invalidPayload: return "Invalid Attestation JWT. Cannot parse payload."
     case .missingSubject: return "Invalid Attestation JWT. Missing subject claim."
     case .missingCnfClaim: return "Invalid Attestation JWT. Missing cnf claim."

--- a/Tests/AttestationBased/AttestationBasedTests.swift
+++ b/Tests/AttestationBased/AttestationBasedTests.swift
@@ -65,4 +65,141 @@ class AttestationBasedTests: XCTestCase {
     
     XCTAssertNotNil(client)
   }
+
+  func testClientAttestationWithValidAlgorithms_shouldSucceed() async throws {
+    // Test that ES256, ES384, ES512 are all accepted
+    let privateKey = try KeyController.generateECDHPrivateKey()
+
+    // Test ES256
+    let clientES256 = try selfSignedClient(
+      clientId: "test-client-es256",
+      algorithm: .ES256,
+      privateKey: privateKey
+    )
+    XCTAssertNotNil(clientES256, "ES256 should be accepted")
+
+    // Test ES384
+    let clientES384 = try selfSignedClient(
+      clientId: "test-client-es384",
+      algorithm: .ES384,
+      privateKey: privateKey
+    )
+    XCTAssertNotNil(clientES384, "ES384 should be accepted")
+
+    // Test ES512
+    let clientES512 = try selfSignedClient(
+      clientId: "test-client-es512",
+      algorithm: .ES512,
+      privateKey: privateKey
+    )
+    XCTAssertNotNil(clientES512, "ES512 should be accepted")
+  }
+
+  func testClientAttestationWithInvalidAlgorithm_shouldFail() async throws {
+    // Test that RS256 (RSA) is rejected
+    // Create a JWT with RS256 algorithm in the header
+    let now = Date().timeIntervalSince1970
+    let exp = Date().addingTimeInterval(300).timeIntervalSince1970
+
+    let headerDict: [String: Any] = [
+      "alg": "RS256",
+      "typ": "oauth-client-attestation+jwt"
+    ]
+
+    let payloadDict: [String: Any] = [
+      "iss": "test-client",
+      "aud": "test-client",
+      "sub": "test-client",
+      "iat": now,
+      "exp": exp,
+      "cnf": [
+        "jwk": [
+          "kty": "RSA",
+          "n": "test",
+          "e": "AQAB"
+        ]
+      ]
+    ]
+
+    let headerData = try JSONSerialization.data(withJSONObject: headerDict)
+    let payloadData = try JSONSerialization.data(withJSONObject: payloadDict)
+
+    let headerB64 = base64URLEncode(headerData)
+    let payloadB64 = base64URLEncode(payloadData)
+    let signature = "fake-signature"
+
+    let compactJWT = "\(headerB64).\(payloadB64).\(signature)"
+    let jws = try JWS(compactSerialization: compactJWT)
+
+    // Should throw invalidAlgorithm error
+    XCTAssertThrowsError(try ClientAttestationJWT(jws: jws)) { error in
+      guard let attestationError = error as? ClientAttestationError,
+            case .invalidAlgorithm(let allowed) = attestationError else {
+        XCTFail("Expected ClientAttestationError.invalidAlgorithm, got \(error)")
+        return
+      }
+
+      // Verify the error includes all allowed algorithms
+      XCTAssertEqual(allowed.sorted(), ["ES256", "ES384", "ES512"])
+
+      // Verify error message is descriptive
+      let errorMessage = attestationError.errorDescription ?? ""
+      XCTAssertTrue(errorMessage.contains("ES256"))
+      XCTAssertTrue(errorMessage.contains("ES384"))
+      XCTAssertTrue(errorMessage.contains("ES512"))
+    }
+  }
+
+  func testClientAttestationWithHMACAlgorithm_shouldFail() async throws {
+    // Test that HS256 (HMAC) is rejected
+    let now = Date().timeIntervalSince1970
+    let exp = Date().addingTimeInterval(300).timeIntervalSince1970
+
+    let headerDict: [String: Any] = [
+      "alg": "HS256",
+      "typ": "oauth-client-attestation+jwt"
+    ]
+
+    let payloadDict: [String: Any] = [
+      "iss": "test-client",
+      "aud": "test-client",
+      "sub": "test-client",
+      "iat": now,
+      "exp": exp,
+      "cnf": [
+        "jwk": [
+          "kty": "oct",
+          "k": "test"
+        ]
+      ]
+    ]
+
+    let headerData = try JSONSerialization.data(withJSONObject: headerDict)
+    let payloadData = try JSONSerialization.data(withJSONObject: payloadDict)
+
+    let headerB64 = base64URLEncode(headerData)
+    let payloadB64 = base64URLEncode(payloadData)
+    let signature = "fake-signature"
+
+    let compactJWT = "\(headerB64).\(payloadB64).\(signature)"
+    let jws = try JWS(compactSerialization: compactJWT)
+
+    // Should throw invalidAlgorithm error
+    XCTAssertThrowsError(try ClientAttestationJWT(jws: jws)) { error in
+      guard let attestationError = error as? ClientAttestationError,
+            case .invalidAlgorithm = attestationError else {
+        XCTFail("Expected ClientAttestationError.invalidAlgorithm, got \(error)")
+        return
+      }
+    }
+  }
+
+  // Helper function for base64 URL encoding
+  private func base64URLEncode(_ data: Data) -> String {
+    var base64String = data.base64EncodedString()
+    base64String = base64String.replacingOccurrences(of: "/", with: "_")
+    base64String = base64String.replacingOccurrences(of: "+", with: "-")
+    base64String = base64String.replacingOccurrences(of: "=", with: "")
+    return base64String
+  }
 }


### PR DESCRIPTION
# Description of change

Restrict ClientAttestationJWT to only accept ECDSA algorithms (ES256, ES384, ES512) . Reject other signature algorithms (RSA, HMAC) with a descriptive error listing the allowed algorithms.

## Type of change

- [x] New feature (non-breaking change which adds functionality)


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Addresses: #227 