### PR TITLE
Add an option for a Wallet to configure supported Proof types

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ In particular, the library focuses on the wallet's role in the protocol to:
 | `attestation` proof type                                                                        | ✅                                                                                                                  |
 | `key_attestation` to the JWT Proof (JOSE header)                                                | ✅                                                                                                                  |
 | Wallet attestation                                                                              | ✅                                                                                                                  |
+| Proof Types Policy                                   | ✅                                                                                                                  |
 
 
 ## Disclaimer
@@ -288,6 +289,7 @@ public struct OpenId4VCIConfig: Sendable {
   public let dPoPConstructor: DPoPConstructorType?
   public let clientAttestationPoPBuilder: ClientAttestationPoPBuilder?
   public let issuerMetadataPolicy: IssuerMetadataPolicy
+  public let proofTypesPolicy: ProofTypesPolicy
 }
 ```
 
@@ -301,6 +303,27 @@ public struct OpenId4VCIConfig: Sendable {
 - `dPoPConstructor`: If dpop is supported this option constructs what is required.
 - `clientAttestationPoPBuilder`: If the authorization supports client attestations, this object constructs what is required.
 - `issuerMetadataPolicy`: Trust between the Wallet and the Signer of the signed metadata advertised by the Credential Issuer is established using this configuration option.
+- `proofTypesPolicy`: Policy defining which proof types the wallet supports. See [Proof Types Policy Configuration](#proof-types-policy-configuration) for details.
+
+### Proof Types Policy Configuration
+
+The library supports configuring which proof types your wallet will accept for credential issuance.
+
+#### Policy Options
+
+**1. Accept All (Default - Backward Compatible)**
+Accepts any proof type including simple JWT proofs without key attestation. Use for testing or legacy compatibility.
+
+**2. Device Bound (HAIP Compliant - Recommended for Production)**
+Enforces HAIP v1 / ETSI TS 119 472-3 compliance:
+- Accepts JWT proofs WITH key attestation
+- Accepts attestation proofs
+- Rejects simple JWT proofs without key attestation
+- Ensures device-bound credentials are properly secured with hardware-backed keys
+
+**3. Flexible Policy**
+Allows custom configuration supporting both device-bound and non-device-bound credentials.
+
 
 ## Features supported
 
@@ -369,10 +392,6 @@ can be requested using `authorization_details` or `scope` parameter when using a
 Though for `authorization_details` we don't support the `format` attribute and its specializations per format.
 Only `credential_configuration_id` attribute is supported.
 
-### Key attestations
-
-Current version of the library does not support [key attestations](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-15.html#appendix-D) 
-neither as a [proof type](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-15.html#section-8.2.1.3) nor as a `key_attestation` header in JWT proofs.
 
 ## How to contribute
 

--- a/Sources/Entities/Errors/CredentialIssuanceError.swift
+++ b/Sources/Entities/Errors/CredentialIssuanceError.swift
@@ -48,6 +48,12 @@ public enum CredentialIssuanceError: Error, LocalizedError {
   case proofTypeKeyAttestationRequired
   case combinationOfBindingKeys
   
+  case proofTypesNotSupportedByCredentialConfiguration
+  case proofTypeNotSupportedByWalletPolicy
+  case proofTypeJwtWithoutKeyAttestationNotAllowedByPolicy
+  case bindingKeyNotAttestationCapable
+  case noMatchingAlgorithmForProofType
+  
   public var errorDescription: String? {
     switch self {
     case .pushedAuthorizationRequestFailed(_, let errorDescription),
@@ -109,6 +115,16 @@ public enum CredentialIssuanceError: Error, LocalizedError {
       return "Proof type key attestation required."
     case .combinationOfBindingKeys:
       return "Combination of binding keys"
+    case .proofTypesNotSupportedByCredentialConfiguration:
+      return "Credential configuration does not support proof types required by wallet policy."
+    case .proofTypeNotSupportedByWalletPolicy:
+      return "The credential configuration requires a proof type that is not supported by the wallet's policy."
+    case .proofTypeJwtWithoutKeyAttestationNotAllowedByPolicy:
+      return "The credential configuration requires JWT proof without key attestation, which is not allowed by the wallet's policy."
+    case .bindingKeyNotAttestationCapable:
+      return "The binding key is not attestation-capable but the credential configuration or wallet policy requires key attestation."
+    case .noMatchingAlgorithmForProofType:
+      return "No matching cryptographic algorithm found between wallet policy and credential configuration for the required proof type."
     }
   }
 }

--- a/Sources/Entities/Wallet/Config.swift
+++ b/Sources/Entities/Wallet/Config.swift
@@ -56,6 +56,13 @@ public struct OpenId4VCIConfig: Sendable {
   /// Dpop requirement, if required by wallet and not supported by issuer, halt the issuance process
   public let requireDpop: Bool
   
+  /// Policy defining which proof types the wallet supports.
+  /// Wallets should reject credentials that require plain JWT proofs without key attestation
+  /// for device-bound attestations.
+  ///
+  /// Default is `.acceptAll` for backward compatibility.
+  public let proofTypesPolicy: ProofTypesPolicy
+  
   /// Initializes an `OpenId4VCIConfig` instance with the given parameters.
   /// - Parameters:
   ///   - client: The client used for OpenID4VCI operations.
@@ -65,6 +72,7 @@ public struct OpenId4VCIConfig: Sendable {
   ///   - clientAttestationPoPBuilder: An optional client attestation PoP builder (default: `nil`).
   ///   - issuerMetadataPolicy: Policy defining how issuer metadata should be handled (default: `.ignoreSigned`).
   ///   - requireDpop: If dpop is supported then use it, otherwise always don't
+  ///   - proofTypesPolicy: Policy defining which proof types the wallet supports (default: `.acceptAll`).
   public init(
     client: Client,
     authFlowRedirectionURI: URL,
@@ -73,7 +81,8 @@ public struct OpenId4VCIConfig: Sendable {
     clientAttestationPoPBuilder: ClientAttestationPoPBuilder? = nil,
     issuerMetadataPolicy: IssuerMetadataPolicy = .ignoreSigned,
     supportedCompressionAlgorithms: [CompressionAlgorithm]? = nil,
-    requireDpop: Bool = true
+    requireDpop: Bool = true,
+    proofTypesPolicy: ProofTypesPolicy = .acceptAll
   ) {
     self.client = client
     self.authFlowRedirectionURI = authFlowRedirectionURI
@@ -83,5 +92,6 @@ public struct OpenId4VCIConfig: Sendable {
     self.issuerMetadataPolicy = issuerMetadataPolicy
     self.supportedCompressionAlgorithms = supportedCompressionAlgorithms
     self.requireDpop = requireDpop
+    self.proofTypesPolicy = proofTypesPolicy
   }
 }

--- a/Sources/Entities/Wallet/ProofTypesPolicy.swift
+++ b/Sources/Entities/Wallet/ProofTypesPolicy.swift
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Foundation
+import JOSESwift
+
+/// Policy defining which proof types the wallet supports for credential issuance.
+///
+/// For device-bound attestations, proofs of type JWT cannot be used alone
+/// - Wallet must use either:
+///   - Proof of type `attestation`
+///   - Proof of type `jwt` + `key_attestation`
+/// - Plain JWT proofs (without key_attestation) are not allowed for device-bound credentials
+public enum ProofTypesPolicy: Sendable {
+  /// Default policy: accepts any proof type including plain JWT without key attestation.
+  /// This is the legacy behavior for backward compatibility.
+  case acceptAll
+
+  /// Rejects credential configurations that require plain JWT proofs without key attestation.
+  /// - Parameter policy: The device-bound proof policy specifying supported algorithms and proof types.
+  case deviceBound(DeviceBoundProofPolicy)
+
+  /// Flexible policy: supports both device-bound and non-device-bound attestations.
+  /// - Parameters:
+  ///   - deviceBound: Policy for device-bound credentials
+  ///   - allowNonDeviceBound: Whether to allow non-device-bound credentials (no proofs required)
+  case flexible(deviceBound: DeviceBoundProofPolicy, allowNonDeviceBound: Bool)
+}
+
+/// Policy configuration for device-bound proof types.
+public struct DeviceBoundProofPolicy: Sendable {
+  public let supportedAlgorithms: [JWSAlgorithm]
+  public let supportedProofTypes: Set<DeviceBoundProofType>
+
+  public init(
+    supportedAlgorithms: [JWSAlgorithm],
+    supportedProofTypes: Set<DeviceBoundProofType>
+  ) {
+    self.supportedAlgorithms = supportedAlgorithms
+    self.supportedProofTypes = supportedProofTypes
+  }
+
+  /// Creates a HAIP compliant policy.
+  /// This policy only accepts JWT with key attestation or attestation proofs.
+  /// - Parameter algorithms: Supported signing algorithms. Defaults to ES256.
+  /// - Returns: A compliant device-bound proof policy.
+  public static func haipCompliant(
+    algorithms: [JWSAlgorithm] = [JWSAlgorithm(.ES256)]
+  ) -> DeviceBoundProofPolicy {
+    return DeviceBoundProofPolicy(
+      supportedAlgorithms: algorithms,
+      supportedProofTypes: [.jwtWithKeyAttestation, .attestation]
+    )
+  }
+}
+
+/// Types of proofs for device-bound credentials.
+public enum DeviceBoundProofType: String, Hashable, Sendable {
+  
+  case jwtWithoutKeyAttestation = "jwt_without_key_attestation"
+  case jwtWithKeyAttestation = "jwt_with_key_attestation"
+  case attestation = "attestation"
+}
+
+// MARK: - Validation
+
+public extension ProofTypesPolicy {
+
+  /// Validates whether a credential configuration is compatible with this policy.
+  ///
+  /// - Parameters:
+  ///   - credentialConfiguration: The credential configuration to validate.
+  ///   - bindingKey: The binding key that will be used for the proof.
+  /// - Throws: `CredentialIssuanceError` if the configuration violates the policy.
+  func validate(
+    credentialConfiguration: CredentialSupported,
+    bindingKey: BindingKey
+  ) throws {
+    switch self {
+    case .acceptAll:
+      // Accept everything - no validation needed
+      return
+
+    case .deviceBound(let policy):
+      try validateDeviceBound(
+        credentialConfiguration: credentialConfiguration,
+        policy: policy,
+        bindingKey: bindingKey,
+        allowNonDeviceBound: false
+      )
+
+    case .flexible(let policy, let allowNonDeviceBound):
+      try validateDeviceBound(
+        credentialConfiguration: credentialConfiguration,
+        policy: policy,
+        bindingKey: bindingKey,
+        allowNonDeviceBound: allowNonDeviceBound
+      )
+    }
+  }
+
+  private func validateDeviceBound(
+    credentialConfiguration: CredentialSupported,
+    policy: DeviceBoundProofPolicy,
+    bindingKey: BindingKey,
+    allowNonDeviceBound: Bool
+  ) throws {
+    guard let proofTypesSupported = credentialConfiguration.proofTypesSupported else {
+      if allowNonDeviceBound {
+        return
+      } else {
+        throw CredentialIssuanceError.proofTypesNotSupportedByCredentialConfiguration
+      }
+    }
+
+    if let jwtProofMeta = proofTypesSupported["jwt"] {
+      try validateJwtProof(
+        jwtProofMeta: jwtProofMeta,
+        policy: policy,
+        bindingKey: bindingKey
+      )
+    }
+
+    if let attestationProofMeta = proofTypesSupported["attestation"] {
+      try validateAttestationProof(
+        attestationProofMeta: attestationProofMeta,
+        policy: policy,
+        bindingKey: bindingKey
+      )
+    }
+  }
+
+  private func validateJwtProof(
+    jwtProofMeta: ProofTypeSupportedMeta,
+    policy: DeviceBoundProofPolicy,
+    bindingKey: BindingKey
+  ) throws {
+    
+    let hasMatchingAlgorithm = jwtProofMeta.algorithms.contains { issuerAlg in
+      policy.supportedAlgorithms.contains { walletAlg in
+        walletAlg.name == issuerAlg
+      }
+    }
+
+    guard hasMatchingAlgorithm else {
+      throw CredentialIssuanceError.noMatchingAlgorithmForProofType
+    }
+
+    // Determine if key attestation is required
+    let keyAttestationRequired = jwtProofMeta.keyAttestationRequirement != nil &&
+                                 jwtProofMeta.keyAttestationRequirement != .notRequired
+
+    if keyAttestationRequired {
+      // Issuer requires key attestation - check if wallet policy supports it
+      guard policy.supportedProofTypes.contains(.jwtWithKeyAttestation) else {
+        throw CredentialIssuanceError.proofTypeNotSupportedByWalletPolicy
+      }
+
+      // Check if the binding key is attestation-capable
+      guard bindingKey.isAttestationCapable else {
+        throw CredentialIssuanceError.bindingKeyNotAttestationCapable
+      }
+    } else {
+      // Issuer allows plain JWT without key attestation
+      // Check if wallet policy allows this
+      guard policy.supportedProofTypes.contains(.jwtWithoutKeyAttestation) else {
+        throw CredentialIssuanceError.proofTypeJwtWithoutKeyAttestationNotAllowedByPolicy
+      }
+    }
+  }
+
+  private func validateAttestationProof(
+    attestationProofMeta: ProofTypeSupportedMeta,
+    policy: DeviceBoundProofPolicy,
+    bindingKey: BindingKey
+  ) throws {
+    guard policy.supportedProofTypes.contains(.attestation) else {
+      throw CredentialIssuanceError.proofTypeNotSupportedByWalletPolicy
+    }
+
+    guard bindingKey.isAttestationCapable else {
+      throw CredentialIssuanceError.bindingKeyNotAttestationCapable
+    }
+
+    let hasMatchingAlgorithm = attestationProofMeta.algorithms.contains { issuerAlg in
+      policy.supportedAlgorithms.contains { walletAlg in
+        walletAlg.name == issuerAlg
+      }
+    }
+
+    guard hasMatchingAlgorithm else {
+      throw CredentialIssuanceError.noMatchingAlgorithmForProofType
+    }
+  }
+}

--- a/Sources/Issuers/Issuer.swift
+++ b/Sources/Issuers/Issuer.swift
@@ -484,6 +484,13 @@ private extension Issuer {
       throw ValidationError.error(reason: "Invalid Supported credential for requestSingle")
     }
     
+    for bindingKey in bindingKeys {
+      try config.proofTypesPolicy.validate(
+        credentialConfiguration: supportedCredential,
+        bindingKey: bindingKey
+      )
+    }
+
     let proofs = try await obtainProofs(
       authorizedRequest: authorizedRequest,
       batchCredentialIssuance: issuerMetadata.batchCredentialIssuance,
@@ -519,6 +526,13 @@ private extension Issuer {
     guard let supportedCredential = issuerMetadata
       .credentialsSupported[credentialConfigurationIdentifier] else {
       throw ValidationError.error(reason: "Invalid Supported credential for requestSingle")
+    }
+    
+    for bindingKey in bindingKeys {
+      try config.proofTypesPolicy.validate(
+        credentialConfiguration: supportedCredential,
+        bindingKey: bindingKey
+      )
     }
     
     let proofs = try await obtainProofs(

--- a/Tests/Entities/ProofTypesPolicyTests.swift
+++ b/Tests/Entities/ProofTypesPolicyTests.swift
@@ -1,0 +1,461 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import XCTest
+import JOSESwift
+
+@testable import OpenID4VCI
+
+final class ProofTypesPolicyTests: XCTestCase {
+
+  // MARK: - Policy Creation Tests
+
+  func testAcceptAllPolicy() throws {
+    let policy = ProofTypesPolicy.acceptAll
+
+    // Create a test credential configuration that requires JWT without key attestation
+    let proofTypesSupported: [String: ProofTypeSupportedMeta] = [
+      "jwt": ProofTypeSupportedMeta(
+        algorithms: ["ES256"],
+        keyAttestationRequirement: .notRequired
+      )
+    ]
+    let credentialConfig = createTestCredentialConfiguration(proofTypesSupported: proofTypesSupported)
+
+    // Create a plain JWT binding key
+    let bindingKey = try createJwtBindingKey()
+
+    // Should not throw with acceptAll policy
+    XCTAssertNoThrow(try policy.validate(
+      credentialConfiguration: credentialConfig,
+      bindingKey: bindingKey
+    ))
+  }
+
+  func testHaipCompliantPolicy() throws {
+    let policy = DeviceBoundProofPolicy.haipCompliant()
+
+    XCTAssertEqual(policy.supportedAlgorithms.count, 1)
+    XCTAssertEqual(policy.supportedAlgorithms.first?.name, "ES256")
+    XCTAssertTrue(policy.supportedProofTypes.contains(.jwtWithKeyAttestation))
+    XCTAssertTrue(policy.supportedProofTypes.contains(.attestation))
+    XCTAssertFalse(policy.supportedProofTypes.contains(.jwtWithoutKeyAttestation))
+  }
+
+  func testDeviceBoundPolicyCreation() throws {
+    let policy = DeviceBoundProofPolicy(
+      supportedAlgorithms: [JWSAlgorithm(.ES256), JWSAlgorithm(.ES384)],
+      supportedProofTypes: [.jwtWithKeyAttestation, .attestation]
+    )
+
+    XCTAssertEqual(policy.supportedAlgorithms.count, 2)
+    XCTAssertTrue(policy.supportedAlgorithms.contains(where: { $0.name == "ES256" }))
+    XCTAssertTrue(policy.supportedAlgorithms.contains(where: { $0.name == "ES384" }))
+    XCTAssertEqual(policy.supportedProofTypes.count, 2)
+  }
+
+  // MARK: - Validation Tests - JWT Without Key Attestation
+
+  func testDeviceBoundPolicy_RejectsJwtWithoutKeyAttestation() throws {
+    let deviceBoundPolicy = DeviceBoundProofPolicy(
+      supportedAlgorithms: [JWSAlgorithm(.ES256)],
+      supportedProofTypes: [.jwtWithKeyAttestation, .attestation]
+    )
+    let policy = ProofTypesPolicy.deviceBound(deviceBoundPolicy)
+
+    // Credential requires JWT without key attestation
+    let proofTypesSupported: [String: ProofTypeSupportedMeta] = [
+      "jwt": ProofTypeSupportedMeta(
+        algorithms: ["ES256"],
+        keyAttestationRequirement: .notRequired
+      )
+    ]
+    let credentialConfig = createTestCredentialConfiguration(proofTypesSupported: proofTypesSupported)
+    let bindingKey = try createJwtBindingKey()
+
+    // Should throw because policy doesn't support JWT without key attestation
+    XCTAssertThrowsError(try policy.validate(
+      credentialConfiguration: credentialConfig,
+      bindingKey: bindingKey
+    )) { error in
+      guard let issuanceError = error as? CredentialIssuanceError else {
+        XCTFail("Expected CredentialIssuanceError")
+        return
+      }
+      if case .proofTypeJwtWithoutKeyAttestationNotAllowedByPolicy = issuanceError {
+        // Expected error
+      } else {
+        XCTFail("Expected proofTypeJwtWithoutKeyAttestationNotAllowedByPolicy error")
+      }
+    }
+  }
+
+  func testAcceptAllPolicy_AcceptsJwtWithoutKeyAttestation() throws {
+    let policy = ProofTypesPolicy.acceptAll
+
+    // Credential requires JWT without key attestation
+    let proofTypesSupported: [String: ProofTypeSupportedMeta] = [
+      "jwt": ProofTypeSupportedMeta(
+        algorithms: ["ES256"],
+        keyAttestationRequirement: .notRequired
+      )
+    ]
+    let credentialConfig = createTestCredentialConfiguration(proofTypesSupported: proofTypesSupported)
+    let bindingKey = try createJwtBindingKey()
+
+    // Should not throw with acceptAll policy
+    XCTAssertNoThrow(try policy.validate(
+      credentialConfiguration: credentialConfig,
+      bindingKey: bindingKey
+    ))
+  }
+
+  // MARK: - Validation Tests - JWT With Key Attestation
+
+  func testDeviceBoundPolicy_AcceptsJwtWithKeyAttestation() throws {
+    let deviceBoundPolicy = DeviceBoundProofPolicy(
+      supportedAlgorithms: [JWSAlgorithm(.ES256)],
+      supportedProofTypes: [.jwtWithKeyAttestation]
+    )
+    let policy = ProofTypesPolicy.deviceBound(deviceBoundPolicy)
+
+    // Credential requires JWT with key attestation
+    let proofTypesSupported: [String: ProofTypeSupportedMeta] = [
+      "jwt": ProofTypeSupportedMeta(
+        algorithms: ["ES256"],
+        keyAttestationRequirement: .required(
+          keyStorageConstraints: [.iso18045High],
+          userAuthenticationConstraints: [.iso18045Moderate],
+          preferredKeyStorageStatusPeriod: nil
+        )
+      )
+    ]
+    let credentialConfig = createTestCredentialConfiguration(proofTypesSupported: proofTypesSupported)
+    let bindingKey = try createJwtKeyAttestationBindingKey()
+
+    // Should not throw
+    XCTAssertNoThrow(try policy.validate(
+      credentialConfiguration: credentialConfig,
+      bindingKey: bindingKey
+    ))
+  }
+
+  func testDeviceBoundPolicy_RejectsJwtWithKeyAttestation_WhenNotInSupportedProofTypes() throws {
+    let deviceBoundPolicy = DeviceBoundProofPolicy(
+      supportedAlgorithms: [JWSAlgorithm(.ES256)],
+      supportedProofTypes: [.attestation] // Only attestation, not JWT with key attestation
+    )
+    let policy = ProofTypesPolicy.deviceBound(deviceBoundPolicy)
+
+    // Credential requires JWT with key attestation
+    let proofTypesSupported: [String: ProofTypeSupportedMeta] = [
+      "jwt": ProofTypeSupportedMeta(
+        algorithms: ["ES256"],
+        keyAttestationRequirement: .required(
+          keyStorageConstraints: [.iso18045High],
+          userAuthenticationConstraints: [.iso18045Moderate],
+          preferredKeyStorageStatusPeriod: nil
+        )
+      )
+    ]
+    let credentialConfig = createTestCredentialConfiguration(proofTypesSupported: proofTypesSupported)
+    let bindingKey = try createJwtKeyAttestationBindingKey()
+
+    // Should throw because policy doesn't support JWT with key attestation
+    XCTAssertThrowsError(try policy.validate(
+      credentialConfiguration: credentialConfig,
+      bindingKey: bindingKey
+    )) { error in
+      guard let issuanceError = error as? CredentialIssuanceError else {
+        XCTFail("Expected CredentialIssuanceError")
+        return
+      }
+      if case .proofTypeNotSupportedByWalletPolicy = issuanceError {
+        // Expected error
+      } else {
+        XCTFail("Expected proofTypeNotSupportedByWalletPolicy error")
+      }
+    }
+  }
+
+  func testDeviceBoundPolicy_RejectsJwtWithKeyAttestation_WhenBindingKeyNotAttestationCapable() throws {
+    let deviceBoundPolicy = DeviceBoundProofPolicy(
+      supportedAlgorithms: [JWSAlgorithm(.ES256)],
+      supportedProofTypes: [.jwtWithKeyAttestation]
+    )
+    let policy = ProofTypesPolicy.deviceBound(deviceBoundPolicy)
+
+    // Credential requires JWT with key attestation
+    let proofTypesSupported: [String: ProofTypeSupportedMeta] = [
+      "jwt": ProofTypeSupportedMeta(
+        algorithms: ["ES256"],
+        keyAttestationRequirement: .required(
+          keyStorageConstraints: [.iso18045High],
+          userAuthenticationConstraints: [.iso18045Moderate],
+          preferredKeyStorageStatusPeriod: nil
+        )
+      )
+    ]
+    let credentialConfig = createTestCredentialConfiguration(proofTypesSupported: proofTypesSupported)
+    // Use a plain JWT binding key (not attestation-capable)
+    let bindingKey = try createJwtBindingKey()
+
+    // Should throw because binding key is not attestation-capable
+    XCTAssertThrowsError(try policy.validate(
+      credentialConfiguration: credentialConfig,
+      bindingKey: bindingKey
+    )) { error in
+      guard let issuanceError = error as? CredentialIssuanceError else {
+        XCTFail("Expected CredentialIssuanceError")
+        return
+      }
+      if case .bindingKeyNotAttestationCapable = issuanceError {
+        // Expected error
+      } else {
+        XCTFail("Expected bindingKeyNotAttestationCapable error")
+      }
+    }
+  }
+
+  // MARK: - Validation Tests - Attestation Proof Type
+
+  func testDeviceBoundPolicy_AcceptsAttestationProof() throws {
+    let deviceBoundPolicy = DeviceBoundProofPolicy(
+      supportedAlgorithms: [JWSAlgorithm(.ES256)],
+      supportedProofTypes: [.attestation]
+    )
+    let policy = ProofTypesPolicy.deviceBound(deviceBoundPolicy)
+
+    // Credential requires attestation proof
+    let proofTypesSupported: [String: ProofTypeSupportedMeta] = [
+      "attestation": ProofTypeSupportedMeta(
+        algorithms: ["ES256"],
+        keyAttestationRequirement: nil
+      )
+    ]
+    let credentialConfig = createTestCredentialConfiguration(proofTypesSupported: proofTypesSupported)
+    let bindingKey = try createAttestationBindingKey()
+
+    // Should not throw
+    XCTAssertNoThrow(try policy.validate(
+      credentialConfiguration: credentialConfig,
+      bindingKey: bindingKey
+    ))
+  }
+
+  func testDeviceBoundPolicy_RejectsAttestationProof_WhenNotInSupportedProofTypes() throws {
+    let deviceBoundPolicy = DeviceBoundProofPolicy(
+      supportedAlgorithms: [JWSAlgorithm(.ES256)],
+      supportedProofTypes: [.jwtWithKeyAttestation] // Only JWT with key attestation
+    )
+    let policy = ProofTypesPolicy.deviceBound(deviceBoundPolicy)
+
+    // Credential requires attestation proof
+    let proofTypesSupported: [String: ProofTypeSupportedMeta] = [
+      "attestation": ProofTypeSupportedMeta(
+        algorithms: ["ES256"],
+        keyAttestationRequirement: nil
+      )
+    ]
+    let credentialConfig = createTestCredentialConfiguration(proofTypesSupported: proofTypesSupported)
+    let bindingKey = try createAttestationBindingKey()
+
+    // Should throw because policy doesn't support attestation proofs
+    XCTAssertThrowsError(try policy.validate(
+      credentialConfiguration: credentialConfig,
+      bindingKey: bindingKey
+    )) { error in
+      guard let issuanceError = error as? CredentialIssuanceError else {
+        XCTFail("Expected CredentialIssuanceError")
+        return
+      }
+      if case .proofTypeNotSupportedByWalletPolicy = issuanceError {
+        // Expected error
+      } else {
+        XCTFail("Expected proofTypeNotSupportedByWalletPolicy error")
+      }
+    }
+  }
+
+  // MARK: - Algorithm Matching Tests
+
+  func testDeviceBoundPolicy_RejectsWhenNoMatchingAlgorithm() throws {
+    let deviceBoundPolicy = DeviceBoundProofPolicy(
+      supportedAlgorithms: [JWSAlgorithm(.ES384)], // Only ES384
+      supportedProofTypes: [.jwtWithKeyAttestation]
+    )
+    let policy = ProofTypesPolicy.deviceBound(deviceBoundPolicy)
+
+    // Credential requires ES256
+    let proofTypesSupported: [String: ProofTypeSupportedMeta] = [
+      "jwt": ProofTypeSupportedMeta(
+        algorithms: ["ES256"], // Different algorithm
+        keyAttestationRequirement: .required(
+          keyStorageConstraints: [.iso18045High],
+          userAuthenticationConstraints: [.iso18045Moderate],
+          preferredKeyStorageStatusPeriod: nil
+        )
+      )
+    ]
+    let credentialConfig = createTestCredentialConfiguration(proofTypesSupported: proofTypesSupported)
+    let bindingKey = try createJwtKeyAttestationBindingKey()
+
+    // Should throw because no matching algorithm
+    XCTAssertThrowsError(try policy.validate(
+      credentialConfiguration: credentialConfig,
+      bindingKey: bindingKey
+    )) { error in
+      guard let issuanceError = error as? CredentialIssuanceError else {
+        XCTFail("Expected CredentialIssuanceError")
+        return
+      }
+      if case .noMatchingAlgorithmForProofType = issuanceError {
+        // Expected error
+      } else {
+        XCTFail("Expected noMatchingAlgorithmForProofType error")
+      }
+    }
+  }
+
+  // MARK: - Flexible Policy Tests
+
+  func testFlexiblePolicy_AllowsNonDeviceBound() throws {
+    let deviceBoundPolicy = DeviceBoundProofPolicy(
+      supportedAlgorithms: [JWSAlgorithm(.ES256)],
+      supportedProofTypes: [.jwtWithKeyAttestation]
+    )
+    let policy = ProofTypesPolicy.flexible(
+      deviceBound: deviceBoundPolicy,
+      allowNonDeviceBound: true
+    )
+
+    // Credential without proof types (non-device-bound)
+    let credentialConfig = createTestCredentialConfiguration(proofTypesSupported: nil)
+    let bindingKey = try createJwtBindingKey()
+
+    // Should not throw because non-device-bound is allowed
+    XCTAssertNoThrow(try policy.validate(
+      credentialConfiguration: credentialConfig,
+      bindingKey: bindingKey
+    ))
+  }
+
+  func testFlexiblePolicy_RejectsNonDeviceBound_WhenNotAllowed() throws {
+    let deviceBoundPolicy = DeviceBoundProofPolicy(
+      supportedAlgorithms: [JWSAlgorithm(.ES256)],
+      supportedProofTypes: [.jwtWithKeyAttestation]
+    )
+    let policy = ProofTypesPolicy.flexible(
+      deviceBound: deviceBoundPolicy,
+      allowNonDeviceBound: false
+    )
+
+    // Credential without proof types (non-device-bound)
+    let credentialConfig = createTestCredentialConfiguration(proofTypesSupported: nil)
+    let bindingKey = try createJwtBindingKey()
+
+    // Should throw because non-device-bound is not allowed
+    XCTAssertThrowsError(try policy.validate(
+      credentialConfiguration: credentialConfig,
+      bindingKey: bindingKey
+    )) { error in
+      guard let issuanceError = error as? CredentialIssuanceError else {
+        XCTFail("Expected CredentialIssuanceError")
+        return
+      }
+      if case .proofTypesNotSupportedByCredentialConfiguration = issuanceError {
+        // Expected error
+      } else {
+        XCTFail("Expected proofTypesNotSupportedByCredentialConfiguration error")
+      }
+    }
+  }
+
+  // MARK: - Helper Methods
+
+  private func createTestCredentialConfiguration(
+    proofTypesSupported: [String: ProofTypeSupportedMeta]?
+  ) -> CredentialSupported {
+    let credentialDefinition = SdJwtVcFormat.CredentialDefinition(
+      type: "VerifiableCredential",
+      claims: []
+    )
+
+    let config = SdJwtVcFormat.CredentialConfiguration(
+      scope: nil,
+      vct: "test_vct",
+      cryptographicBindingMethodsSupported: [],
+      credentialSigningAlgValuesSupported: [],
+      proofTypesSupported: proofTypesSupported,
+      credentialMetadata: nil,
+      credentialDefinition: credentialDefinition
+    )
+    return .sdJwtVc(config)
+  }
+
+  private func createJwtBindingKey() throws -> BindingKey {
+    let privateKey = try KeyController.generateECDHPrivateKey()
+    let publicKey = try KeyController.generateECDHPublicKey(from: privateKey)
+    let jwk = try ECPublicKey(
+      publicKey: publicKey,
+      additionalParameters: [
+        "use": "sig",
+        "kid": "test-key-1",
+        "alg": JWSAlgorithm(.ES256).name
+      ]
+    )
+
+    return .jwt(
+      algorithm: JWSAlgorithm(.ES256),
+      jwk: jwk,
+      privateKey: .secKey(privateKey),
+      issuer: nil
+    )
+  }
+
+  private func createJwtKeyAttestationBindingKey() throws -> BindingKey {
+    let privateKey = try KeyController.generateECDHPrivateKey()
+
+    // Mock compact JWS string for testing
+    let mockJWSString = "eyJhbGciOiJFUzI1NiIsInR5cCI6ImtleS1hdHRlc3RhdGlvbitqd3QifQ.eyJ0ZXN0IjoiZGF0YSJ9.mock_signature"
+
+    return .jwtKeyAttestation(
+      algorithm: JWSAlgorithm(.ES256),
+      keyAttestationJWT: { _ in
+        // Mock key attestation JWT using compact serialization
+        try KeyAttestationJWT(
+          jws: JWS(compactSerialization: mockJWSString)
+        )
+      },
+      keyIndex: 0,
+      privateKey: .secKey(privateKey),
+      issuer: nil
+    )
+  }
+
+  private func createAttestationBindingKey() throws -> BindingKey {
+    // Mock compact JWS string for testing
+    let mockJWSString = "eyJhbGciOiJFUzI1NiIsInR5cCI6ImtleS1hdHRlc3RhdGlvbitqd3QifQ.eyJ0ZXN0IjoiZGF0YSJ9.mock_signature"
+
+    return .attestation(
+      keyAttestationJWT: { _ in
+        // Mock key attestation JWT using compact serialization
+        try KeyAttestationJWT(
+          jws: JWS(compactSerialization: mockJWSString)
+        )
+      }
+    )
+  }
+}


### PR DESCRIPTION
# Description of change

This PR adds support for configuring proof types policy in the wallet, enabling HAIP v1 / ETSI TS 119 472-3 compliance for device-bound credentials.

New proofTypesPolicy parameter in OpenId4VCIConfig with three policy modes:

- .acceptAll (default) - Maintains backward compatibility, accepts any proof type
- .deviceBound(.haipCompliant()) - Enforces HAIP compliance, requires JWT with key attestation or attestation proofs
- .flexible(...) - Allows custom configuration for mixed credential types

Enhanced Security: Prevents wallets from accepting insecure simple JWT proofs without key attestation for device-bound credentials, as required by European digital identity standards.

Fully backward compatible - existing code continues to work unchanged with the default .acceptAll policy

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Closes #236 