### PR TITLE
Add support for preferred_key_storage_status_period in key attestations

### DIFF
--- a/Sources/Entities/KeyAttestationRequirement.swift
+++ b/Sources/Entities/KeyAttestationRequirement.swift
@@ -36,15 +36,18 @@ public enum KeyAttestationRequirement: Codable, Sendable, Equatable {
   /// - Parameters:
   ///   - keyStorageConstraints: Constraints related to key storage.
   ///   - userAuthenticationConstraints: Constraints related to user authentication.
+  ///   - preferredKeyStorageStatusPeriod: Preferred remaining status maintenance period for KA in seconds.
   case required(
     keyStorageConstraints: [AttackPotentialResistance],
-    userAuthenticationConstraints: [AttackPotentialResistance]
+    userAuthenticationConstraints: [AttackPotentialResistance],
+    preferredKeyStorageStatusPeriod: Int?
   )
 
   /// Coding keys for encoding and decoding.
   private enum CodingKeys: String, CodingKey {
     case keyStorageConstraints = "key_storage"
     case userAuthenticationConstraints = "user_authentication"
+    case preferredKeyStorageStatusPeriod = "preferred_key_storage_status_period"
   }
 
   /// Initializes a `KeyAttestationRequirement` instance from a decoder.
@@ -59,9 +62,11 @@ public enum KeyAttestationRequirement: Codable, Sendable, Equatable {
       guard !keyStorageConstraints.isEmpty, !userAuthenticationConstraints.isEmpty else {
         throw KeyAttestationRequirementError.invalidConstraints
       }
+      let preferredKeyStorageStatusPeriod = try? container.decodeIfPresent(Int.self, forKey: .preferredKeyStorageStatusPeriod)
       self = .required(
         keyStorageConstraints: keyStorageConstraints,
-        userAuthenticationConstraints: userAuthenticationConstraints
+        userAuthenticationConstraints: userAuthenticationConstraints,
+        preferredKeyStorageStatusPeriod: preferredKeyStorageStatusPeriod
       )
     } else {
       self = .notRequired
@@ -78,9 +83,12 @@ public enum KeyAttestationRequirement: Codable, Sendable, Equatable {
     switch self {
     case .notRequired, .requiredNoConstraints:
       break
-    case .required(let keyStorageConstraints, let userAuthenticationConstraints):
+    case .required(let keyStorageConstraints, let userAuthenticationConstraints, let preferredKeyStorageStatusPeriod):
       try container.encode(keyStorageConstraints, forKey: .keyStorageConstraints)
       try container.encode(userAuthenticationConstraints, forKey: .userAuthenticationConstraints)
+      if let preferredKeyStorageStatusPeriod = preferredKeyStorageStatusPeriod {
+        try container.encode(preferredKeyStorageStatusPeriod, forKey: .preferredKeyStorageStatusPeriod)
+      }
     }
   }
 }
@@ -95,14 +103,16 @@ public extension KeyAttestationRequirement {
   /// - Throws: `KeyAttestationRequirementError.invalidConstraints` if constraints are empty.
   init(
     keyStorageConstraints: [AttackPotentialResistance] = [],
-    userAuthenticationConstraints: [AttackPotentialResistance] = []
+    userAuthenticationConstraints: [AttackPotentialResistance] = [],
+    preferredKeyStorageStatusPeriod: Int? = nil
   ) throws {
     guard !keyStorageConstraints.isEmpty, !userAuthenticationConstraints.isEmpty else {
       throw KeyAttestationRequirementError.invalidConstraints
     }
     self = .required(
       keyStorageConstraints: keyStorageConstraints,
-      userAuthenticationConstraints: userAuthenticationConstraints
+      userAuthenticationConstraints: userAuthenticationConstraints,
+      preferredKeyStorageStatusPeriod: preferredKeyStorageStatusPeriod
     )
   }
 
@@ -134,10 +144,13 @@ public extension KeyAttestationRequirement {
       self = .notRequired
       return
     }
-    
+
+    let preferredKeyStorageStatusPeriod = json[CodingKeys.preferredKeyStorageStatusPeriod.rawValue].int
+
     try self.init(
       keyStorageConstraints: keyStorageConstraints,
-      userAuthenticationConstraints: userAuthenticationConstraints
+      userAuthenticationConstraints: userAuthenticationConstraints,
+      preferredKeyStorageStatusPeriod: preferredKeyStorageStatusPeriod
     )
   }
 }

--- a/Tests/Helpers/KeyAttestationRequirementTests.swift
+++ b/Tests/Helpers/KeyAttestationRequirementTests.swift
@@ -42,7 +42,7 @@ final class KeyAttestationRequirementTests: XCTestCase {
       userAuthenticationConstraints: userAuthenticationConstraints
     )
     
-    if case let .required(storedConstraints, authConstraints) = requirement {
+    if case let .required(storedConstraints, authConstraints, _) = requirement {
       XCTAssertEqual(storedConstraints, keyStorageConstraints)
       XCTAssertEqual(authConstraints, userAuthenticationConstraints)
     } else {
@@ -61,7 +61,8 @@ final class KeyAttestationRequirementTests: XCTestCase {
   func testEncoding_required() throws {
     let requirement = KeyAttestationRequirement.required(
       keyStorageConstraints: [.iso18045Basic],
-      userAuthenticationConstraints: [.iso18045EnhancedBasic]
+      userAuthenticationConstraints: [.iso18045EnhancedBasic],
+      preferredKeyStorageStatusPeriod: nil
     )
     
     let encoder = JSONEncoder()
@@ -84,7 +85,7 @@ final class KeyAttestationRequirementTests: XCTestCase {
     let decoder = JSONDecoder()
     let requirement = try decoder.decode(KeyAttestationRequirement.self, from: jsonData)
     
-    if case let .required(storedConstraints, authConstraints) = requirement {
+    if case let .required(storedConstraints, authConstraints, _) = requirement {
       XCTAssertEqual(storedConstraints, [.iso18045High])
       XCTAssertEqual(authConstraints, [.iso18045EnhancedBasic])
     } else {
@@ -127,7 +128,7 @@ final class KeyAttestationRequirementTests: XCTestCase {
     
     let requirement = try KeyAttestationRequirement(json: json)
     
-    if case let .required(storedConstraints, authConstraints) = requirement {
+    if case let .required(storedConstraints, authConstraints, _) = requirement {
       XCTAssertEqual(storedConstraints, [.iso18045Basic])
       XCTAssertEqual(authConstraints, [.iso18045High])
     } else {
@@ -146,8 +147,172 @@ final class KeyAttestationRequirementTests: XCTestCase {
       "key_storage": [],
       "user_authentication": []
     ]
-    
+
     let requirement = try KeyAttestationRequirement(json: json)
     XCTAssertEqual(requirement, .notRequired)
+  }
+
+  // MARK: - Preferred Key Storage Status Period Tests
+
+  func testDecoding_withPreferredKeyStorageStatusPeriod() throws {
+    let jsonData = """
+        {
+            "key_storage": ["iso_18045_high"],
+            "user_authentication": ["iso_18045_enhanced-basic"],
+            "preferred_key_storage_status_period": 86400
+        }
+        """.data(using: .utf8)!
+
+    let decoder = JSONDecoder()
+    let requirement = try decoder.decode(KeyAttestationRequirement.self, from: jsonData)
+
+    if case let .required(storedConstraints, authConstraints, preferredPeriod) = requirement {
+      XCTAssertEqual(storedConstraints, [.iso18045High])
+      XCTAssertEqual(authConstraints, [.iso18045EnhancedBasic])
+      XCTAssertEqual(preferredPeriod, 86400)
+    } else {
+      XCTFail("Expected .required case")
+    }
+  }
+
+  func testDecoding_withoutPreferredKeyStorageStatusPeriod() throws {
+    let jsonData = """
+        {
+            "key_storage": ["iso_18045_high"],
+            "user_authentication": ["iso_18045_enhanced-basic"]
+        }
+        """.data(using: .utf8)!
+
+    let decoder = JSONDecoder()
+    let requirement = try decoder.decode(KeyAttestationRequirement.self, from: jsonData)
+
+    if case let .required(_, _, preferredPeriod) = requirement {
+      XCTAssertNil(preferredPeriod)
+    } else {
+      XCTFail("Expected .required case")
+    }
+  }
+
+  func testEncoding_withPreferredKeyStorageStatusPeriod() throws {
+    let requirement = KeyAttestationRequirement.required(
+      keyStorageConstraints: [.iso18045Basic],
+      userAuthenticationConstraints: [.iso18045EnhancedBasic],
+      preferredKeyStorageStatusPeriod: 3600
+    )
+
+    let encoder = JSONEncoder()
+    let data = try encoder.encode(requirement)
+    let jsonString = String(data: data, encoding: .utf8)
+
+    XCTAssertNotNil(jsonString)
+    XCTAssertTrue(jsonString!.contains("\"preferred_key_storage_status_period\":3600"))
+  }
+
+  func testInitFromJSON_withPreferredKeyStorageStatusPeriod() throws {
+    let json: JSON = [
+      "key_storage": [
+        "iso_18045_basic"
+      ],
+      "user_authentication": [
+        "iso_18045_high"
+      ],
+      "preferred_key_storage_status_period": 7200
+    ]
+
+    let requirement = try KeyAttestationRequirement(json: json)
+
+    if case let .required(storedConstraints, authConstraints, preferredPeriod) = requirement {
+      XCTAssertEqual(storedConstraints, [.iso18045Basic])
+      XCTAssertEqual(authConstraints, [.iso18045High])
+      XCTAssertEqual(preferredPeriod, 7200)
+    } else {
+      XCTFail("Expected .required case")
+    }
+  }
+
+  func testInit_withPreferredKeyStorageStatusPeriod() throws {
+    let requirement = try KeyAttestationRequirement(
+      keyStorageConstraints: [.iso18045High],
+      userAuthenticationConstraints: [.iso18045Moderate],
+      preferredKeyStorageStatusPeriod: 43200
+    )
+
+    if case let .required(_, _, preferredPeriod) = requirement {
+      XCTAssertEqual(preferredPeriod, 43200)
+    } else {
+      XCTFail("Expected .required case")
+    }
+  }
+
+  // MARK: - ProofTypeSupportedMeta Integration Tests
+
+  func testProofTypeSupportedMeta_withPreferredKeyStorageStatusPeriod() throws {
+    let jsonData = """
+        {
+            "proof_signing_alg_values_supported": ["ES256", "ES384"],
+            "key_attestations_required": {
+                "key_storage": ["iso_18045_high"],
+                "user_authentication": ["iso_18045_moderate"],
+                "preferred_key_storage_status_period": 172800
+            }
+        }
+        """.data(using: .utf8)!
+
+    let decoder = JSONDecoder()
+    let proofTypeMeta = try decoder.decode(ProofTypeSupportedMeta.self, from: jsonData)
+
+    XCTAssertEqual(proofTypeMeta.algorithms, ["ES256", "ES384"])
+    XCTAssertNotNil(proofTypeMeta.keyAttestationRequirement)
+
+    if case let .required(_, _, preferredPeriod) = proofTypeMeta.keyAttestationRequirement {
+      XCTAssertEqual(preferredPeriod, 172800)
+    } else {
+      XCTFail("Expected .required case with preferredKeyStorageStatusPeriod")
+    }
+  }
+
+  func testProofTypesSupported_bothJwtAndAttestation() throws {
+    // Test that both jwt and attestation proof types support preferred_key_storage_status_period
+    let jsonData = """
+        {
+            "jwt": {
+                "proof_signing_alg_values_supported": ["ES256"],
+                "key_attestations_required": {
+                    "key_storage": ["iso_18045_high"],
+                    "user_authentication": ["iso_18045_moderate"],
+                    "preferred_key_storage_status_period": 86400
+                }
+            },
+            "attestation": {
+                "proof_signing_alg_values_supported": ["ES256"],
+                "key_attestations_required": {
+                    "key_storage": ["iso_18045_enhanced-basic"],
+                    "user_authentication": ["iso_18045_high"],
+                    "preferred_key_storage_status_period": 172800
+                }
+            }
+        }
+        """.data(using: .utf8)!
+
+    let decoder = JSONDecoder()
+    let proofTypesSupported = try decoder.decode([String: ProofTypeSupportedMeta].self, from: jsonData)
+
+    // Verify jwt proof type
+    XCTAssertNotNil(proofTypesSupported["jwt"])
+    if let jwtProofType = proofTypesSupported["jwt"],
+       case let .required(_, _, jwtPreferredPeriod) = jwtProofType.keyAttestationRequirement {
+      XCTAssertEqual(jwtPreferredPeriod, 86400)
+    } else {
+      XCTFail("Expected jwt proof type with preferred_key_storage_status_period")
+    }
+
+    // Verify attestation proof type
+    XCTAssertNotNil(proofTypesSupported["attestation"])
+    if let attestationProofType = proofTypesSupported["attestation"],
+       case let .required(_, _, attestationPreferredPeriod) = attestationProofType.keyAttestationRequirement {
+      XCTAssertEqual(attestationPreferredPeriod, 172800)
+    } else {
+      XCTFail("Expected attestation proof type with preferred_key_storage_status_period")
+    }
   }
 }


### PR DESCRIPTION
# Description of change

Implement parsing for the preferred_key_storage_status_period attribute within key_attestations_required object as defined in TS3 v1.5. This optional integer field indicates the issuer's preference for the remaining key attestation status maintenance
period in seconds

 Changes:
  - Add preferredKeyStorageStatusPeriod to KeyAttestationRequirement.required case
  - Update encoders/decoders to handle the new field
  - Add comprehensive test coverage for parsing and encoding

## Type of change

- [x] New feature (non-breaking change which adds functionality)


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes