### PR TITLE
Add support for refreshing access tokens 

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,27 @@ switch requestOutcome {
 
 You can also check the unit test target for more usage examples.
 
+### Refresh Access Token
+
+A Wallet/Caller can refresh the `AccessToken` of an `AuthorizedRequest` using a `refresh_token` grant.
+
+Prerequisites:
+1. Authorization Server supports `refresh_token` grant
+2. `AuthorizedRequest` contains a `RefreshToken`
+
+Library will perform a `refresh_token` grant, and return the updated `AuthorizedRequest`:
+
+```swift
+import OpenID4VCI
+
+let authorizedRequest: AuthorizedRequest = ... // has been retrieved in a previous step
+let issuer: Issuer = ...
+
+let updatedAuthorizedRequest = try await issuer.refresh(
+    authorizedRequest: authorizedRequest
+)
+```
+
 ## Configuration options
 
 ```swift

--- a/Sources/Issuers/Issuer.swift
+++ b/Sources/Issuers/Issuer.swift
@@ -17,7 +17,7 @@ import Foundation
 import JOSESwift
 
 /// A protocol defining the operations required for an issuer in the credential issuance process.
-public protocol IssuerType: Sendable {
+public protocol IssuerType: RefreshAccessToken {
   
   /// Initiates an authorization request using a credential offer.
   ///
@@ -819,7 +819,7 @@ public extension Issuer {
     dPopNonce: Nonce? = nil
   ) async throws -> AuthorizedRequest {
     if let refreshToken = authorizedRequest.refreshToken {
-        let (accessToken, refreshToken, _, _, timeStamp, _) = try await authorizer.refreshAccessToken(
+        let (accessToken, newRefreshToken, _, _, timeStamp, _) = try await authorizer.refreshAccessToken(
           clientId: clientId,
           refreshToken: refreshToken,
           dpopNonce: dPopNonce,
@@ -827,6 +827,7 @@ public extension Issuer {
         )
         return authorizedRequest.replacing(
             accessToken: accessToken,
+            refreshToken: newRefreshToken,
             timeStamp: timeStamp?.asTimeInterval ?? .zero
           )
     }
@@ -853,6 +854,24 @@ public extension Issuer {
           )
     }
     return authorizedRequest
+  }
+
+  /// Refreshes the access token using the issuer's configured client.
+  /// - Parameters:
+  ///   - authorizedRequest: The authorized request containing the tokens to refresh.
+  ///   - dPopNonce: An optional nonce for DPoP (Demonstrating Proof-of-Possession).
+  /// - Returns: A new `AuthorizedRequest` with refreshed tokens if successful,
+  ///            or the original request if refresh is not possible.
+  /// - Throws: An error if the token refresh request fails.
+  func refresh(
+    authorizedRequest: AuthorizedRequest,
+    dPopNonce: Nonce?
+  ) async throws -> AuthorizedRequest {
+    try await refresh(
+      client: config.client,
+      authorizedRequest: authorizedRequest,
+      dPopNonce: dPopNonce
+    )
   }
 }
 

--- a/Sources/Issuers/RefreshAccessToken.swift
+++ b/Sources/Issuers/RefreshAccessToken.swift
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Foundation
+
+/// A protocol that defines the capability to refresh an access token.
+///
+public protocol RefreshAccessToken: Sendable {
+
+  /// Refreshes the access token in an authorized request.
+  ///
+  /// This method attempts to refresh the access token using the refresh token
+  /// present in the provided `AuthorizedRequest`. If the request does not contain
+  /// a refresh token, or if the refresh token has expired, the original request
+  /// is returned unchanged.
+  ///
+  /// The client credentials are obtained from the issuer's configuration, so they
+  /// do not need to be provided separately.
+  ///
+  /// - Parameters:
+  ///   - authorizedRequest: The authorized request containing the tokens to refresh.
+  ///   - dPopNonce: An optional nonce for DPoP (Demonstrating Proof-of-Possession).
+  /// - Returns: A new `AuthorizedRequest` with refreshed tokens if successful,
+  ///            or the original request if refresh is not possible.
+  /// - Throws: An error if the token refresh request fails.
+  func refresh(
+    authorizedRequest: AuthorizedRequest,
+    dPopNonce: Nonce?
+  ) async throws -> AuthorizedRequest
+}
+
+public extension RefreshAccessToken {
+
+  /// Refreshes the access token in an authorized request with default DPoP nonce.
+  ///
+  /// This convenience method calls the main refresh method with a nil DPoP nonce.
+  ///
+  /// - Parameter authorizedRequest: The authorized request containing the tokens to refresh.
+  /// - Returns: A new `AuthorizedRequest` with refreshed tokens if successful,
+  ///            or the original request if refresh is not possible.
+  /// - Throws: An error if the token refresh request fails.
+  func refresh(
+    authorizedRequest: AuthorizedRequest
+  ) async throws -> AuthorizedRequest {
+    try await refresh(authorizedRequest: authorizedRequest, dPopNonce: nil)
+  }
+}

--- a/Tests/Issuance/IssuanceRefreshTokenTest.swift
+++ b/Tests/Issuance/IssuanceRefreshTokenTest.swift
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Foundation
+import XCTest
+
+@testable import OpenID4VCI
+
+class IssuanceRefreshTokenTest: XCTestCase {
+
+  let config: OpenId4VCIConfig = .init(
+    client: .public(id: WALLET_DEV_CLIENT_ID),
+    authFlowRedirectionURI: URL(string: "urn:ietf:wg:oauth:2.0:oob")!,
+    authorizeIssuanceConfig: .favorScopes
+  )
+
+  func testManualRefreshAccessTokenSuccess() async throws {
+
+    // Given
+    guard let offer = await TestsConstants.createMockCredentialOffer() else {
+      XCTFail("Unable to resolve credential offer")
+      return
+    }
+
+    // Create mock authorized request with refresh token
+    let originalAccessToken = try IssuanceAccessToken(
+      accessToken: "original_access_token",
+      tokenType: .init(value: "Bearer")
+    )
+    let refreshToken = try IssuanceRefreshToken(
+      refreshToken: "refresh_token_value",
+      expiresIn: 3600
+    )
+    let originalRequest = AuthorizedRequest(
+      accessToken: originalAccessToken,
+      refreshToken: refreshToken,
+      credentialIdentifiers: nil,
+      timeStamp: Date().timeIntervalSince1970,
+      dPopNonce: nil,
+      grantType: .authorizationCode
+    )
+
+    // Create issuer with mock token endpoint
+    let issuer = try Issuer(
+      authorizationServerMetadata: offer.authorizationServerMetadata,
+      issuerMetadata: offer.credentialIssuerMetadata,
+      config: config,
+      tokenPoster: Poster(
+        session: NetworkingMock(
+          path: "access_token_request_response",
+          extension: "json"
+        )
+      )
+    )
+
+    // When - using the new simplified refresh method
+    do {
+      let refreshedRequest = try await issuer.refresh(
+        authorizedRequest: originalRequest
+      )
+
+      // Then
+      XCTAssertNotNil(refreshedRequest.accessToken)
+      XCTAssertNotEqual(
+        refreshedRequest.accessToken.accessToken,
+        originalRequest.accessToken.accessToken,
+        "Access token should be refreshed"
+      )
+      XCTAssertNotEqual(
+        refreshedRequest.timeStamp,
+        originalRequest.timeStamp,
+        "Timestamp should be updated"
+      )
+    } catch {
+      XCTFail("Token refresh failed: \(error.localizedDescription)")
+    }
+  }
+
+  func testManualRefreshWithoutRefreshTokenReturnsOriginal() async throws {
+
+    // Given
+    guard let offer = await TestsConstants.createMockCredentialOffer() else {
+      XCTFail("Unable to resolve credential offer")
+      return
+    }
+
+    // Create authorized request WITHOUT refresh token
+    let originalAccessToken = try IssuanceAccessToken(
+      accessToken: "original_access_token",
+      tokenType: .init(value: "Bearer")
+    )
+    let originalRequest = AuthorizedRequest(
+      accessToken: originalAccessToken,
+      refreshToken: nil,  // No refresh token
+      credentialIdentifiers: nil,
+      timeStamp: Date().timeIntervalSince1970,
+      dPopNonce: nil,
+      grantType: .authorizationCode
+    )
+
+    let issuer = try Issuer(
+      authorizationServerMetadata: offer.authorizationServerMetadata,
+      issuerMetadata: offer.credentialIssuerMetadata,
+      config: config
+    )
+
+    // When
+    let refreshedRequest = try await issuer.refresh(
+      authorizedRequest: originalRequest
+    )
+
+    // Then - should return original request unchanged
+    XCTAssertEqual(
+      refreshedRequest.accessToken.accessToken,
+      originalRequest.accessToken.accessToken,
+      "Access token should remain unchanged when no refresh token is present"
+    )
+    XCTAssertEqual(
+      refreshedRequest.timeStamp,
+      originalRequest.timeStamp,
+      "Timestamp should remain unchanged when no refresh token is present"
+    )
+  }
+
+  func testManualRefreshWithDPoPNonce() async throws {
+
+    // Given
+    guard let offer = await TestsConstants.createMockCredentialOffer() else {
+      XCTFail("Unable to resolve credential offer")
+      return
+    }
+
+    let originalAccessToken = try IssuanceAccessToken(
+      accessToken: "original_access_token",
+      tokenType: .init(value: "Bearer")
+    )
+    let refreshToken = try IssuanceRefreshToken(
+      refreshToken: "refresh_token_value",
+      expiresIn: 3600
+    )
+    let originalRequest = AuthorizedRequest(
+      accessToken: originalAccessToken,
+      refreshToken: refreshToken,
+      credentialIdentifiers: nil,
+      timeStamp: Date().timeIntervalSince1970,
+      dPopNonce: nil,
+      grantType: .authorizationCode
+    )
+
+    let issuer = try Issuer(
+      authorizationServerMetadata: offer.authorizationServerMetadata,
+      issuerMetadata: offer.credentialIssuerMetadata,
+      config: config,
+      tokenPoster: Poster(
+        session: NetworkingMock(
+          path: "access_token_request_response",
+          extension: "json"
+        )
+      )
+    )
+
+    let dpopNonce = Nonce(value: "test_dpop_nonce")
+
+    // When - using refresh with explicit DPoP nonce
+    do {
+      let refreshedRequest = try await issuer.refresh(
+        authorizedRequest: originalRequest,
+        dPopNonce: dpopNonce
+      )
+
+      // Then
+      XCTAssertNotNil(refreshedRequest.accessToken)
+      // The refresh should succeed even with a DPoP nonce parameter
+    } catch {
+      XCTFail("Token refresh with DPoP nonce failed: \(error.localizedDescription)")
+    }
+  }
+}


### PR DESCRIPTION
# Description of change

Expose a public API to allow wallets to refresh an access token using a refresh token present in an authorized request. This change introduces the `RefreshAccessToken` protocol, implements the refresh logic in the `Issuer` class, and ensures that both the access token and the new refresh token are correctly updated in the returned request.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes