### PR TITLE
Add an option for a Wallet to configure supported Proof types

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ In particular, the library focuses on the wallet's role in the protocol to:
 | `attestation` proof type                                                                        | ✅                                                                                                                  |
 | `key_attestation` to the JWT Proof (JOSE header)                                                | ✅                                                                                                                  |
 | Wallet attestation                                                                              | ✅                                                                                                                  |
+| Proof Types Policy                                   | ✅                                                                                                                  |
 
 
 ## Disclaimer
@@ -288,6 +289,7 @@ public struct OpenId4VCIConfig: Sendable {
   public let dPoPConstructor: DPoPConstructorType?
   public let clientAttestationPoPBuilder: ClientAttestationPoPBuilder?
   public let issuerMetadataPolicy: IssuerMetadataPolicy
+  public let proofTypesPolicy: ProofTypesPolicy
 }
 ```
 
@@ -301,6 +303,27 @@ public struct OpenId4VCIConfig: Sendable {
 - `dPoPConstructor`: If dpop is supported this option constructs what is required.
 - `clientAttestationPoPBuilder`: If the authorization supports client attestations, this object constructs what is required.
 - `issuerMetadataPolicy`: Trust between the Wallet and the Signer of the signed metadata advertised by the Credential Issuer is established using this configuration option.
+- `proofTypesPolicy`: Policy defining which proof types the wallet supports. See [Proof Types Policy Configuration](#proof-types-policy-configuration) for details.
+
+### Proof Types Policy Configuration
+
+The library supports configuring which proof types your wallet will accept for credential issuance.
+
+#### Policy Options
+
+**1. Accept All (Default - Backward Compatible)**
+Accepts any proof type including simple JWT proofs without key attestation. Use for testing or legacy compatibility.
+
+**2. Device Bound (HAIP Compliant - Recommended for Production)**
+Enforces HAIP v1 / ETSI TS 119 472-3 compliance:
+- Accepts JWT proofs WITH key attestation
+- Accepts attestation proofs
+- Rejects simple JWT proofs without key attestation
+- Ensures device-bound credentials are properly secured with hardware-backed keys
+
+**3. Flexible Policy**
+Allows custom configuration supporting both device-bound and non-device-bound credentials.
+
 
 ## Features supported
 
@@ -369,10 +392,6 @@ can be requested using `authorization_details` or `scope` parameter when using a
 Though for `authorization_details` we don't support the `format` attribute and its specializations per format.
 Only `credential_configuration_id` attribute is supported.
 
-### Key attestations
-
-Current version of the library does not support [key attestations](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-15.html#appendix-D) 
-neither as a [proof type](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-15.html#section-8.2.1.3) nor as a `key_attestation` header in JWT proofs.
 
 ## How to contribute
 

--- a/README.md
+++ b/README.md
@@ -256,6 +256,27 @@ switch requestOutcome {
 
 You can also check the unit test target for more usage examples.
 
+### Refresh Access Token
+
+A Wallet/Caller can refresh the `AccessToken` of an `AuthorizedRequest` using a `refresh_token` grant.
+
+Prerequisites:
+1. Authorization Server supports `refresh_token` grant
+2. `AuthorizedRequest` contains a `RefreshToken`
+
+Library will perform a `refresh_token` grant, and return the updated `AuthorizedRequest`:
+
+```swift
+import OpenID4VCI
+
+let authorizedRequest: AuthorizedRequest = ... // has been retrieved in a previous step
+let issuer: Issuer = ...
+
+let updatedAuthorizedRequest = try await issuer.refresh(
+    authorizedRequest: authorizedRequest
+)
+```
+
 ## Configuration options
 
 ```swift

--- a/Sources/Entities/CredentialIssuer/CredentialIssuerMetadata.swift
+++ b/Sources/Entities/CredentialIssuer/CredentialIssuerMetadata.swift
@@ -30,6 +30,7 @@ public struct CredentialIssuerMetadata: Decodable, Equatable, Sendable {
   public let credentialIdentifiersSupported: Bool?
   public let display: [Display]
   public let batchCredentialIssuance: BatchCredentialIssuance?
+  public let preferredClientStatusPeriod: Int?
   
   public enum CodingKeys: String, CodingKey {
     case credentialIssuerIdentifier = "credential_issuer"
@@ -47,6 +48,7 @@ public struct CredentialIssuerMetadata: Decodable, Equatable, Sendable {
     case credentialRequestEncryption = "credential_request_encryption"
     case credentialIdentifiersSupported = "credential_identifiers_supported"
     case batchCredentialIssuance = "batch_credential_issuance"
+    case preferredClientStatusPeriod = "preferred_client_status_period"
   }
   
   public init(
@@ -61,7 +63,8 @@ public struct CredentialIssuerMetadata: Decodable, Equatable, Sendable {
     credentialConfigurationsSupported: [CredentialConfigurationIdentifier: CredentialSupported],
     display: [Display]?,
     credentialIdentifiersSupported: Bool? = nil,
-    batchCredentialIssuance: BatchCredentialIssuance? = nil
+    batchCredentialIssuance: BatchCredentialIssuance? = nil,
+    preferredClientStatusPeriod: Int? = nil
   ) {
     self.credentialIssuerIdentifier = credentialIssuerIdentifier
     self.authorizationServers = authorizationServers
@@ -79,6 +82,7 @@ public struct CredentialIssuerMetadata: Decodable, Equatable, Sendable {
     
     self.credentialIdentifiersSupported = credentialIdentifiersSupported
     self.batchCredentialIssuance = batchCredentialIssuance
+    self.preferredClientStatusPeriod = preferredClientStatusPeriod
   }
   
   public init(deferredCredentialEndpoint: CredentialIssuerEndpoint?) throws {
@@ -191,6 +195,11 @@ public struct CredentialIssuerMetadata: Decodable, Equatable, Sendable {
     batchCredentialIssuance = try? container.decodeIfPresent(
       BatchCredentialIssuance.self,
       forKey: .batchCredentialIssuance
+    )
+
+    preferredClientStatusPeriod = try? container.decodeIfPresent(
+      Int.self,
+      forKey: .preferredClientStatusPeriod
     )
   }
   

--- a/Sources/Entities/Errors/CredentialIssuanceError.swift
+++ b/Sources/Entities/Errors/CredentialIssuanceError.swift
@@ -48,6 +48,12 @@ public enum CredentialIssuanceError: Error, LocalizedError {
   case proofTypeKeyAttestationRequired
   case combinationOfBindingKeys
   
+  case proofTypesNotSupportedByCredentialConfiguration
+  case proofTypeNotSupportedByWalletPolicy
+  case proofTypeJwtWithoutKeyAttestationNotAllowedByPolicy
+  case bindingKeyNotAttestationCapable
+  case noMatchingAlgorithmForProofType
+  
   public var errorDescription: String? {
     switch self {
     case .pushedAuthorizationRequestFailed(_, let errorDescription),
@@ -109,6 +115,16 @@ public enum CredentialIssuanceError: Error, LocalizedError {
       return "Proof type key attestation required."
     case .combinationOfBindingKeys:
       return "Combination of binding keys"
+    case .proofTypesNotSupportedByCredentialConfiguration:
+      return "Credential configuration does not support proof types required by wallet policy."
+    case .proofTypeNotSupportedByWalletPolicy:
+      return "The credential configuration requires a proof type that is not supported by the wallet's policy."
+    case .proofTypeJwtWithoutKeyAttestationNotAllowedByPolicy:
+      return "The credential configuration requires JWT proof without key attestation, which is not allowed by the wallet's policy."
+    case .bindingKeyNotAttestationCapable:
+      return "The binding key is not attestation-capable but the credential configuration or wallet policy requires key attestation."
+    case .noMatchingAlgorithmForProofType:
+      return "No matching cryptographic algorithm found between wallet policy and credential configuration for the required proof type."
     }
   }
 }

--- a/Sources/Entities/KeyAttestationRequirement.swift
+++ b/Sources/Entities/KeyAttestationRequirement.swift
@@ -36,15 +36,18 @@ public enum KeyAttestationRequirement: Codable, Sendable, Equatable {
   /// - Parameters:
   ///   - keyStorageConstraints: Constraints related to key storage.
   ///   - userAuthenticationConstraints: Constraints related to user authentication.
+  ///   - preferredKeyStorageStatusPeriod: Preferred remaining status maintenance period for KA in seconds.
   case required(
     keyStorageConstraints: [AttackPotentialResistance],
-    userAuthenticationConstraints: [AttackPotentialResistance]
+    userAuthenticationConstraints: [AttackPotentialResistance],
+    preferredKeyStorageStatusPeriod: Int?
   )
 
   /// Coding keys for encoding and decoding.
   private enum CodingKeys: String, CodingKey {
     case keyStorageConstraints = "key_storage"
     case userAuthenticationConstraints = "user_authentication"
+    case preferredKeyStorageStatusPeriod = "preferred_key_storage_status_period"
   }
 
   /// Initializes a `KeyAttestationRequirement` instance from a decoder.
@@ -59,9 +62,11 @@ public enum KeyAttestationRequirement: Codable, Sendable, Equatable {
       guard !keyStorageConstraints.isEmpty, !userAuthenticationConstraints.isEmpty else {
         throw KeyAttestationRequirementError.invalidConstraints
       }
+      let preferredKeyStorageStatusPeriod = try? container.decodeIfPresent(Int.self, forKey: .preferredKeyStorageStatusPeriod)
       self = .required(
         keyStorageConstraints: keyStorageConstraints,
-        userAuthenticationConstraints: userAuthenticationConstraints
+        userAuthenticationConstraints: userAuthenticationConstraints,
+        preferredKeyStorageStatusPeriod: preferredKeyStorageStatusPeriod
       )
     } else {
       self = .notRequired
@@ -78,9 +83,12 @@ public enum KeyAttestationRequirement: Codable, Sendable, Equatable {
     switch self {
     case .notRequired, .requiredNoConstraints:
       break
-    case .required(let keyStorageConstraints, let userAuthenticationConstraints):
+    case .required(let keyStorageConstraints, let userAuthenticationConstraints, let preferredKeyStorageStatusPeriod):
       try container.encode(keyStorageConstraints, forKey: .keyStorageConstraints)
       try container.encode(userAuthenticationConstraints, forKey: .userAuthenticationConstraints)
+      if let preferredKeyStorageStatusPeriod = preferredKeyStorageStatusPeriod {
+        try container.encode(preferredKeyStorageStatusPeriod, forKey: .preferredKeyStorageStatusPeriod)
+      }
     }
   }
 }
@@ -95,14 +103,16 @@ public extension KeyAttestationRequirement {
   /// - Throws: `KeyAttestationRequirementError.invalidConstraints` if constraints are empty.
   init(
     keyStorageConstraints: [AttackPotentialResistance] = [],
-    userAuthenticationConstraints: [AttackPotentialResistance] = []
+    userAuthenticationConstraints: [AttackPotentialResistance] = [],
+    preferredKeyStorageStatusPeriod: Int? = nil
   ) throws {
     guard !keyStorageConstraints.isEmpty, !userAuthenticationConstraints.isEmpty else {
       throw KeyAttestationRequirementError.invalidConstraints
     }
     self = .required(
       keyStorageConstraints: keyStorageConstraints,
-      userAuthenticationConstraints: userAuthenticationConstraints
+      userAuthenticationConstraints: userAuthenticationConstraints,
+      preferredKeyStorageStatusPeriod: preferredKeyStorageStatusPeriod
     )
   }
 
@@ -134,10 +144,13 @@ public extension KeyAttestationRequirement {
       self = .notRequired
       return
     }
-    
+
+    let preferredKeyStorageStatusPeriod = json[CodingKeys.preferredKeyStorageStatusPeriod.rawValue].int
+
     try self.init(
       keyStorageConstraints: keyStorageConstraints,
-      userAuthenticationConstraints: userAuthenticationConstraints
+      userAuthenticationConstraints: userAuthenticationConstraints,
+      preferredKeyStorageStatusPeriod: preferredKeyStorageStatusPeriod
     )
   }
 }

--- a/Sources/Entities/Wallet/Config.swift
+++ b/Sources/Entities/Wallet/Config.swift
@@ -56,6 +56,13 @@ public struct OpenId4VCIConfig: Sendable {
   /// Dpop requirement, if required by wallet and not supported by issuer, halt the issuance process
   public let requireDpop: Bool
   
+  /// Policy defining which proof types the wallet supports.
+  /// Wallets should reject credentials that require plain JWT proofs without key attestation
+  /// for device-bound attestations.
+  ///
+  /// Default is `.acceptAll` for backward compatibility.
+  public let proofTypesPolicy: ProofTypesPolicy
+  
   /// Initializes an `OpenId4VCIConfig` instance with the given parameters.
   /// - Parameters:
   ///   - client: The client used for OpenID4VCI operations.
@@ -65,6 +72,7 @@ public struct OpenId4VCIConfig: Sendable {
   ///   - clientAttestationPoPBuilder: An optional client attestation PoP builder (default: `nil`).
   ///   - issuerMetadataPolicy: Policy defining how issuer metadata should be handled (default: `.ignoreSigned`).
   ///   - requireDpop: If dpop is supported then use it, otherwise always don't
+  ///   - proofTypesPolicy: Policy defining which proof types the wallet supports (default: `.acceptAll`).
   public init(
     client: Client,
     authFlowRedirectionURI: URL,
@@ -73,7 +81,8 @@ public struct OpenId4VCIConfig: Sendable {
     clientAttestationPoPBuilder: ClientAttestationPoPBuilder? = nil,
     issuerMetadataPolicy: IssuerMetadataPolicy = .ignoreSigned,
     supportedCompressionAlgorithms: [CompressionAlgorithm]? = nil,
-    requireDpop: Bool = true
+    requireDpop: Bool = true,
+    proofTypesPolicy: ProofTypesPolicy = .acceptAll
   ) {
     self.client = client
     self.authFlowRedirectionURI = authFlowRedirectionURI
@@ -83,5 +92,6 @@ public struct OpenId4VCIConfig: Sendable {
     self.issuerMetadataPolicy = issuerMetadataPolicy
     self.supportedCompressionAlgorithms = supportedCompressionAlgorithms
     self.requireDpop = requireDpop
+    self.proofTypesPolicy = proofTypesPolicy
   }
 }

--- a/Sources/Entities/Wallet/ProofTypesPolicy.swift
+++ b/Sources/Entities/Wallet/ProofTypesPolicy.swift
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Foundation
+import JOSESwift
+
+/// Policy defining which proof types the wallet supports for credential issuance.
+///
+/// For device-bound attestations, proofs of type JWT cannot be used alone
+/// - Wallet must use either:
+///   - Proof of type `attestation`
+///   - Proof of type `jwt` + `key_attestation`
+/// - Plain JWT proofs (without key_attestation) are not allowed for device-bound credentials
+public enum ProofTypesPolicy: Sendable {
+  /// Default policy: accepts any proof type including plain JWT without key attestation.
+  /// This is the legacy behavior for backward compatibility.
+  case acceptAll
+
+  /// Rejects credential configurations that require plain JWT proofs without key attestation.
+  /// - Parameter policy: The device-bound proof policy specifying supported algorithms and proof types.
+  case deviceBound(DeviceBoundProofPolicy)
+
+  /// Flexible policy: supports both device-bound and non-device-bound attestations.
+  /// - Parameters:
+  ///   - deviceBound: Policy for device-bound credentials
+  ///   - allowNonDeviceBound: Whether to allow non-device-bound credentials (no proofs required)
+  case flexible(deviceBound: DeviceBoundProofPolicy, allowNonDeviceBound: Bool)
+}
+
+/// Policy configuration for device-bound proof types.
+public struct DeviceBoundProofPolicy: Sendable {
+  public let supportedAlgorithms: [JWSAlgorithm]
+  public let supportedProofTypes: Set<DeviceBoundProofType>
+
+  public init(
+    supportedAlgorithms: [JWSAlgorithm],
+    supportedProofTypes: Set<DeviceBoundProofType>
+  ) {
+    self.supportedAlgorithms = supportedAlgorithms
+    self.supportedProofTypes = supportedProofTypes
+  }
+
+  /// Creates a HAIP compliant policy.
+  /// This policy only accepts JWT with key attestation or attestation proofs.
+  /// - Parameter algorithms: Supported signing algorithms. Defaults to ES256.
+  /// - Returns: A compliant device-bound proof policy.
+  public static func haipCompliant(
+    algorithms: [JWSAlgorithm] = [JWSAlgorithm(.ES256)]
+  ) -> DeviceBoundProofPolicy {
+    return DeviceBoundProofPolicy(
+      supportedAlgorithms: algorithms,
+      supportedProofTypes: [.jwtWithKeyAttestation, .attestation]
+    )
+  }
+}
+
+/// Types of proofs for device-bound credentials.
+public enum DeviceBoundProofType: String, Hashable, Sendable {
+  
+  case jwtWithoutKeyAttestation = "jwt_without_key_attestation"
+  case jwtWithKeyAttestation = "jwt_with_key_attestation"
+  case attestation = "attestation"
+}
+
+// MARK: - Validation
+
+public extension ProofTypesPolicy {
+
+  /// Validates whether a credential configuration is compatible with this policy.
+  ///
+  /// - Parameters:
+  ///   - credentialConfiguration: The credential configuration to validate.
+  ///   - bindingKey: The binding key that will be used for the proof.
+  /// - Throws: `CredentialIssuanceError` if the configuration violates the policy.
+  func validate(
+    credentialConfiguration: CredentialSupported,
+    bindingKey: BindingKey
+  ) throws {
+    switch self {
+    case .acceptAll:
+      // Accept everything - no validation needed
+      return
+
+    case .deviceBound(let policy):
+      try validateDeviceBound(
+        credentialConfiguration: credentialConfiguration,
+        policy: policy,
+        bindingKey: bindingKey,
+        allowNonDeviceBound: false
+      )
+
+    case .flexible(let policy, let allowNonDeviceBound):
+      try validateDeviceBound(
+        credentialConfiguration: credentialConfiguration,
+        policy: policy,
+        bindingKey: bindingKey,
+        allowNonDeviceBound: allowNonDeviceBound
+      )
+    }
+  }
+
+  private func validateDeviceBound(
+    credentialConfiguration: CredentialSupported,
+    policy: DeviceBoundProofPolicy,
+    bindingKey: BindingKey,
+    allowNonDeviceBound: Bool
+  ) throws {
+    guard let proofTypesSupported = credentialConfiguration.proofTypesSupported else {
+      if allowNonDeviceBound {
+        return
+      } else {
+        throw CredentialIssuanceError.proofTypesNotSupportedByCredentialConfiguration
+      }
+    }
+
+    if let jwtProofMeta = proofTypesSupported["jwt"] {
+      try validateJwtProof(
+        jwtProofMeta: jwtProofMeta,
+        policy: policy,
+        bindingKey: bindingKey
+      )
+    }
+
+    if let attestationProofMeta = proofTypesSupported["attestation"] {
+      try validateAttestationProof(
+        attestationProofMeta: attestationProofMeta,
+        policy: policy,
+        bindingKey: bindingKey
+      )
+    }
+  }
+
+  private func validateJwtProof(
+    jwtProofMeta: ProofTypeSupportedMeta,
+    policy: DeviceBoundProofPolicy,
+    bindingKey: BindingKey
+  ) throws {
+    
+    let hasMatchingAlgorithm = jwtProofMeta.algorithms.contains { issuerAlg in
+      policy.supportedAlgorithms.contains { walletAlg in
+        walletAlg.name == issuerAlg
+      }
+    }
+
+    guard hasMatchingAlgorithm else {
+      throw CredentialIssuanceError.noMatchingAlgorithmForProofType
+    }
+
+    // Determine if key attestation is required
+    let keyAttestationRequired = jwtProofMeta.keyAttestationRequirement != nil &&
+                                 jwtProofMeta.keyAttestationRequirement != .notRequired
+
+    if keyAttestationRequired {
+      // Issuer requires key attestation - check if wallet policy supports it
+      guard policy.supportedProofTypes.contains(.jwtWithKeyAttestation) else {
+        throw CredentialIssuanceError.proofTypeNotSupportedByWalletPolicy
+      }
+
+      // Check if the binding key is attestation-capable
+      guard bindingKey.isAttestationCapable else {
+        throw CredentialIssuanceError.bindingKeyNotAttestationCapable
+      }
+    } else {
+      // Issuer allows plain JWT without key attestation
+      // Check if wallet policy allows this
+      guard policy.supportedProofTypes.contains(.jwtWithoutKeyAttestation) else {
+        throw CredentialIssuanceError.proofTypeJwtWithoutKeyAttestationNotAllowedByPolicy
+      }
+    }
+  }
+
+  private func validateAttestationProof(
+    attestationProofMeta: ProofTypeSupportedMeta,
+    policy: DeviceBoundProofPolicy,
+    bindingKey: BindingKey
+  ) throws {
+    guard policy.supportedProofTypes.contains(.attestation) else {
+      throw CredentialIssuanceError.proofTypeNotSupportedByWalletPolicy
+    }
+
+    guard bindingKey.isAttestationCapable else {
+      throw CredentialIssuanceError.bindingKeyNotAttestationCapable
+    }
+
+    let hasMatchingAlgorithm = attestationProofMeta.algorithms.contains { issuerAlg in
+      policy.supportedAlgorithms.contains { walletAlg in
+        walletAlg.name == issuerAlg
+      }
+    }
+
+    guard hasMatchingAlgorithm else {
+      throw CredentialIssuanceError.noMatchingAlgorithmForProofType
+    }
+  }
+}

--- a/Sources/Issuers/Issuer.swift
+++ b/Sources/Issuers/Issuer.swift
@@ -484,6 +484,13 @@ private extension Issuer {
       throw ValidationError.error(reason: "Invalid Supported credential for requestSingle")
     }
     
+    for bindingKey in bindingKeys {
+      try config.proofTypesPolicy.validate(
+        credentialConfiguration: supportedCredential,
+        bindingKey: bindingKey
+      )
+    }
+
     let proofs = try await obtainProofs(
       authorizedRequest: authorizedRequest,
       batchCredentialIssuance: issuerMetadata.batchCredentialIssuance,
@@ -519,6 +526,13 @@ private extension Issuer {
     guard let supportedCredential = issuerMetadata
       .credentialsSupported[credentialConfigurationIdentifier] else {
       throw ValidationError.error(reason: "Invalid Supported credential for requestSingle")
+    }
+    
+    for bindingKey in bindingKeys {
+      try config.proofTypesPolicy.validate(
+        credentialConfiguration: supportedCredential,
+        bindingKey: bindingKey
+      )
     }
     
     let proofs = try await obtainProofs(

--- a/Sources/Issuers/Issuer.swift
+++ b/Sources/Issuers/Issuer.swift
@@ -17,7 +17,7 @@ import Foundation
 import JOSESwift
 
 /// A protocol defining the operations required for an issuer in the credential issuance process.
-public protocol IssuerType: Sendable {
+public protocol IssuerType: RefreshAccessToken {
   
   /// Initiates an authorization request using a credential offer.
   ///
@@ -819,7 +819,7 @@ public extension Issuer {
     dPopNonce: Nonce? = nil
   ) async throws -> AuthorizedRequest {
     if let refreshToken = authorizedRequest.refreshToken {
-        let (accessToken, refreshToken, _, _, timeStamp, _) = try await authorizer.refreshAccessToken(
+        let (accessToken, newRefreshToken, _, _, timeStamp, _) = try await authorizer.refreshAccessToken(
           clientId: clientId,
           refreshToken: refreshToken,
           dpopNonce: dPopNonce,
@@ -827,6 +827,7 @@ public extension Issuer {
         )
         return authorizedRequest.replacing(
             accessToken: accessToken,
+            refreshToken: newRefreshToken,
             timeStamp: timeStamp?.asTimeInterval ?? .zero
           )
     }
@@ -853,6 +854,24 @@ public extension Issuer {
           )
     }
     return authorizedRequest
+  }
+
+  /// Refreshes the access token using the issuer's configured client.
+  /// - Parameters:
+  ///   - authorizedRequest: The authorized request containing the tokens to refresh.
+  ///   - dPopNonce: An optional nonce for DPoP (Demonstrating Proof-of-Possession).
+  /// - Returns: A new `AuthorizedRequest` with refreshed tokens if successful,
+  ///            or the original request if refresh is not possible.
+  /// - Throws: An error if the token refresh request fails.
+  func refresh(
+    authorizedRequest: AuthorizedRequest,
+    dPopNonce: Nonce?
+  ) async throws -> AuthorizedRequest {
+    try await refresh(
+      client: config.client,
+      authorizedRequest: authorizedRequest,
+      dPopNonce: dPopNonce
+    )
   }
 }
 

--- a/Sources/Issuers/RefreshAccessToken.swift
+++ b/Sources/Issuers/RefreshAccessToken.swift
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Foundation
+
+/// A protocol that defines the capability to refresh an access token.
+///
+public protocol RefreshAccessToken: Sendable {
+
+  /// Refreshes the access token in an authorized request.
+  ///
+  /// This method attempts to refresh the access token using the refresh token
+  /// present in the provided `AuthorizedRequest`. If the request does not contain
+  /// a refresh token, or if the refresh token has expired, the original request
+  /// is returned unchanged.
+  ///
+  /// The client credentials are obtained from the issuer's configuration, so they
+  /// do not need to be provided separately.
+  ///
+  /// - Parameters:
+  ///   - authorizedRequest: The authorized request containing the tokens to refresh.
+  ///   - dPopNonce: An optional nonce for DPoP (Demonstrating Proof-of-Possession).
+  /// - Returns: A new `AuthorizedRequest` with refreshed tokens if successful,
+  ///            or the original request if refresh is not possible.
+  /// - Throws: An error if the token refresh request fails.
+  func refresh(
+    authorizedRequest: AuthorizedRequest,
+    dPopNonce: Nonce?
+  ) async throws -> AuthorizedRequest
+}
+
+public extension RefreshAccessToken {
+
+  /// Refreshes the access token in an authorized request with default DPoP nonce.
+  ///
+  /// This convenience method calls the main refresh method with a nil DPoP nonce.
+  ///
+  /// - Parameter authorizedRequest: The authorized request containing the tokens to refresh.
+  /// - Returns: A new `AuthorizedRequest` with refreshed tokens if successful,
+  ///            or the original request if refresh is not possible.
+  /// - Throws: An error if the token refresh request fails.
+  func refresh(
+    authorizedRequest: AuthorizedRequest
+  ) async throws -> AuthorizedRequest {
+    try await refresh(authorizedRequest: authorizedRequest, dPopNonce: nil)
+  }
+}

--- a/Sources/Main/AttestationBasedClient/ClientAttestation.swift
+++ b/Sources/Main/AttestationBasedClient/ClientAttestation.swift
@@ -21,11 +21,19 @@ public struct ClientAttestationJWT: Sendable {
   public let jws: JWS
   private let payload: JSON
   
+  private static let allowedAlgorithms: Set<SignatureAlgorithm> = [
+    .ES256, .ES384, .ES512
+  ]
+  
   public init(jws: JWS, validateCnf: Bool = true) throws {
     self.jws = jws
     
-    guard jws.header.algorithm != nil else {
+    guard let algorithm = jws.header.algorithm else {
       throw ClientAttestationError.notSigned
+    }
+    
+    guard Self.allowedAlgorithms.contains(algorithm) else {
+      throw ClientAttestationError.invalidAlgorithm(allowedAlgorithms: Self.allowedAlgorithms.map { $0.rawValue})
     }
     
     let payloadData = jws.payload.data()

--- a/Sources/Main/AttestationBasedClient/ClientAttestationError.swift
+++ b/Sources/Main/AttestationBasedClient/ClientAttestationError.swift
@@ -17,6 +17,7 @@ import Foundation
 
 enum ClientAttestationError: Error, LocalizedError {
   case notSigned
+  case invalidAlgorithm(allowedAlgorithms:[String])
   case invalidPayload
   case invalidClientId
   case missingSubject
@@ -31,6 +32,9 @@ enum ClientAttestationError: Error, LocalizedError {
   var errorDescription: String? {
     switch self {
     case .notSigned: return "Invalid Attestation JWT. Not properly signed."
+    case .invalidAlgorithm(let allowed):
+      let list = allowed.sorted().joined(separator: ", ")
+      return "Invalid Attestation JWT. Signature algorithm must be one of: \(list)."
     case .invalidPayload: return "Invalid Attestation JWT. Cannot parse payload."
     case .missingSubject: return "Invalid Attestation JWT. Missing subject claim."
     case .missingCnfClaim: return "Invalid Attestation JWT. Missing cnf claim."

--- a/Tests/AttestationBased/AttestationBasedTests.swift
+++ b/Tests/AttestationBased/AttestationBasedTests.swift
@@ -65,4 +65,141 @@ class AttestationBasedTests: XCTestCase {
     
     XCTAssertNotNil(client)
   }
+
+  func testClientAttestationWithValidAlgorithms_shouldSucceed() async throws {
+    // Test that ES256, ES384, ES512 are all accepted
+    let privateKey = try KeyController.generateECDHPrivateKey()
+
+    // Test ES256
+    let clientES256 = try selfSignedClient(
+      clientId: "test-client-es256",
+      algorithm: .ES256,
+      privateKey: privateKey
+    )
+    XCTAssertNotNil(clientES256, "ES256 should be accepted")
+
+    // Test ES384
+    let clientES384 = try selfSignedClient(
+      clientId: "test-client-es384",
+      algorithm: .ES384,
+      privateKey: privateKey
+    )
+    XCTAssertNotNil(clientES384, "ES384 should be accepted")
+
+    // Test ES512
+    let clientES512 = try selfSignedClient(
+      clientId: "test-client-es512",
+      algorithm: .ES512,
+      privateKey: privateKey
+    )
+    XCTAssertNotNil(clientES512, "ES512 should be accepted")
+  }
+
+  func testClientAttestationWithInvalidAlgorithm_shouldFail() async throws {
+    // Test that RS256 (RSA) is rejected
+    // Create a JWT with RS256 algorithm in the header
+    let now = Date().timeIntervalSince1970
+    let exp = Date().addingTimeInterval(300).timeIntervalSince1970
+
+    let headerDict: [String: Any] = [
+      "alg": "RS256",
+      "typ": "oauth-client-attestation+jwt"
+    ]
+
+    let payloadDict: [String: Any] = [
+      "iss": "test-client",
+      "aud": "test-client",
+      "sub": "test-client",
+      "iat": now,
+      "exp": exp,
+      "cnf": [
+        "jwk": [
+          "kty": "RSA",
+          "n": "test",
+          "e": "AQAB"
+        ]
+      ]
+    ]
+
+    let headerData = try JSONSerialization.data(withJSONObject: headerDict)
+    let payloadData = try JSONSerialization.data(withJSONObject: payloadDict)
+
+    let headerB64 = base64URLEncode(headerData)
+    let payloadB64 = base64URLEncode(payloadData)
+    let signature = "fake-signature"
+
+    let compactJWT = "\(headerB64).\(payloadB64).\(signature)"
+    let jws = try JWS(compactSerialization: compactJWT)
+
+    // Should throw invalidAlgorithm error
+    XCTAssertThrowsError(try ClientAttestationJWT(jws: jws)) { error in
+      guard let attestationError = error as? ClientAttestationError,
+            case .invalidAlgorithm(let allowed) = attestationError else {
+        XCTFail("Expected ClientAttestationError.invalidAlgorithm, got \(error)")
+        return
+      }
+
+      // Verify the error includes all allowed algorithms
+      XCTAssertEqual(allowed.sorted(), ["ES256", "ES384", "ES512"])
+
+      // Verify error message is descriptive
+      let errorMessage = attestationError.errorDescription ?? ""
+      XCTAssertTrue(errorMessage.contains("ES256"))
+      XCTAssertTrue(errorMessage.contains("ES384"))
+      XCTAssertTrue(errorMessage.contains("ES512"))
+    }
+  }
+
+  func testClientAttestationWithHMACAlgorithm_shouldFail() async throws {
+    // Test that HS256 (HMAC) is rejected
+    let now = Date().timeIntervalSince1970
+    let exp = Date().addingTimeInterval(300).timeIntervalSince1970
+
+    let headerDict: [String: Any] = [
+      "alg": "HS256",
+      "typ": "oauth-client-attestation+jwt"
+    ]
+
+    let payloadDict: [String: Any] = [
+      "iss": "test-client",
+      "aud": "test-client",
+      "sub": "test-client",
+      "iat": now,
+      "exp": exp,
+      "cnf": [
+        "jwk": [
+          "kty": "oct",
+          "k": "test"
+        ]
+      ]
+    ]
+
+    let headerData = try JSONSerialization.data(withJSONObject: headerDict)
+    let payloadData = try JSONSerialization.data(withJSONObject: payloadDict)
+
+    let headerB64 = base64URLEncode(headerData)
+    let payloadB64 = base64URLEncode(payloadData)
+    let signature = "fake-signature"
+
+    let compactJWT = "\(headerB64).\(payloadB64).\(signature)"
+    let jws = try JWS(compactSerialization: compactJWT)
+
+    // Should throw invalidAlgorithm error
+    XCTAssertThrowsError(try ClientAttestationJWT(jws: jws)) { error in
+      guard let attestationError = error as? ClientAttestationError,
+            case .invalidAlgorithm = attestationError else {
+        XCTFail("Expected ClientAttestationError.invalidAlgorithm, got \(error)")
+        return
+      }
+    }
+  }
+
+  // Helper function for base64 URL encoding
+  private func base64URLEncode(_ data: Data) -> String {
+    var base64String = data.base64EncodedString()
+    base64String = base64String.replacingOccurrences(of: "/", with: "_")
+    base64String = base64String.replacingOccurrences(of: "+", with: "-")
+    base64String = base64String.replacingOccurrences(of: "=", with: "")
+    return base64String
+  }
 }

--- a/Tests/Entities/ProofTypesPolicyTests.swift
+++ b/Tests/Entities/ProofTypesPolicyTests.swift
@@ -1,0 +1,461 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import XCTest
+import JOSESwift
+
+@testable import OpenID4VCI
+
+final class ProofTypesPolicyTests: XCTestCase {
+
+  // MARK: - Policy Creation Tests
+
+  func testAcceptAllPolicy() throws {
+    let policy = ProofTypesPolicy.acceptAll
+
+    // Create a test credential configuration that requires JWT without key attestation
+    let proofTypesSupported: [String: ProofTypeSupportedMeta] = [
+      "jwt": ProofTypeSupportedMeta(
+        algorithms: ["ES256"],
+        keyAttestationRequirement: .notRequired
+      )
+    ]
+    let credentialConfig = createTestCredentialConfiguration(proofTypesSupported: proofTypesSupported)
+
+    // Create a plain JWT binding key
+    let bindingKey = try createJwtBindingKey()
+
+    // Should not throw with acceptAll policy
+    XCTAssertNoThrow(try policy.validate(
+      credentialConfiguration: credentialConfig,
+      bindingKey: bindingKey
+    ))
+  }
+
+  func testHaipCompliantPolicy() throws {
+    let policy = DeviceBoundProofPolicy.haipCompliant()
+
+    XCTAssertEqual(policy.supportedAlgorithms.count, 1)
+    XCTAssertEqual(policy.supportedAlgorithms.first?.name, "ES256")
+    XCTAssertTrue(policy.supportedProofTypes.contains(.jwtWithKeyAttestation))
+    XCTAssertTrue(policy.supportedProofTypes.contains(.attestation))
+    XCTAssertFalse(policy.supportedProofTypes.contains(.jwtWithoutKeyAttestation))
+  }
+
+  func testDeviceBoundPolicyCreation() throws {
+    let policy = DeviceBoundProofPolicy(
+      supportedAlgorithms: [JWSAlgorithm(.ES256), JWSAlgorithm(.ES384)],
+      supportedProofTypes: [.jwtWithKeyAttestation, .attestation]
+    )
+
+    XCTAssertEqual(policy.supportedAlgorithms.count, 2)
+    XCTAssertTrue(policy.supportedAlgorithms.contains(where: { $0.name == "ES256" }))
+    XCTAssertTrue(policy.supportedAlgorithms.contains(where: { $0.name == "ES384" }))
+    XCTAssertEqual(policy.supportedProofTypes.count, 2)
+  }
+
+  // MARK: - Validation Tests - JWT Without Key Attestation
+
+  func testDeviceBoundPolicy_RejectsJwtWithoutKeyAttestation() throws {
+    let deviceBoundPolicy = DeviceBoundProofPolicy(
+      supportedAlgorithms: [JWSAlgorithm(.ES256)],
+      supportedProofTypes: [.jwtWithKeyAttestation, .attestation]
+    )
+    let policy = ProofTypesPolicy.deviceBound(deviceBoundPolicy)
+
+    // Credential requires JWT without key attestation
+    let proofTypesSupported: [String: ProofTypeSupportedMeta] = [
+      "jwt": ProofTypeSupportedMeta(
+        algorithms: ["ES256"],
+        keyAttestationRequirement: .notRequired
+      )
+    ]
+    let credentialConfig = createTestCredentialConfiguration(proofTypesSupported: proofTypesSupported)
+    let bindingKey = try createJwtBindingKey()
+
+    // Should throw because policy doesn't support JWT without key attestation
+    XCTAssertThrowsError(try policy.validate(
+      credentialConfiguration: credentialConfig,
+      bindingKey: bindingKey
+    )) { error in
+      guard let issuanceError = error as? CredentialIssuanceError else {
+        XCTFail("Expected CredentialIssuanceError")
+        return
+      }
+      if case .proofTypeJwtWithoutKeyAttestationNotAllowedByPolicy = issuanceError {
+        // Expected error
+      } else {
+        XCTFail("Expected proofTypeJwtWithoutKeyAttestationNotAllowedByPolicy error")
+      }
+    }
+  }
+
+  func testAcceptAllPolicy_AcceptsJwtWithoutKeyAttestation() throws {
+    let policy = ProofTypesPolicy.acceptAll
+
+    // Credential requires JWT without key attestation
+    let proofTypesSupported: [String: ProofTypeSupportedMeta] = [
+      "jwt": ProofTypeSupportedMeta(
+        algorithms: ["ES256"],
+        keyAttestationRequirement: .notRequired
+      )
+    ]
+    let credentialConfig = createTestCredentialConfiguration(proofTypesSupported: proofTypesSupported)
+    let bindingKey = try createJwtBindingKey()
+
+    // Should not throw with acceptAll policy
+    XCTAssertNoThrow(try policy.validate(
+      credentialConfiguration: credentialConfig,
+      bindingKey: bindingKey
+    ))
+  }
+
+  // MARK: - Validation Tests - JWT With Key Attestation
+
+  func testDeviceBoundPolicy_AcceptsJwtWithKeyAttestation() throws {
+    let deviceBoundPolicy = DeviceBoundProofPolicy(
+      supportedAlgorithms: [JWSAlgorithm(.ES256)],
+      supportedProofTypes: [.jwtWithKeyAttestation]
+    )
+    let policy = ProofTypesPolicy.deviceBound(deviceBoundPolicy)
+
+    // Credential requires JWT with key attestation
+    let proofTypesSupported: [String: ProofTypeSupportedMeta] = [
+      "jwt": ProofTypeSupportedMeta(
+        algorithms: ["ES256"],
+        keyAttestationRequirement: .required(
+          keyStorageConstraints: [.iso18045High],
+          userAuthenticationConstraints: [.iso18045Moderate],
+          preferredKeyStorageStatusPeriod: nil
+        )
+      )
+    ]
+    let credentialConfig = createTestCredentialConfiguration(proofTypesSupported: proofTypesSupported)
+    let bindingKey = try createJwtKeyAttestationBindingKey()
+
+    // Should not throw
+    XCTAssertNoThrow(try policy.validate(
+      credentialConfiguration: credentialConfig,
+      bindingKey: bindingKey
+    ))
+  }
+
+  func testDeviceBoundPolicy_RejectsJwtWithKeyAttestation_WhenNotInSupportedProofTypes() throws {
+    let deviceBoundPolicy = DeviceBoundProofPolicy(
+      supportedAlgorithms: [JWSAlgorithm(.ES256)],
+      supportedProofTypes: [.attestation] // Only attestation, not JWT with key attestation
+    )
+    let policy = ProofTypesPolicy.deviceBound(deviceBoundPolicy)
+
+    // Credential requires JWT with key attestation
+    let proofTypesSupported: [String: ProofTypeSupportedMeta] = [
+      "jwt": ProofTypeSupportedMeta(
+        algorithms: ["ES256"],
+        keyAttestationRequirement: .required(
+          keyStorageConstraints: [.iso18045High],
+          userAuthenticationConstraints: [.iso18045Moderate],
+          preferredKeyStorageStatusPeriod: nil
+        )
+      )
+    ]
+    let credentialConfig = createTestCredentialConfiguration(proofTypesSupported: proofTypesSupported)
+    let bindingKey = try createJwtKeyAttestationBindingKey()
+
+    // Should throw because policy doesn't support JWT with key attestation
+    XCTAssertThrowsError(try policy.validate(
+      credentialConfiguration: credentialConfig,
+      bindingKey: bindingKey
+    )) { error in
+      guard let issuanceError = error as? CredentialIssuanceError else {
+        XCTFail("Expected CredentialIssuanceError")
+        return
+      }
+      if case .proofTypeNotSupportedByWalletPolicy = issuanceError {
+        // Expected error
+      } else {
+        XCTFail("Expected proofTypeNotSupportedByWalletPolicy error")
+      }
+    }
+  }
+
+  func testDeviceBoundPolicy_RejectsJwtWithKeyAttestation_WhenBindingKeyNotAttestationCapable() throws {
+    let deviceBoundPolicy = DeviceBoundProofPolicy(
+      supportedAlgorithms: [JWSAlgorithm(.ES256)],
+      supportedProofTypes: [.jwtWithKeyAttestation]
+    )
+    let policy = ProofTypesPolicy.deviceBound(deviceBoundPolicy)
+
+    // Credential requires JWT with key attestation
+    let proofTypesSupported: [String: ProofTypeSupportedMeta] = [
+      "jwt": ProofTypeSupportedMeta(
+        algorithms: ["ES256"],
+        keyAttestationRequirement: .required(
+          keyStorageConstraints: [.iso18045High],
+          userAuthenticationConstraints: [.iso18045Moderate],
+          preferredKeyStorageStatusPeriod: nil
+        )
+      )
+    ]
+    let credentialConfig = createTestCredentialConfiguration(proofTypesSupported: proofTypesSupported)
+    // Use a plain JWT binding key (not attestation-capable)
+    let bindingKey = try createJwtBindingKey()
+
+    // Should throw because binding key is not attestation-capable
+    XCTAssertThrowsError(try policy.validate(
+      credentialConfiguration: credentialConfig,
+      bindingKey: bindingKey
+    )) { error in
+      guard let issuanceError = error as? CredentialIssuanceError else {
+        XCTFail("Expected CredentialIssuanceError")
+        return
+      }
+      if case .bindingKeyNotAttestationCapable = issuanceError {
+        // Expected error
+      } else {
+        XCTFail("Expected bindingKeyNotAttestationCapable error")
+      }
+    }
+  }
+
+  // MARK: - Validation Tests - Attestation Proof Type
+
+  func testDeviceBoundPolicy_AcceptsAttestationProof() throws {
+    let deviceBoundPolicy = DeviceBoundProofPolicy(
+      supportedAlgorithms: [JWSAlgorithm(.ES256)],
+      supportedProofTypes: [.attestation]
+    )
+    let policy = ProofTypesPolicy.deviceBound(deviceBoundPolicy)
+
+    // Credential requires attestation proof
+    let proofTypesSupported: [String: ProofTypeSupportedMeta] = [
+      "attestation": ProofTypeSupportedMeta(
+        algorithms: ["ES256"],
+        keyAttestationRequirement: nil
+      )
+    ]
+    let credentialConfig = createTestCredentialConfiguration(proofTypesSupported: proofTypesSupported)
+    let bindingKey = try createAttestationBindingKey()
+
+    // Should not throw
+    XCTAssertNoThrow(try policy.validate(
+      credentialConfiguration: credentialConfig,
+      bindingKey: bindingKey
+    ))
+  }
+
+  func testDeviceBoundPolicy_RejectsAttestationProof_WhenNotInSupportedProofTypes() throws {
+    let deviceBoundPolicy = DeviceBoundProofPolicy(
+      supportedAlgorithms: [JWSAlgorithm(.ES256)],
+      supportedProofTypes: [.jwtWithKeyAttestation] // Only JWT with key attestation
+    )
+    let policy = ProofTypesPolicy.deviceBound(deviceBoundPolicy)
+
+    // Credential requires attestation proof
+    let proofTypesSupported: [String: ProofTypeSupportedMeta] = [
+      "attestation": ProofTypeSupportedMeta(
+        algorithms: ["ES256"],
+        keyAttestationRequirement: nil
+      )
+    ]
+    let credentialConfig = createTestCredentialConfiguration(proofTypesSupported: proofTypesSupported)
+    let bindingKey = try createAttestationBindingKey()
+
+    // Should throw because policy doesn't support attestation proofs
+    XCTAssertThrowsError(try policy.validate(
+      credentialConfiguration: credentialConfig,
+      bindingKey: bindingKey
+    )) { error in
+      guard let issuanceError = error as? CredentialIssuanceError else {
+        XCTFail("Expected CredentialIssuanceError")
+        return
+      }
+      if case .proofTypeNotSupportedByWalletPolicy = issuanceError {
+        // Expected error
+      } else {
+        XCTFail("Expected proofTypeNotSupportedByWalletPolicy error")
+      }
+    }
+  }
+
+  // MARK: - Algorithm Matching Tests
+
+  func testDeviceBoundPolicy_RejectsWhenNoMatchingAlgorithm() throws {
+    let deviceBoundPolicy = DeviceBoundProofPolicy(
+      supportedAlgorithms: [JWSAlgorithm(.ES384)], // Only ES384
+      supportedProofTypes: [.jwtWithKeyAttestation]
+    )
+    let policy = ProofTypesPolicy.deviceBound(deviceBoundPolicy)
+
+    // Credential requires ES256
+    let proofTypesSupported: [String: ProofTypeSupportedMeta] = [
+      "jwt": ProofTypeSupportedMeta(
+        algorithms: ["ES256"], // Different algorithm
+        keyAttestationRequirement: .required(
+          keyStorageConstraints: [.iso18045High],
+          userAuthenticationConstraints: [.iso18045Moderate],
+          preferredKeyStorageStatusPeriod: nil
+        )
+      )
+    ]
+    let credentialConfig = createTestCredentialConfiguration(proofTypesSupported: proofTypesSupported)
+    let bindingKey = try createJwtKeyAttestationBindingKey()
+
+    // Should throw because no matching algorithm
+    XCTAssertThrowsError(try policy.validate(
+      credentialConfiguration: credentialConfig,
+      bindingKey: bindingKey
+    )) { error in
+      guard let issuanceError = error as? CredentialIssuanceError else {
+        XCTFail("Expected CredentialIssuanceError")
+        return
+      }
+      if case .noMatchingAlgorithmForProofType = issuanceError {
+        // Expected error
+      } else {
+        XCTFail("Expected noMatchingAlgorithmForProofType error")
+      }
+    }
+  }
+
+  // MARK: - Flexible Policy Tests
+
+  func testFlexiblePolicy_AllowsNonDeviceBound() throws {
+    let deviceBoundPolicy = DeviceBoundProofPolicy(
+      supportedAlgorithms: [JWSAlgorithm(.ES256)],
+      supportedProofTypes: [.jwtWithKeyAttestation]
+    )
+    let policy = ProofTypesPolicy.flexible(
+      deviceBound: deviceBoundPolicy,
+      allowNonDeviceBound: true
+    )
+
+    // Credential without proof types (non-device-bound)
+    let credentialConfig = createTestCredentialConfiguration(proofTypesSupported: nil)
+    let bindingKey = try createJwtBindingKey()
+
+    // Should not throw because non-device-bound is allowed
+    XCTAssertNoThrow(try policy.validate(
+      credentialConfiguration: credentialConfig,
+      bindingKey: bindingKey
+    ))
+  }
+
+  func testFlexiblePolicy_RejectsNonDeviceBound_WhenNotAllowed() throws {
+    let deviceBoundPolicy = DeviceBoundProofPolicy(
+      supportedAlgorithms: [JWSAlgorithm(.ES256)],
+      supportedProofTypes: [.jwtWithKeyAttestation]
+    )
+    let policy = ProofTypesPolicy.flexible(
+      deviceBound: deviceBoundPolicy,
+      allowNonDeviceBound: false
+    )
+
+    // Credential without proof types (non-device-bound)
+    let credentialConfig = createTestCredentialConfiguration(proofTypesSupported: nil)
+    let bindingKey = try createJwtBindingKey()
+
+    // Should throw because non-device-bound is not allowed
+    XCTAssertThrowsError(try policy.validate(
+      credentialConfiguration: credentialConfig,
+      bindingKey: bindingKey
+    )) { error in
+      guard let issuanceError = error as? CredentialIssuanceError else {
+        XCTFail("Expected CredentialIssuanceError")
+        return
+      }
+      if case .proofTypesNotSupportedByCredentialConfiguration = issuanceError {
+        // Expected error
+      } else {
+        XCTFail("Expected proofTypesNotSupportedByCredentialConfiguration error")
+      }
+    }
+  }
+
+  // MARK: - Helper Methods
+
+  private func createTestCredentialConfiguration(
+    proofTypesSupported: [String: ProofTypeSupportedMeta]?
+  ) -> CredentialSupported {
+    let credentialDefinition = SdJwtVcFormat.CredentialDefinition(
+      type: "VerifiableCredential",
+      claims: []
+    )
+
+    let config = SdJwtVcFormat.CredentialConfiguration(
+      scope: nil,
+      vct: "test_vct",
+      cryptographicBindingMethodsSupported: [],
+      credentialSigningAlgValuesSupported: [],
+      proofTypesSupported: proofTypesSupported,
+      credentialMetadata: nil,
+      credentialDefinition: credentialDefinition
+    )
+    return .sdJwtVc(config)
+  }
+
+  private func createJwtBindingKey() throws -> BindingKey {
+    let privateKey = try KeyController.generateECDHPrivateKey()
+    let publicKey = try KeyController.generateECDHPublicKey(from: privateKey)
+    let jwk = try ECPublicKey(
+      publicKey: publicKey,
+      additionalParameters: [
+        "use": "sig",
+        "kid": "test-key-1",
+        "alg": JWSAlgorithm(.ES256).name
+      ]
+    )
+
+    return .jwt(
+      algorithm: JWSAlgorithm(.ES256),
+      jwk: jwk,
+      privateKey: .secKey(privateKey),
+      issuer: nil
+    )
+  }
+
+  private func createJwtKeyAttestationBindingKey() throws -> BindingKey {
+    let privateKey = try KeyController.generateECDHPrivateKey()
+
+    // Mock compact JWS string for testing
+    let mockJWSString = "eyJhbGciOiJFUzI1NiIsInR5cCI6ImtleS1hdHRlc3RhdGlvbitqd3QifQ.eyJ0ZXN0IjoiZGF0YSJ9.mock_signature"
+
+    return .jwtKeyAttestation(
+      algorithm: JWSAlgorithm(.ES256),
+      keyAttestationJWT: { _ in
+        // Mock key attestation JWT using compact serialization
+        try KeyAttestationJWT(
+          jws: JWS(compactSerialization: mockJWSString)
+        )
+      },
+      keyIndex: 0,
+      privateKey: .secKey(privateKey),
+      issuer: nil
+    )
+  }
+
+  private func createAttestationBindingKey() throws -> BindingKey {
+    // Mock compact JWS string for testing
+    let mockJWSString = "eyJhbGciOiJFUzI1NiIsInR5cCI6ImtleS1hdHRlc3RhdGlvbitqd3QifQ.eyJ0ZXN0IjoiZGF0YSJ9.mock_signature"
+
+    return .attestation(
+      keyAttestationJWT: { _ in
+        // Mock key attestation JWT using compact serialization
+        try KeyAttestationJWT(
+          jws: JWS(compactSerialization: mockJWSString)
+        )
+      }
+    )
+  }
+}

--- a/Tests/Helpers/KeyAttestationRequirementTests.swift
+++ b/Tests/Helpers/KeyAttestationRequirementTests.swift
@@ -42,7 +42,7 @@ final class KeyAttestationRequirementTests: XCTestCase {
       userAuthenticationConstraints: userAuthenticationConstraints
     )
     
-    if case let .required(storedConstraints, authConstraints) = requirement {
+    if case let .required(storedConstraints, authConstraints, _) = requirement {
       XCTAssertEqual(storedConstraints, keyStorageConstraints)
       XCTAssertEqual(authConstraints, userAuthenticationConstraints)
     } else {
@@ -61,7 +61,8 @@ final class KeyAttestationRequirementTests: XCTestCase {
   func testEncoding_required() throws {
     let requirement = KeyAttestationRequirement.required(
       keyStorageConstraints: [.iso18045Basic],
-      userAuthenticationConstraints: [.iso18045EnhancedBasic]
+      userAuthenticationConstraints: [.iso18045EnhancedBasic],
+      preferredKeyStorageStatusPeriod: nil
     )
     
     let encoder = JSONEncoder()
@@ -84,7 +85,7 @@ final class KeyAttestationRequirementTests: XCTestCase {
     let decoder = JSONDecoder()
     let requirement = try decoder.decode(KeyAttestationRequirement.self, from: jsonData)
     
-    if case let .required(storedConstraints, authConstraints) = requirement {
+    if case let .required(storedConstraints, authConstraints, _) = requirement {
       XCTAssertEqual(storedConstraints, [.iso18045High])
       XCTAssertEqual(authConstraints, [.iso18045EnhancedBasic])
     } else {
@@ -127,7 +128,7 @@ final class KeyAttestationRequirementTests: XCTestCase {
     
     let requirement = try KeyAttestationRequirement(json: json)
     
-    if case let .required(storedConstraints, authConstraints) = requirement {
+    if case let .required(storedConstraints, authConstraints, _) = requirement {
       XCTAssertEqual(storedConstraints, [.iso18045Basic])
       XCTAssertEqual(authConstraints, [.iso18045High])
     } else {
@@ -146,8 +147,172 @@ final class KeyAttestationRequirementTests: XCTestCase {
       "key_storage": [],
       "user_authentication": []
     ]
-    
+
     let requirement = try KeyAttestationRequirement(json: json)
     XCTAssertEqual(requirement, .notRequired)
+  }
+
+  // MARK: - Preferred Key Storage Status Period Tests
+
+  func testDecoding_withPreferredKeyStorageStatusPeriod() throws {
+    let jsonData = """
+        {
+            "key_storage": ["iso_18045_high"],
+            "user_authentication": ["iso_18045_enhanced-basic"],
+            "preferred_key_storage_status_period": 86400
+        }
+        """.data(using: .utf8)!
+
+    let decoder = JSONDecoder()
+    let requirement = try decoder.decode(KeyAttestationRequirement.self, from: jsonData)
+
+    if case let .required(storedConstraints, authConstraints, preferredPeriod) = requirement {
+      XCTAssertEqual(storedConstraints, [.iso18045High])
+      XCTAssertEqual(authConstraints, [.iso18045EnhancedBasic])
+      XCTAssertEqual(preferredPeriod, 86400)
+    } else {
+      XCTFail("Expected .required case")
+    }
+  }
+
+  func testDecoding_withoutPreferredKeyStorageStatusPeriod() throws {
+    let jsonData = """
+        {
+            "key_storage": ["iso_18045_high"],
+            "user_authentication": ["iso_18045_enhanced-basic"]
+        }
+        """.data(using: .utf8)!
+
+    let decoder = JSONDecoder()
+    let requirement = try decoder.decode(KeyAttestationRequirement.self, from: jsonData)
+
+    if case let .required(_, _, preferredPeriod) = requirement {
+      XCTAssertNil(preferredPeriod)
+    } else {
+      XCTFail("Expected .required case")
+    }
+  }
+
+  func testEncoding_withPreferredKeyStorageStatusPeriod() throws {
+    let requirement = KeyAttestationRequirement.required(
+      keyStorageConstraints: [.iso18045Basic],
+      userAuthenticationConstraints: [.iso18045EnhancedBasic],
+      preferredKeyStorageStatusPeriod: 3600
+    )
+
+    let encoder = JSONEncoder()
+    let data = try encoder.encode(requirement)
+    let jsonString = String(data: data, encoding: .utf8)
+
+    XCTAssertNotNil(jsonString)
+    XCTAssertTrue(jsonString!.contains("\"preferred_key_storage_status_period\":3600"))
+  }
+
+  func testInitFromJSON_withPreferredKeyStorageStatusPeriod() throws {
+    let json: JSON = [
+      "key_storage": [
+        "iso_18045_basic"
+      ],
+      "user_authentication": [
+        "iso_18045_high"
+      ],
+      "preferred_key_storage_status_period": 7200
+    ]
+
+    let requirement = try KeyAttestationRequirement(json: json)
+
+    if case let .required(storedConstraints, authConstraints, preferredPeriod) = requirement {
+      XCTAssertEqual(storedConstraints, [.iso18045Basic])
+      XCTAssertEqual(authConstraints, [.iso18045High])
+      XCTAssertEqual(preferredPeriod, 7200)
+    } else {
+      XCTFail("Expected .required case")
+    }
+  }
+
+  func testInit_withPreferredKeyStorageStatusPeriod() throws {
+    let requirement = try KeyAttestationRequirement(
+      keyStorageConstraints: [.iso18045High],
+      userAuthenticationConstraints: [.iso18045Moderate],
+      preferredKeyStorageStatusPeriod: 43200
+    )
+
+    if case let .required(_, _, preferredPeriod) = requirement {
+      XCTAssertEqual(preferredPeriod, 43200)
+    } else {
+      XCTFail("Expected .required case")
+    }
+  }
+
+  // MARK: - ProofTypeSupportedMeta Integration Tests
+
+  func testProofTypeSupportedMeta_withPreferredKeyStorageStatusPeriod() throws {
+    let jsonData = """
+        {
+            "proof_signing_alg_values_supported": ["ES256", "ES384"],
+            "key_attestations_required": {
+                "key_storage": ["iso_18045_high"],
+                "user_authentication": ["iso_18045_moderate"],
+                "preferred_key_storage_status_period": 172800
+            }
+        }
+        """.data(using: .utf8)!
+
+    let decoder = JSONDecoder()
+    let proofTypeMeta = try decoder.decode(ProofTypeSupportedMeta.self, from: jsonData)
+
+    XCTAssertEqual(proofTypeMeta.algorithms, ["ES256", "ES384"])
+    XCTAssertNotNil(proofTypeMeta.keyAttestationRequirement)
+
+    if case let .required(_, _, preferredPeriod) = proofTypeMeta.keyAttestationRequirement {
+      XCTAssertEqual(preferredPeriod, 172800)
+    } else {
+      XCTFail("Expected .required case with preferredKeyStorageStatusPeriod")
+    }
+  }
+
+  func testProofTypesSupported_bothJwtAndAttestation() throws {
+    // Test that both jwt and attestation proof types support preferred_key_storage_status_period
+    let jsonData = """
+        {
+            "jwt": {
+                "proof_signing_alg_values_supported": ["ES256"],
+                "key_attestations_required": {
+                    "key_storage": ["iso_18045_high"],
+                    "user_authentication": ["iso_18045_moderate"],
+                    "preferred_key_storage_status_period": 86400
+                }
+            },
+            "attestation": {
+                "proof_signing_alg_values_supported": ["ES256"],
+                "key_attestations_required": {
+                    "key_storage": ["iso_18045_enhanced-basic"],
+                    "user_authentication": ["iso_18045_high"],
+                    "preferred_key_storage_status_period": 172800
+                }
+            }
+        }
+        """.data(using: .utf8)!
+
+    let decoder = JSONDecoder()
+    let proofTypesSupported = try decoder.decode([String: ProofTypeSupportedMeta].self, from: jsonData)
+
+    // Verify jwt proof type
+    XCTAssertNotNil(proofTypesSupported["jwt"])
+    if let jwtProofType = proofTypesSupported["jwt"],
+       case let .required(_, _, jwtPreferredPeriod) = jwtProofType.keyAttestationRequirement {
+      XCTAssertEqual(jwtPreferredPeriod, 86400)
+    } else {
+      XCTFail("Expected jwt proof type with preferred_key_storage_status_period")
+    }
+
+    // Verify attestation proof type
+    XCTAssertNotNil(proofTypesSupported["attestation"])
+    if let attestationProofType = proofTypesSupported["attestation"],
+       case let .required(_, _, attestationPreferredPeriod) = attestationProofType.keyAttestationRequirement {
+      XCTAssertEqual(attestationPreferredPeriod, 172800)
+    } else {
+      XCTFail("Expected attestation proof type with preferred_key_storage_status_period")
+    }
   }
 }

--- a/Tests/Issuance/IssuanceRefreshTokenTest.swift
+++ b/Tests/Issuance/IssuanceRefreshTokenTest.swift
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Foundation
+import XCTest
+
+@testable import OpenID4VCI
+
+class IssuanceRefreshTokenTest: XCTestCase {
+
+  let config: OpenId4VCIConfig = .init(
+    client: .public(id: WALLET_DEV_CLIENT_ID),
+    authFlowRedirectionURI: URL(string: "urn:ietf:wg:oauth:2.0:oob")!,
+    authorizeIssuanceConfig: .favorScopes
+  )
+
+  func testManualRefreshAccessTokenSuccess() async throws {
+
+    // Given
+    guard let offer = await TestsConstants.createMockCredentialOffer() else {
+      XCTFail("Unable to resolve credential offer")
+      return
+    }
+
+    // Create mock authorized request with refresh token
+    let originalAccessToken = try IssuanceAccessToken(
+      accessToken: "original_access_token",
+      tokenType: .init(value: "Bearer")
+    )
+    let refreshToken = try IssuanceRefreshToken(
+      refreshToken: "refresh_token_value",
+      expiresIn: 3600
+    )
+    let originalRequest = AuthorizedRequest(
+      accessToken: originalAccessToken,
+      refreshToken: refreshToken,
+      credentialIdentifiers: nil,
+      timeStamp: Date().timeIntervalSince1970,
+      dPopNonce: nil,
+      grantType: .authorizationCode
+    )
+
+    // Create issuer with mock token endpoint
+    let issuer = try Issuer(
+      authorizationServerMetadata: offer.authorizationServerMetadata,
+      issuerMetadata: offer.credentialIssuerMetadata,
+      config: config,
+      tokenPoster: Poster(
+        session: NetworkingMock(
+          path: "access_token_request_response",
+          extension: "json"
+        )
+      )
+    )
+
+    // When - using the new simplified refresh method
+    do {
+      let refreshedRequest = try await issuer.refresh(
+        authorizedRequest: originalRequest
+      )
+
+      // Then
+      XCTAssertNotNil(refreshedRequest.accessToken)
+      XCTAssertNotEqual(
+        refreshedRequest.accessToken.accessToken,
+        originalRequest.accessToken.accessToken,
+        "Access token should be refreshed"
+      )
+      XCTAssertNotEqual(
+        refreshedRequest.timeStamp,
+        originalRequest.timeStamp,
+        "Timestamp should be updated"
+      )
+    } catch {
+      XCTFail("Token refresh failed: \(error.localizedDescription)")
+    }
+  }
+
+  func testManualRefreshWithoutRefreshTokenReturnsOriginal() async throws {
+
+    // Given
+    guard let offer = await TestsConstants.createMockCredentialOffer() else {
+      XCTFail("Unable to resolve credential offer")
+      return
+    }
+
+    // Create authorized request WITHOUT refresh token
+    let originalAccessToken = try IssuanceAccessToken(
+      accessToken: "original_access_token",
+      tokenType: .init(value: "Bearer")
+    )
+    let originalRequest = AuthorizedRequest(
+      accessToken: originalAccessToken,
+      refreshToken: nil,  // No refresh token
+      credentialIdentifiers: nil,
+      timeStamp: Date().timeIntervalSince1970,
+      dPopNonce: nil,
+      grantType: .authorizationCode
+    )
+
+    let issuer = try Issuer(
+      authorizationServerMetadata: offer.authorizationServerMetadata,
+      issuerMetadata: offer.credentialIssuerMetadata,
+      config: config
+    )
+
+    // When
+    let refreshedRequest = try await issuer.refresh(
+      authorizedRequest: originalRequest
+    )
+
+    // Then - should return original request unchanged
+    XCTAssertEqual(
+      refreshedRequest.accessToken.accessToken,
+      originalRequest.accessToken.accessToken,
+      "Access token should remain unchanged when no refresh token is present"
+    )
+    XCTAssertEqual(
+      refreshedRequest.timeStamp,
+      originalRequest.timeStamp,
+      "Timestamp should remain unchanged when no refresh token is present"
+    )
+  }
+
+  func testManualRefreshWithDPoPNonce() async throws {
+
+    // Given
+    guard let offer = await TestsConstants.createMockCredentialOffer() else {
+      XCTFail("Unable to resolve credential offer")
+      return
+    }
+
+    let originalAccessToken = try IssuanceAccessToken(
+      accessToken: "original_access_token",
+      tokenType: .init(value: "Bearer")
+    )
+    let refreshToken = try IssuanceRefreshToken(
+      refreshToken: "refresh_token_value",
+      expiresIn: 3600
+    )
+    let originalRequest = AuthorizedRequest(
+      accessToken: originalAccessToken,
+      refreshToken: refreshToken,
+      credentialIdentifiers: nil,
+      timeStamp: Date().timeIntervalSince1970,
+      dPopNonce: nil,
+      grantType: .authorizationCode
+    )
+
+    let issuer = try Issuer(
+      authorizationServerMetadata: offer.authorizationServerMetadata,
+      issuerMetadata: offer.credentialIssuerMetadata,
+      config: config,
+      tokenPoster: Poster(
+        session: NetworkingMock(
+          path: "access_token_request_response",
+          extension: "json"
+        )
+      )
+    )
+
+    let dpopNonce = Nonce(value: "test_dpop_nonce")
+
+    // When - using refresh with explicit DPoP nonce
+    do {
+      let refreshedRequest = try await issuer.refresh(
+        authorizedRequest: originalRequest,
+        dPopNonce: dpopNonce
+      )
+
+      // Then
+      XCTAssertNotNil(refreshedRequest.accessToken)
+      // The refresh should succeed even with a DPoP nonce parameter
+    } catch {
+      XCTFail("Token refresh with DPoP nonce failed: \(error.localizedDescription)")
+    }
+  }
+}


### PR DESCRIPTION
# Description of change

This PR adds support for configuring proof types policy in the wallet, enabling HAIP v1 / ETSI TS 119 472-3 compliance for device-bound credentials.

New proofTypesPolicy parameter in OpenId4VCIConfig with three policy modes:

- .acceptAll (default) - Maintains backward compatibility, accepts any proof type
- .deviceBound(.haipCompliant()) - Enforces HAIP compliance, requires JWT with key attestation or attestation proofs
- .flexible(...) - Allows custom configuration for mixed credential types

Enhanced Security: Prevents wallets from accepting insecure simple JWT proofs without key attestation for device-bound credentials, as required by European digital identity standards.

Fully backward compatible - existing code continues to work unchanged with the default .acceptAll policy

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes