### PR TITLE
Credential reuse policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ In particular, the library focuses on the wallet's role in the protocol to:
 | `attestation` proof type                                                                        | ✅                                                                                                                  |
 | `key_attestation` to the JWT Proof (JOSE header)                                                | ✅                                                                                                                  |
 | Wallet attestation                                                                              | ✅                                                                                                                  |
+| Credential Reuse Policy (ETSI TS 119 472-3 / ARF Annex II)                                      | ✅                                                                                                                  |
 
 
 ## Disclaimer
@@ -329,6 +330,94 @@ interactions use the newly provided DPoP Nonce value.
 Library supports [OAUTH2 Attestation-Based Client Authentication - Draft 03](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-03.html)
 
 An example can be found in this test: `testNoOfferSdJWTClientAuthentication()`
+
+### Credential Reuse Policy
+
+The library supports **Credential Reuse Policies** according to **ETSI TS 119 472-3** and **ARF Annex II** specifications, fully aligned with the Android implementation.
+
+#### What is a Credential Reuse Policy?
+
+Credential reuse policies define how many times and under what conditions a verifiable credential can be presented to relying parties. This enables issuers to control credential usage patterns for security and privacy purposes.
+
+#### Supported Reuse Methods
+
+The library supports all 4 ARF Annex II reuse policy methods:
+
+1. **Method A - Once Only** (`once_only`): Credential can only be presented once
+2. **Method B - Limited Time** (`limited_time`): Credential can be presented unlimited times until expiry
+3. **Method C - Rotating Batch** (`rotating-batch`): Issue batch of credentials, trigger reissuance based on unused count or time
+4. **Method D - Per Relying Party** (`per-relying-party`): Issue batch with one credential per relying party
+
+#### Wallet Configuration
+
+Configure the wallet's reuse policy support using `SupportedCredentialReusePolicies`:
+
+```swift
+// Option 1: Wallet supports policies but doesn't require them
+let walletConfig = SupportedCredentialReusePolicies.supported([
+  .onceOnly,
+  .rotatingBatch,
+  .limitedTime
+])
+
+// Option 2: Wallet requires issuer to provide a matching policy
+let walletConfig = SupportedCredentialReusePolicies.required([
+  .rotatingBatch
+])
+
+// Option 3: Wallet doesn't support reuse policies at all
+let walletConfig = SupportedCredentialReusePolicies.notSupported
+```
+
+#### Policy Selection and Validation
+
+The library automatically handles policy matching between issuer and wallet:
+
+```swift
+import OpenID4VCI
+
+// Issuer metadata contains reuse policy (parsed automatically)
+let issuerMetadata: CredentialIssuerMetadata = ...
+
+// Select matching policy
+let selectedPolicy = try CredentialReusePolicyValidator.selectMatchingPolicy(
+  issuerPolicy: issuerMetadata.credentialReusePolicy,
+  walletSupported: walletConfig
+)
+
+// Determine batch size (policy takes priority over metadata)
+let batchSize = CredentialReusePolicyValidator.determineBatchSize(
+  selectedPolicy: selectedPolicy,
+  issuerBatchSize: issuerMetadata.batchCredentialIssuance
+)
+
+// Validate proof count matches batch size
+try CredentialReusePolicyValidator.validateProofCount(
+  proofCount: proofs.count,
+  requiredBatchSize: batchSize
+)
+```
+
+#### Behavior Matrix
+
+| Wallet Config | Issuer Has Policy | Result |
+|---------------|-------------------|--------|
+| `.supported([...])` | No | Returns `nil`, continues normally |
+| `.supported([...])` | Yes, matches | Returns matching policy |
+| `.supported([...])` | Yes, no match | Throws `noSupportedPolicyFound` |
+| `.required([...])` | No | Throws `noSupportedPolicyFound` |
+| `.required([...])` | Yes, matches | Returns matching policy |
+| `.required([...])` | Yes, no match | Throws `noSupportedPolicyFound` |
+| `.notSupported` | No | Returns `nil`, continues normally |
+| `.notSupported` | Yes | Returns `nil`, ignores policy |
+
+#### Batch Issuance
+
+When a reuse policy requires batch issuance, the library handles it automatically:
+
+- Policy `batch_size` takes priority over issuer metadata `batch_credential_issuance`
+- Multiple proofs must be generated (one per credential in batch)
+- Proof count validation ensures correct number of proofs
 
 #### Notes
 

--- a/Sources/Entities/CredentialReuse/CredentialReusePolicy.swift
+++ b/Sources/Entities/CredentialReuse/CredentialReusePolicy.swift
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Foundation
+
+/// Controls how attestations should be re-used when presented to relying parties
+public struct CredentialReusePolicy: Sendable, Equatable {
+
+  public let id: String
+  public let options: [ReusePolicy]
+
+  public init(id: String, options: [ReusePolicy]) {
+    self.id = id
+    self.options = options
+  }
+}
+
+extension CredentialReusePolicy: Codable {
+
+  enum CodingKeys: String, CodingKey {
+    case id
+    case options
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+
+    id = try container.decode(String.self, forKey: .id)
+
+
+    let jsonOptions = try container.decode([ReusePolicyOption].self, forKey: .options)
+    var expandedPolicies: [ReusePolicy] = []
+
+    for jsonOption in jsonOptions {
+      let policies = try ReusePolicy.fromDetails(
+        details: jsonOption.details,
+        batchSize: jsonOption.batchSize,
+        reissueTriggerUnused: jsonOption.reissueTriggerUnused,
+        reissueTriggerLifetimeLeft: jsonOption.reissueTriggerLifetimeLeft
+      )
+      expandedPolicies.append(contentsOf: policies)
+    }
+
+    guard !expandedPolicies.isEmpty else {
+      throw CredentialReusePolicyError.invalidPolicyStructure("options array cannot be empty after expansion")
+    }
+
+    options = expandedPolicies
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(id, forKey: .id)
+
+    // Convert each ReusePolicy to a ReusePolicyOption with single-element details array
+    let jsonOptions = options.map { policy -> ReusePolicyOption in
+      switch policy {
+      case .onceOnly(let batchSize, let reissueTriggerUnused):
+        return ReusePolicyOption(
+          details: [.onceOnly],
+          batchSize: batchSize,
+          reissueTriggerUnused: reissueTriggerUnused,
+          reissueTriggerLifetimeLeft: nil
+        )
+
+      case .limitedTime(let reissueTriggerLifetimeLeft):
+        return ReusePolicyOption(
+          details: [.limitedTime],
+          batchSize: nil,
+          reissueTriggerUnused: nil,
+          reissueTriggerLifetimeLeft: reissueTriggerLifetimeLeft
+        )
+
+      case .rotatingBatch(let batchSize, let reissueTriggerLifetimeLeft):
+        return ReusePolicyOption(
+          details: [.rotatingBatch],
+          batchSize: batchSize,
+          reissueTriggerUnused: nil,
+          reissueTriggerLifetimeLeft: reissueTriggerLifetimeLeft
+        )
+
+      case .perRelyingParty(let batchSize, let reissueTriggerUnused, let reissueTriggerLifetimeLeft):
+        return ReusePolicyOption(
+          details: [.perRelyingParty],
+          batchSize: batchSize,
+          reissueTriggerUnused: reissueTriggerUnused,
+          reissueTriggerLifetimeLeft: reissueTriggerLifetimeLeft
+        )
+      }
+    }
+
+    try container.encode(jsonOptions, forKey: .options)
+  }
+}

--- a/Sources/Entities/CredentialReuse/ReuseMethod.swift
+++ b/Sources/Entities/CredentialReuse/ReuseMethod.swift
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Foundation
+
+public enum ReuseMethod: String, Codable, Sendable, Equatable {
+  case onceOnly = "once_only"
+  case limitedTime = "limited_time"
+  case rotatingBatch = "rotating-batch"
+  case perRelyingParty = "per-relying-party"
+}

--- a/Sources/Entities/CredentialReuse/ReusePolicy.swift
+++ b/Sources/Entities/CredentialReuse/ReusePolicy.swift
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Foundation
+
+public enum ReusePolicy: Sendable, Equatable {
+  case onceOnly(batchSize: Int, reissueTriggerUnused: Int)
+  case limitedTime(reissueTriggerLifetimeLeft: Int)
+  case rotatingBatch(batchSize: Int, reissueTriggerLifetimeLeft: Int)
+  case perRelyingParty(
+    batchSize: Int,
+    reissueTriggerUnused: Int,
+    reissueTriggerLifetimeLeft: Int
+  )
+
+  public var method: ReuseMethod {
+    switch self {
+    case .onceOnly: return .onceOnly
+    case .limitedTime: return .limitedTime
+    case .rotatingBatch: return .rotatingBatch
+    case .perRelyingParty: return .perRelyingParty
+    }
+  }
+
+  public var batchSize: Int? {
+    switch self {
+    case .onceOnly(let batchSize, _): return batchSize
+    case .limitedTime: return nil
+    case .rotatingBatch(let batchSize, _): return batchSize
+    case .perRelyingParty(let batchSize, _, _): return batchSize
+    }
+  }
+
+  public func validate() throws {
+    switch self {
+    case .onceOnly(let batchSize, let reissueTriggerUnused):
+      guard batchSize > 0 else {
+        throw CredentialReusePolicyError.missingRequiredField("batch_size must be > 0")
+      }
+      guard reissueTriggerUnused > 0 else {
+        throw CredentialReusePolicyError.missingRequiredField("reissue_trigger_unused must be > 0")
+      }
+      guard reissueTriggerUnused < batchSize else {
+        throw CredentialReusePolicyError.missingRequiredField("reissue_trigger_unused must be < batch_size")
+      }
+
+    case .limitedTime(let reissueTriggerLifetimeLeft):
+      guard reissueTriggerLifetimeLeft > 0 else {
+        throw CredentialReusePolicyError.missingRequiredField("reissue_trigger_lifetime_left must be > 0")
+      }
+
+    case .rotatingBatch(let batchSize, let reissueTriggerLifetimeLeft):
+      guard batchSize > 0 else {
+        throw CredentialReusePolicyError.missingRequiredField("batch_size must be > 0")
+      }
+      guard reissueTriggerLifetimeLeft > 0 else {
+        throw CredentialReusePolicyError.missingRequiredField("reissue_trigger_lifetime_left must be > 0")
+      }
+
+    case .perRelyingParty(let batchSize, let reissueTriggerUnused, let reissueTriggerLifetimeLeft):
+      guard batchSize > 0 else {
+        throw CredentialReusePolicyError.missingRequiredField("batch_size must be > 0")
+      }
+      guard reissueTriggerUnused > 0 else {
+        throw CredentialReusePolicyError.missingRequiredField("reissue_trigger_unused must be > 0")
+      }
+      guard reissueTriggerUnused < batchSize else {
+        throw CredentialReusePolicyError.missingRequiredField("reissue_trigger_unused must be < batch_size")
+      }
+      guard reissueTriggerLifetimeLeft > 0 else {
+        throw CredentialReusePolicyError.missingRequiredField("reissue_trigger_lifetime_left must be > 0")
+      }
+    }
+  }
+
+  /// Factory method to create policy options from details array
+  public static func fromDetails(
+    details: [ReuseMethod],
+    batchSize: Int?,
+    reissueTriggerUnused: Int?,
+    reissueTriggerLifetimeLeft: Int?
+  ) throws -> [ReusePolicy] {
+
+    // Validate non-empty
+    guard !details.isEmpty else {
+      throw CredentialReusePolicyError.invalidDetailsCombination(details)
+    }
+
+    // Check for base method (once_only OR limited_time)
+    let hasOnceOnly = details.contains(.onceOnly)
+    let hasLimitedTime = details.contains(.limitedTime)
+
+    guard hasOnceOnly || hasLimitedTime else {
+      throw CredentialReusePolicyError.invalidPolicyStructure(
+        "details must contain either once_only or limited_time"
+      )
+    }
+
+    guard !(hasOnceOnly && hasLimitedTime) else {
+      throw CredentialReusePolicyError.invalidPolicyStructure(
+        "details cannot contain both once_only and limited_time"
+      )
+    }
+
+    // Expand each detail into a separate ReusePolicy
+    var policies: [ReusePolicy] = []
+
+    for method in details {
+      let policy: ReusePolicy
+
+      switch method {
+      case .onceOnly:
+        guard let batchSize = batchSize else {
+          throw CredentialReusePolicyError.missingRequiredField("batch_size required for once_only")
+        }
+        guard let reissueTriggerUnused = reissueTriggerUnused else {
+          throw CredentialReusePolicyError.missingRequiredField("reissue_trigger_unused required for once_only")
+        }
+        policy = .onceOnly(batchSize: batchSize, reissueTriggerUnused: reissueTriggerUnused)
+
+      case .limitedTime:
+        guard let reissueTriggerLifetimeLeft = reissueTriggerLifetimeLeft else {
+          throw CredentialReusePolicyError.missingRequiredField("reissue_trigger_lifetime_left required for limited_time")
+        }
+        policy = .limitedTime(reissueTriggerLifetimeLeft: reissueTriggerLifetimeLeft)
+
+      case .rotatingBatch:
+        guard let batchSize = batchSize else {
+          throw CredentialReusePolicyError.missingRequiredField("batch_size required for rotating-batch")
+        }
+        guard let reissueTriggerLifetimeLeft = reissueTriggerLifetimeLeft else {
+          throw CredentialReusePolicyError.missingRequiredField("reissue_trigger_lifetime_left required for rotating-batch")
+        }
+        policy = .rotatingBatch(batchSize: batchSize, reissueTriggerLifetimeLeft: reissueTriggerLifetimeLeft)
+
+      case .perRelyingParty:
+        guard let batchSize = batchSize else {
+          throw CredentialReusePolicyError.missingRequiredField("batch_size required for per-relying-party")
+        }
+        guard let reissueTriggerUnused = reissueTriggerUnused else {
+          throw CredentialReusePolicyError.missingRequiredField("reissue_trigger_unused required for per-relying-party")
+        }
+        guard let reissueTriggerLifetimeLeft = reissueTriggerLifetimeLeft else {
+          throw CredentialReusePolicyError.missingRequiredField("reissue_trigger_lifetime_left required for per-relying-party")
+        }
+        policy = .perRelyingParty(
+          batchSize: batchSize,
+          reissueTriggerUnused: reissueTriggerUnused,
+          reissueTriggerLifetimeLeft: reissueTriggerLifetimeLeft
+        )
+      }
+
+      // Validate each policy
+      try policy.validate()
+      policies.append(policy)
+    }
+
+    return policies
+  }
+}

--- a/Sources/Entities/CredentialReuse/ReusePolicyOption.swift
+++ b/Sources/Entities/CredentialReuse/ReusePolicyOption.swift
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Foundation
+
+/// JSON parsing intermediate structure for credential reuse policy options.
+/// This struct is used ONLY for JSON encoding/decoding and is immediately
+/// expanded into [ReusePolicy] via ReusePolicy.fromDetails().
+///
+struct ReusePolicyOption: Codable, Sendable, Equatable {
+  let details: [ReuseMethod]
+  let batchSize: Int?
+  let reissueTriggerUnused: Int?
+  let reissueTriggerLifetimeLeft: Int?
+
+  enum CodingKeys: String, CodingKey {
+    case details
+    case batchSize = "batch_size"
+    case reissueTriggerUnused = "reissue_trigger_unused"
+    case reissueTriggerLifetimeLeft = "reissue_trigger_lifetime_left"
+  }
+
+  init(
+    details: [ReuseMethod],
+    batchSize: Int? = nil,
+    reissueTriggerUnused: Int? = nil,
+    reissueTriggerLifetimeLeft: Int? = nil
+  ) {
+    self.details = details
+    self.batchSize = batchSize
+    self.reissueTriggerUnused = reissueTriggerUnused
+    self.reissueTriggerLifetimeLeft = reissueTriggerLifetimeLeft
+  }
+}

--- a/Sources/Entities/CredentialReuse/SupportedCredentialReusePolicies.swift
+++ b/Sources/Entities/CredentialReuse/SupportedCredentialReusePolicies.swift
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Foundation
+
+/// Wallet configuration for credential reuse policies
+public enum SupportedCredentialReusePolicies: Sendable, Equatable {
+  /// Wallet supports these reuse policies but does not mandate their presence in issuer metadata.
+  /// If issuer has no policy, credential issuance continues normally.
+  /// If issuer has policy, wallet tries to match; fails if no common policy found.
+  case supported(Set<ReuseMethod>)
+
+  /// Wallet requires that issuer defines at least one of these reuse policies.
+  /// If issuer has no policy → issuance fails with error.
+  /// If issuer has policy, wallet tries to match; fails if no common policy found.
+  case required(Set<ReuseMethod>)
+
+  /// Wallet does not support credential reuse policies at all.
+  /// If issuer has policy → credential issuance continues normally
+  case notSupported
+
+  
+  public func validate() throws {
+    switch self {
+    case .supported(let methods), .required(let methods):
+      guard !methods.isEmpty else {
+        throw CredentialReusePolicyError.invalidPolicyStructure(
+          "policyTypes cannot be empty"
+        )
+      }
+
+      let hasBaseMethod = methods.contains(.onceOnly) || methods.contains(.limitedTime)
+      guard hasBaseMethod else {
+        throw CredentialReusePolicyError.invalidPolicyStructure(
+          "policyTypes must contain at least onceOnly or limitedTime"
+        )
+      }
+
+    case .notSupported:
+      // No validation needed
+      break
+    }
+  }
+
+  public func supports(_ method: ReuseMethod) -> Bool {
+    switch self {
+    case .supported(let methods), .required(let methods):
+      return methods.contains(method)
+    case .notSupported:
+      return false
+    }
+  }
+
+  public var supportedMethods: Set<ReuseMethod>? {
+    switch self {
+    case .supported(let methods), .required(let methods):
+      return methods
+    case .notSupported:
+      return nil
+    }
+  }
+
+  public var isRequired: Bool {
+    switch self {
+    case .required:
+      return true
+    case .supported, .notSupported:
+      return false
+    }
+  }
+}

--- a/Sources/Entities/CredentialSupported/CredentialSupported.swift
+++ b/Sources/Entities/CredentialSupported/CredentialSupported.swift
@@ -163,21 +163,41 @@ public extension CredentialSupported {
       []
     }
   }
+
+  var credentialReusePolicy: CredentialReusePolicy? {
+    switch self {
+    case .msoMdoc(let spec):
+      return spec.credentialReusePolicy
+    case .sdJwtVc(let spec):
+      return spec.credentialReusePolicy
+    case .w3CSignedJwt(let spec):
+      return spec.credentialReusePolicy
+    case .w3CJsonLdSignedJwt(let spec):
+      return spec.credentialReusePolicy
+    case .w3CJsonLdDataIntegrity(let spec):
+      return spec.credentialReusePolicy
+    case .scope:
+      return nil
+    }
+  }
 }
 
 
 public struct ConfigurationCredentialMetadata: Codable, Sendable {
   public let display: [Display]
   public let claims: [Claim]
+  public let credentialReusePolicy: CredentialReusePolicy?
   
   enum CodingKeys: String, CodingKey {
     case display
     case claims
+    case credentialReusePolicy = "credential_reuse_policy"
   }
   
-  public init(display: [Display], claims: [Claim]) {
+  public init(display: [Display], claims: [Claim], credentialReusePolicy: CredentialReusePolicy? = nil) {
     self.display = display
     self.claims = claims
+    self.credentialReusePolicy = credentialReusePolicy
   }
   
   public init(json: JSON) throws {
@@ -186,5 +206,13 @@ public struct ConfigurationCredentialMetadata: Codable, Sendable {
     }
     let claims = try json["claims"].array?.compactMap({ try Claim(json: $0)}) ?? []
     self.claims = claims
+    
+    if let policyJson = json["credential_reuse_policy"].dictionaryObject,
+       let policyData = try? JSONSerialization.data(withJSONObject: policyJson),
+       let reusePolicy = try? JSONDecoder().decode(CredentialReusePolicy.self, from: policyData) {
+      self.credentialReusePolicy = reusePolicy
+    } else {
+      self.credentialReusePolicy = nil
+    }
   }
 }

--- a/Sources/Entities/Errors/CredentialReusePolicyError.swift
+++ b/Sources/Entities/Errors/CredentialReusePolicyError.swift
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Foundation
+
+/// Errors related to credential reuse policy validation and processing
+public enum CredentialReusePolicyError: LocalizedError {
+  case invalidPolicyStructure(String)
+  case unsupportedPolicyId(String)
+  case missingRequiredField(String)
+  case invalidDetailsCombination([ReuseMethod])
+  case batchSizeMismatch(required: Int, provided: Int)
+  case noSupportedPolicyFound
+  case unsupportedReuseMethod(ReuseMethod)
+
+  public var errorDescription: String? {
+    switch self {
+    case .invalidPolicyStructure(let reason):
+      return "Invalid credential reuse policy structure: \(reason)"
+    case .unsupportedPolicyId(let id):
+      return "Unsupported policy ID: \(id). Expected 'arf_annex_ii'"
+    case .missingRequiredField(let field):
+      return "Missing required field: \(field)"
+    case .invalidDetailsCombination(let methods):
+      return "Invalid details combination: \(methods.map { $0.rawValue })"
+    case .batchSizeMismatch(let required, let provided):
+      return "Batch size mismatch. Required: \(required), Provided: \(provided)"
+    case .noSupportedPolicyFound:
+      return "No supported reuse policy found in issuer metadata"
+    case .unsupportedReuseMethod(let method):
+      return "Reuse method '\(method.rawValue)' is not supported in this version"
+    }
+  }
+}

--- a/Sources/Entities/Profiles/MsoMdocFormat.swift
+++ b/Sources/Entities/Profiles/MsoMdocFormat.swift
@@ -139,7 +139,8 @@ public extension MsoMdocFormat {
     public let credentialMetadata: ConfigurationCredentialMetadata?
     public let docType: String
     public let policy: Policy?
-    
+    public let credentialReusePolicy: CredentialReusePolicy?
+
     enum CodingKeys: String, CodingKey {
       case format
       case scope
@@ -149,6 +150,7 @@ public extension MsoMdocFormat {
       case credentialMetadata = "credential_metadata"
       case docType = "doctype"
       case policy
+      case credentialReusePolicy = "credential_reuse_policy"
     }
     
     public init(
@@ -159,7 +161,8 @@ public extension MsoMdocFormat {
       proofTypesSupported: [String: ProofTypeSupportedMeta]? = nil,
       credentialMetadata: ConfigurationCredentialMetadata? = nil,
       docType: String,
-      policy: Policy? = nil
+      policy: Policy? = nil,
+      credentialReusePolicy: CredentialReusePolicy? = nil
     ) {
       self.format = format
       self.scope = scope
@@ -169,6 +172,7 @@ public extension MsoMdocFormat {
       self.credentialMetadata = credentialMetadata
       self.docType = docType
       self.policy = policy
+      self.credentialReusePolicy = credentialReusePolicy
     }
     
     func toDomain() throws -> MsoMdocFormat.CredentialConfiguration {
@@ -185,7 +189,8 @@ public extension MsoMdocFormat {
         proofTypesSupported: self.proofTypesSupported,
         credentialMetadata: credentialMetadata,
         docType: docType,
-        policy: policy
+        policy: policy,
+        credentialReusePolicy: credentialReusePolicy
       )
     }
   }
@@ -199,7 +204,8 @@ public extension MsoMdocFormat {
     public let credentialMetadata: ConfigurationCredentialMetadata?
     public let docType: String
     public let policy: Policy?
-    
+    public let credentialReusePolicy: CredentialReusePolicy?
+
     enum CodingKeys: String, CodingKey {
       case format
       case scope
@@ -209,6 +215,7 @@ public extension MsoMdocFormat {
       case credentialMetadata = "credential_metadata"
       case docType = "doctype"
       case policy
+      case credentialReusePolicy = "credential_reuse_policy"
     }
     
     public init(
@@ -219,7 +226,8 @@ public extension MsoMdocFormat {
       proofTypesSupported: [String: ProofTypeSupportedMeta]?,
       credentialMetadata: ConfigurationCredentialMetadata?,
       docType: String,
-      policy: Policy?
+      policy: Policy?,
+      credentialReusePolicy: CredentialReusePolicy? = nil
     ) {
       self.format = format
       self.scope = scope
@@ -229,6 +237,7 @@ public extension MsoMdocFormat {
       self.credentialMetadata = credentialMetadata
       self.docType = docType
       self.policy = policy
+      self.credentialReusePolicy = credentialReusePolicy
     }
     
     public init(from decoder: Decoder) throws {
@@ -245,6 +254,7 @@ public extension MsoMdocFormat {
       credentialMetadata = try container.decode(ConfigurationCredentialMetadata.self, forKey: .credentialMetadata)
       docType = try container.decode(String.self, forKey: .docType)
       policy = try? container.decode(Policy.self, forKey: .policy)
+      credentialReusePolicy = try? container.decode(CredentialReusePolicy.self, forKey: .credentialReusePolicy)
     }
     
     public func encode(to encoder: Encoder) throws {
@@ -258,6 +268,7 @@ public extension MsoMdocFormat {
       try container.encode(credentialMetadata, forKey: .credentialMetadata)
       try container.encode(docType, forKey: .docType)
       try container.encode(policy, forKey: .policy)
+      try container.encodeIfPresent(credentialReusePolicy, forKey: .credentialReusePolicy)
     }
     
     init(json: JSON) throws {
@@ -284,6 +295,7 @@ public extension MsoMdocFormat {
       self.credentialMetadata = try ConfigurationCredentialMetadata(json: json["credential_metadata"])
       self.docType = json["doctype"].stringValue
       self.policy = .init(json: json["policy"])
+      self.credentialReusePolicy = credentialMetadata?.credentialReusePolicy
     }
     
     internal static func parseCredentialSigningAlgorithms(from json: JSON) -> [String] {

--- a/Sources/Entities/Profiles/SdJwtVcFormat.swift
+++ b/Sources/Entities/Profiles/SdJwtVcFormat.swift
@@ -181,7 +181,8 @@ public extension SdJwtVcFormat {
     public let proofTypesSupported: [String: ProofTypeSupportedMeta]?
     public let credentialMetadata: ConfigurationCredentialMetadata?
     public let credentialDefinition: CredentialDefinitionTO
-    
+    public let credentialReusePolicy: CredentialReusePolicy?
+
     enum CodingKeys: String, CodingKey {
       case format
       case scope
@@ -191,6 +192,7 @@ public extension SdJwtVcFormat {
       case proofTypesSupported = "proof_types_supported"
       case credentialMetadata = "credential_metadata"
       case credentialDefinition = "credential_definition"
+      case credentialReusePolicy = "credential_reuse_policy"
     }
     
     public init(
@@ -201,7 +203,8 @@ public extension SdJwtVcFormat {
       credentialSigningAlgValuesSupported: [String]? = nil,
       proofTypesSupported: [String: ProofTypeSupportedMeta]? = nil,
       credentialMetadata: ConfigurationCredentialMetadata? = nil,
-      credentialDefinition: CredentialDefinitionTO
+      credentialDefinition: CredentialDefinitionTO,
+      credentialReusePolicy: CredentialReusePolicy? = nil
     ) {
       self.format = format
       self.scope = scope
@@ -211,6 +214,7 @@ public extension SdJwtVcFormat {
       self.proofTypesSupported = proofTypesSupported
       self.credentialMetadata = credentialMetadata
       self.credentialDefinition = credentialDefinition
+      self.credentialReusePolicy = credentialReusePolicy
     }
     
     func toDomain() throws -> SdJwtVcFormat.CredentialConfiguration {
@@ -222,13 +226,14 @@ public extension SdJwtVcFormat {
       let credentialDefinition = self.credentialDefinition.toDomain()
       
       return .init(
-        scope: scope, 
+        scope: scope,
         vct: vct,
         cryptographicBindingMethodsSupported: bindingMethods,
         credentialSigningAlgValuesSupported: credentialSigningAlgValuesSupported ?? [],
         proofTypesSupported: self.proofTypesSupported,
         credentialMetadata: credentialMetadata,
-        credentialDefinition: credentialDefinition
+        credentialDefinition: credentialDefinition,
+        credentialReusePolicy: credentialReusePolicy
       )
     }
   }
@@ -241,7 +246,8 @@ public extension SdJwtVcFormat {
     public let proofTypesSupported: [String: ProofTypeSupportedMeta]?
     public let credentialMetadata: ConfigurationCredentialMetadata?
     public let credentialDefinition: CredentialDefinition
-    
+    public let credentialReusePolicy: CredentialReusePolicy?
+
     enum CodingKeys: String, CodingKey {
       case scope
       case vct
@@ -250,6 +256,7 @@ public extension SdJwtVcFormat {
       case proofTypesSupported = "proof_types_supported"
       case credentialMetadata = "credential_metadata"
       case credentialDefinition = "credential_definition"
+      case credentialReusePolicy = "credential_reuse_policy"
     }
     
     public init(
@@ -259,7 +266,8 @@ public extension SdJwtVcFormat {
       credentialSigningAlgValuesSupported: [String],
       proofTypesSupported: [String: ProofTypeSupportedMeta]?,
       credentialMetadata: ConfigurationCredentialMetadata?,
-      credentialDefinition: CredentialDefinition
+      credentialDefinition: CredentialDefinition,
+      credentialReusePolicy: CredentialReusePolicy? = nil
     ) {
       self.scope = scope
       self.vct = vct
@@ -268,6 +276,7 @@ public extension SdJwtVcFormat {
       self.proofTypesSupported = proofTypesSupported
       self.credentialMetadata = credentialMetadata
       self.credentialDefinition = credentialDefinition
+      self.credentialReusePolicy = credentialReusePolicy
     }
     
     public init(from decoder: Decoder) throws {
@@ -282,6 +291,7 @@ public extension SdJwtVcFormat {
       
       credentialMetadata = try container.decode(ConfigurationCredentialMetadata.self, forKey: .credentialMetadata)
       credentialDefinition = try container.decode(CredentialDefinition.self, forKey: .credentialDefinition)
+      credentialReusePolicy = try? container.decode(CredentialReusePolicy.self, forKey: .credentialReusePolicy)
     }
     
     public func encode(to encoder: Encoder) throws {
@@ -292,6 +302,7 @@ public extension SdJwtVcFormat {
       try container.encode(proofTypesSupported, forKey: .proofTypesSupported)
       try container.encode(credentialMetadata, forKey: .credentialMetadata)
       try container.encode(credentialDefinition, forKey: .credentialDefinition)
+      try container.encodeIfPresent(credentialReusePolicy, forKey: .credentialReusePolicy)
     }
     
     init(json: JSON) throws {
@@ -318,6 +329,7 @@ public extension SdJwtVcFormat {
       
       self.credentialMetadata = try ConfigurationCredentialMetadata(json: json["credential_metadata"])
       self.credentialDefinition = try CredentialDefinition(json: json["credential_definition"])
+      self.credentialReusePolicy = credentialMetadata?.credentialReusePolicy
     }
     
     func toIssuanceRequest(

--- a/Sources/Entities/Profiles/W3CJsonLdDataIntegrityFormat.swift
+++ b/Sources/Entities/Profiles/W3CJsonLdDataIntegrityFormat.swift
@@ -155,7 +155,8 @@ public extension W3CJsonLdDataIntegrityFormat {
     public let context: [String]
     public let type: [String]
     public let credentialDefinition: CredentialDefinition
-    
+    public let credentialReusePolicy: CredentialReusePolicy? = nil
+
     enum CodingKeys: String, CodingKey {
       case scope
       case cryptographicBindingMethodsSupported = "cryptographic_binding_methods_supported"

--- a/Sources/Entities/Profiles/W3CJsonLdSignedJwtFormat.swift
+++ b/Sources/Entities/Profiles/W3CJsonLdSignedJwtFormat.swift
@@ -150,7 +150,8 @@ public extension W3CJsonLdSignedJwtFormat {
     public let credentialMetadata: ConfigurationCredentialMetadata?
     public let context: [String]
     public let credentialDefinition: CredentialDefinition
-    
+    public let credentialReusePolicy: CredentialReusePolicy? = nil
+
     enum CodingKeys: String, CodingKey {
       case scope
       case cryptographicBindingMethodsSupported = "cryptographic_binding_methods_supported"

--- a/Sources/Entities/Profiles/W3CSignedJwtFormat.swift
+++ b/Sources/Entities/Profiles/W3CSignedJwtFormat.swift
@@ -236,7 +236,8 @@ public extension W3CSignedJwtFormat {
     public let proofTypesSupported: [String: ProofTypeSupportedMeta]?
     public let credentialMetadata: ConfigurationCredentialMetadata?
     public let credentialDefinition: CredentialDefinition
-    
+    public let credentialReusePolicy: CredentialReusePolicy? = nil
+
     enum CodingKeys: String, CodingKey {
       case scope
       case cryptographicBindingMethodsSupported = "cryptographic_binding_methods_supported"

--- a/Sources/Entities/Wallet/Config.swift
+++ b/Sources/Entities/Wallet/Config.swift
@@ -56,6 +56,9 @@ public struct OpenId4VCIConfig: Sendable {
   /// Dpop requirement, if required by wallet and not supported by issuer, halt the issuance process
   public let requireDpop: Bool
   
+  /// Wallet's supported credential reuse policies
+  public let supportedCredentialReusePolicies: SupportedCredentialReusePolicies
+  
   /// Initializes an `OpenId4VCIConfig` instance with the given parameters.
   /// - Parameters:
   ///   - client: The client used for OpenID4VCI operations.
@@ -65,6 +68,7 @@ public struct OpenId4VCIConfig: Sendable {
   ///   - clientAttestationPoPBuilder: An optional client attestation PoP builder (default: `nil`).
   ///   - issuerMetadataPolicy: Policy defining how issuer metadata should be handled (default: `.ignoreSigned`).
   ///   - requireDpop: If dpop is supported then use it, otherwise always don't
+  ///   - supportedCredentialReusePolicies: Wallet's supported credential reuse policies (default: `.notSupported`).
   public init(
     client: Client,
     authFlowRedirectionURI: URL,
@@ -73,7 +77,8 @@ public struct OpenId4VCIConfig: Sendable {
     clientAttestationPoPBuilder: ClientAttestationPoPBuilder? = nil,
     issuerMetadataPolicy: IssuerMetadataPolicy = .ignoreSigned,
     supportedCompressionAlgorithms: [CompressionAlgorithm]? = nil,
-    requireDpop: Bool = true
+    requireDpop: Bool = true,
+    supportedCredentialReusePolicies: SupportedCredentialReusePolicies = .notSupported
   ) {
     self.client = client
     self.authFlowRedirectionURI = authFlowRedirectionURI
@@ -83,5 +88,6 @@ public struct OpenId4VCIConfig: Sendable {
     self.issuerMetadataPolicy = issuerMetadataPolicy
     self.supportedCompressionAlgorithms = supportedCompressionAlgorithms
     self.requireDpop = requireDpop
+    self.supportedCredentialReusePolicies = supportedCredentialReusePolicies
   }
 }

--- a/Sources/Issuers/Issuer.swift
+++ b/Sources/Issuers/Issuer.swift
@@ -572,7 +572,18 @@ private extension Issuer {
       case 1:
         return (proofs, cNonce?.dPoPNonce)
       default:
-        if let batchSize = batchCredentialIssuance?.batchSize,
+        // Determine effective batch size: reuse policy > batch_credential_issuance
+        let selectedPolicy = try? CredentialReusePolicyValidator.selectMatchingPolicy(
+          issuerPolicy: supportedCredential.credentialReusePolicy,
+          walletSupported: config.supportedCredentialReusePolicies
+        )
+
+        let effectiveBatchSize = CredentialReusePolicyValidator.determineBatchSize(
+          selectedPolicy: selectedPolicy,
+          issuerBatchSize: batchCredentialIssuance?.batchSize
+        )
+
+        if let batchSize = effectiveBatchSize,
            proofs.count > batchSize {
           throw ValidationError.issuerBatchSizeLimitExceeded(batchSize)
         }

--- a/Sources/Main/Validators/CredentialReusePolicyValidator.swift
+++ b/Sources/Main/Validators/CredentialReusePolicyValidator.swift
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Foundation
+
+/// Validator for credential reuse policies according to ETSI TS 119 472-3 and ARF Annex II
+public struct CredentialReusePolicyValidator {
+
+  /// Validates issuer policy against wallet capabilities and selects best matching option
+  /// - Parameters:
+  ///   - issuerPolicy: The reuse policy from issuer metadata (optional)
+  ///   - walletSupported: Wallet's supported reuse policy configuration
+  /// - Returns: Selected policy that matches wallet capabilities, or nil if no policy and not required
+  /// - Throws: CredentialReusePolicyError if validation fails or no match found
+  public static func selectMatchingPolicy(
+    issuerPolicy: CredentialReusePolicy?,
+    walletSupported: SupportedCredentialReusePolicies
+  ) throws -> ReusePolicy? {
+
+    try walletSupported.validate()
+
+    if issuerPolicy == nil {
+      switch walletSupported {
+      case .required:
+        throw CredentialReusePolicyError.noSupportedPolicyFound
+      case .supported, .notSupported:
+        return nil
+      }
+    }
+
+    guard let policy = issuerPolicy else {
+      return nil
+    }
+
+    if case .notSupported = walletSupported {
+      // Issuer has policy but wallet doesn't support policies → ignore and continue
+      return nil
+    }
+
+    guard policy.id == "arf_annex_ii" else {
+      throw CredentialReusePolicyError.unsupportedPolicyId(policy.id)
+    }
+
+    guard !policy.options.isEmpty else {
+      throw CredentialReusePolicyError.invalidPolicyStructure("options array is empty")
+    }
+
+    guard let walletMethods = walletSupported.supportedMethods else {
+      throw CredentialReusePolicyError.noSupportedPolicyFound
+    }
+
+    // Find first policy that wallet supports (respecting issuer's priority order)
+    for option in policy.options {
+      if walletMethods.contains(option.method) {
+        return option
+      }
+    }
+
+    // No compatible option found - both have policies but no match → error
+    throw CredentialReusePolicyError.noSupportedPolicyFound
+  }
+
+  /// Determines the batch size to use for credential issuance
+  /// Priority: reuse policy batch size > batch_credential_issuance from metadata
+  /// - Parameters:
+  ///   - selectedPolicy: The selected reuse policy (if any)
+  ///   - issuerBatchSize: The batch_credential_issuance from issuer metadata (if any)
+  /// - Returns: Batch size to use, or nil if no batch issuance
+  public static func determineBatchSize(
+    selectedPolicy: ReusePolicy?,
+    issuerBatchSize: Int?
+  ) -> Int? {
+    // Priority 1: Reuse policy batch size (if present)
+    if let policyBatchSize = selectedPolicy?.batchSize {
+      return policyBatchSize
+    }
+
+    // Priority 2: Fallback to batch_credential_issuance
+    return issuerBatchSize
+  }
+
+  /// Validates that the number of proofs matches the required batch size
+  /// - Parameters:
+  ///   - proofCount: Number of proofs being submitted
+  ///   - requiredBatchSize: Required batch size from policy or issuer metadata
+  /// - Throws: CredentialReusePolicyError.batchSizeMismatch if counts don't match
+  public static func validateProofCount(
+    proofCount: Int,
+    requiredBatchSize: Int?
+  ) throws {
+    guard let requiredSize = requiredBatchSize else {
+      // No batch size requirement
+      return
+    }
+
+    guard proofCount == requiredSize else {
+      throw CredentialReusePolicyError.batchSizeMismatch(
+        required: requiredSize,
+        provided: proofCount
+      )
+    }
+  }
+}

--- a/Tests/Entities/CredentialReusePolicyParsingTests.swift
+++ b/Tests/Entities/CredentialReusePolicyParsingTests.swift
@@ -1,0 +1,367 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import XCTest
+@testable import OpenID4VCI
+import SwiftyJSON
+
+/// Tests for CredentialReusePolicy JSON parsing with details array expansion
+class CredentialReusePolicyParsingTests: XCTestCase {
+
+  // MARK: - Parsing Tests
+
+  /// JSON has 1 option with 3 details -> Should expand to 3 policies
+  func testParsing_PID_msoMdoc_ExpandsToThreePolicies() throws {
+    let json = """
+    {
+      "format": "mso_mdoc",
+      "scope": "PID_msoMdoc",
+      "doctype": "eu.europa.ec.eudi.pid.1",
+      "cryptographic_binding_methods_supported": ["jwk"],
+      "credential_signing_alg_values_supported": [-7, -35, -36],
+      "proof_types_supported": {
+        "jwt": {
+          "proof_signing_alg_values_supported": ["RS256", "ES256"]
+        }
+      },
+      "credential_metadata": {
+        "display": [{"name": "EU PID", "locale": "en-US"}],
+        "credential_reuse_policy": {
+          "id": "arf_annex_ii",
+          "options": [{
+            "details": ["limited_time", "rotating-batch", "per-relying-party"],
+            "batch_size": 5,
+            "reissue_trigger_lifetime_left": 655433,
+            "reissue_trigger_unused": 3
+          }]
+        }
+      }
+    }
+    """
+
+    let data = json.data(using: .utf8)!
+    let jsonObj = try JSON(data: data)
+    let config = try MsoMdocFormat.CredentialConfiguration(json: jsonObj)
+
+    let policy = try XCTUnwrap(config.credentialReusePolicy)
+
+    XCTAssertEqual(policy.options.count, 3)
+
+    // First: LimitedTime
+    if case .limitedTime(let reissueTriggerLifetimeLeft) = policy.options[0] {
+      XCTAssertEqual(reissueTriggerLifetimeLeft, 655433)
+    } else {
+      XCTFail("Expected limitedTime policy at index 0")
+    }
+
+    // Second: RotatingBatch
+    if case .rotatingBatch(let batchSize, let reissueTriggerLifetimeLeft) = policy.options[1] {
+      XCTAssertEqual(batchSize, 5)
+      XCTAssertEqual(reissueTriggerLifetimeLeft, 655433)
+    } else {
+      XCTFail("Expected rotatingBatch policy at index 1")
+    }
+
+    // Third: PerRelyingParty
+    if case .perRelyingParty(let batchSize, let reissueTriggerUnused, let reissueTriggerLifetimeLeft) = policy.options[2] {
+      XCTAssertEqual(batchSize, 5)
+      XCTAssertEqual(reissueTriggerUnused, 3)
+      XCTAssertEqual(reissueTriggerLifetimeLeft, 655433)
+    } else {
+      XCTFail("Expected perRelyingParty policy at index 2")
+    }
+  }
+
+  /// JSON has 2 options with 2 details each -> Should expand to 4 policies
+  func testParsing_PID_SdJwtVc_ExpandsToFourPolicies() throws {
+    let json = """
+    {
+      "format": "dc+sd-jwt",
+      "scope": "PID_SdJwtVc",
+      "vct": "eu.europa.ec.eudi.pid.1",
+      "cryptographic_binding_methods_supported": ["jwk"],
+      "credential_signing_alg_values_supported": ["ES256"],
+      "proof_types_supported": {
+        "jwt": {
+          "proof_signing_alg_values_supported": ["ES256"]
+        }
+      },
+      "credential_metadata": {
+        "display": [{"name": "EU PID SD-JWT", "locale": "en-US"}],
+        "credential_reuse_policy": {
+          "id": "arf_annex_ii",
+          "options": [
+            {
+              "details": ["limited_time", "rotating-batch"],
+              "batch_size": 40,
+              "reissue_trigger_lifetime_left": 655433
+            },
+            {
+              "details": ["once_only", "per-relying-party"],
+              "batch_size": 60,
+              "reissue_trigger_unused": 10,
+              "reissue_trigger_lifetime_left": 777543
+            }
+          ]
+        }
+      },
+      "credential_definition": {
+        "type": ["VerifiableCredential", "PersonIdentificationData"]
+      }
+    }
+    """
+
+    let data = json.data(using: .utf8)!
+    let jsonObj = try JSON(data: data)
+    let config = try SdJwtVcFormat.CredentialConfiguration(json: jsonObj)
+
+    let policy = try XCTUnwrap(config.credentialReusePolicy)
+
+    XCTAssertEqual(policy.options.count, 4)
+
+    // From first JSON option (details: ["limited_time", "rotating-batch"])
+    // Policy 0: LimitedTime
+    if case .limitedTime(let reissueTriggerLifetimeLeft) = policy.options[0] {
+      XCTAssertEqual(reissueTriggerLifetimeLeft, 655433)
+    } else {
+      XCTFail("Expected limitedTime policy at index 0")
+    }
+
+    // Policy 1: RotatingBatch
+    if case .rotatingBatch(let batchSize, let reissueTriggerLifetimeLeft) = policy.options[1] {
+      XCTAssertEqual(batchSize, 40)
+      XCTAssertEqual(reissueTriggerLifetimeLeft, 655433)
+    } else {
+      XCTFail("Expected rotatingBatch policy at index 1")
+    }
+
+    // From second JSON option (details: ["once_only", "per-relying-party"])
+    // Policy 2: OnceOnly
+    if case .onceOnly(let batchSize, let reissueTriggerUnused) = policy.options[2] {
+      XCTAssertEqual(batchSize, 60)
+      XCTAssertEqual(reissueTriggerUnused, 10)
+    } else {
+      XCTFail("Expected onceOnly policy at index 2")
+    }
+
+    // Policy 3: PerRelyingParty
+    if case .perRelyingParty(let batchSize, let reissueTriggerUnused, let reissueTriggerLifetimeLeft) = policy.options[3] {
+      XCTAssertEqual(batchSize, 60)
+      XCTAssertEqual(reissueTriggerUnused, 10)
+      XCTAssertEqual(reissueTriggerLifetimeLeft, 777543)
+    } else {
+      XCTFail("Expected perRelyingParty policy at index 3")
+    }
+  }
+
+  /// Test parsing unknown policy ID
+  func testParsing_UnknownPolicyId_ReturnsNil() throws {
+    let json = """
+    {
+      "id": "some_unknown_policy",
+      "options": [{
+        "details": ["once_only"],
+        "batch_size": 10,
+        "reissue_trigger_unused": 4
+      }]
+    }
+    """
+
+    let data = json.data(using: .utf8)!
+    let policy = try JSONDecoder().decode(CredentialReusePolicy.self, from: data)
+
+    // Policy is parsed but will be rejected by validator
+    XCTAssertEqual(policy.id, "some_unknown_policy")
+  }
+
+  /// Test parsing with empty details array
+  func testParsing_EmptyDetailsArray_ThrowsError() {
+    let json = """
+    {
+      "id": "arf_annex_ii",
+      "options": [{
+        "details": [],
+        "batch_size": 10,
+        "reissue_trigger_unused": 4
+      }]
+    }
+    """
+
+    let data = json.data(using: .utf8)!
+
+    XCTAssertThrowsError(
+      try JSONDecoder().decode(CredentialReusePolicy.self, from: data)
+    )
+  }
+
+  /// Test parsing with missing required field
+  func testParsing_MissingRequiredField_ThrowsError() {
+    let json = """
+    {
+      "id": "arf_annex_ii",
+      "options": [{
+        "details": ["once_only"],
+        "batch_size": 10
+      }]
+    }
+    """
+
+    let data = json.data(using: .utf8)!
+
+    // Missing reissue_trigger_unused for once_only
+    XCTAssertThrowsError(
+      try JSONDecoder().decode(CredentialReusePolicy.self, from: data)
+    )
+  }
+
+  /// Test parsing with both once_only and limited_time (invalid)
+  func testParsing_BothOnceOnlyAndLimitedTime_ThrowsError() {
+    let json = """
+    {
+      "id": "arf_annex_ii",
+      "options": [{
+        "details": ["once_only", "limited_time"],
+        "batch_size": 10,
+        "reissue_trigger_unused": 4,
+        "reissue_trigger_lifetime_left": 100
+      }]
+    }
+    """
+
+    let data = json.data(using: .utf8)!
+
+    XCTAssertThrowsError(
+      try JSONDecoder().decode(CredentialReusePolicy.self, from: data)
+    )
+  }
+
+  /// Test parsing without base method (rotating-batch alone)
+  func testParsing_RotatingBatchAlone_ThrowsError() {
+    let json = """
+    {
+      "id": "arf_annex_ii",
+      "options": [{
+        "details": ["rotating-batch"],
+        "batch_size": 10,
+        "reissue_trigger_lifetime_left": 100
+      }]
+    }
+    """
+
+    let data = json.data(using: .utf8)!
+
+    XCTAssertThrowsError(
+      try JSONDecoder().decode(CredentialReusePolicy.self, from: data)
+    )
+  }
+
+  /// Test that policies are in correct order (order matters for selection)
+  func testParsing_MaintainsOrderFromJSON() throws {
+    let json = """
+    {
+      "id": "arf_annex_ii",
+      "options": [{
+        "details": ["once_only", "limited_time"],
+        "batch_size": 10,
+        "reissue_trigger_unused": 4,
+        "reissue_trigger_lifetime_left": 100
+      }]
+    }
+    """
+
+    // This should fail due to both once_only and limited_time
+    let data = json.data(using: .utf8)!
+    XCTAssertThrowsError(
+      try JSONDecoder().decode(CredentialReusePolicy.self, from: data)
+    )
+  }
+
+  // MARK: - Encoding Tests
+
+  /// Test encoding policies back to JSON (each policy becomes separate option with single-element details)
+  func testEncoding_ConvertsPoliciesBackToJSON() throws {
+    let policy = CredentialReusePolicy(
+      id: "arf_annex_ii",
+      options: [
+        .limitedTime(reissueTriggerLifetimeLeft: 885433),
+        .onceOnly(batchSize: 10, reissueTriggerUnused: 4),
+        .rotatingBatch(batchSize: 40, reissueTriggerLifetimeLeft: 655433),
+        .perRelyingParty(batchSize: 60, reissueTriggerUnused: 10, reissueTriggerLifetimeLeft: 777543)
+      ]
+    )
+
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    let data = try encoder.encode(policy)
+    let jsonString = String(data: data, encoding: .utf8)!
+
+    // Verify structure
+    XCTAssertTrue(jsonString.contains("\"id\" : \"arf_annex_ii\""))
+
+    // Verify each policy is encoded as separate option with single-element details array
+    XCTAssertTrue(jsonString.contains("\"details\" : [\n        \"limited_time\"\n      ]"))
+    XCTAssertTrue(jsonString.contains("\"details\" : [\n        \"once_only\"\n      ]"))
+    XCTAssertTrue(jsonString.contains("\"details\" : [\n        \"rotating-batch\"\n      ]"))
+    XCTAssertTrue(jsonString.contains("\"details\" : [\n        \"per-relying-party\"\n      ]"))
+
+    // Verify batch sizes are present
+    XCTAssertTrue(jsonString.contains("\"batch_size\" : 10"))
+    XCTAssertTrue(jsonString.contains("\"batch_size\" : 40"))
+    XCTAssertTrue(jsonString.contains("\"batch_size\" : 60"))
+
+    // Verify reissue triggers are present
+    XCTAssertTrue(jsonString.contains("\"reissue_trigger_lifetime_left\" : 885433"))
+    XCTAssertTrue(jsonString.contains("\"reissue_trigger_lifetime_left\" : 655433"))
+    XCTAssertTrue(jsonString.contains("\"reissue_trigger_lifetime_left\" : 777543"))
+    XCTAssertTrue(jsonString.contains("\"reissue_trigger_unused\" : 4"))
+    XCTAssertTrue(jsonString.contains("\"reissue_trigger_unused\" : 10"))
+  }
+
+  /// Test round-trip encoding and decoding
+  func testRoundTrip_EncodingAndDecoding() throws {
+    let original = CredentialReusePolicy(
+      id: "arf_annex_ii",
+      options: [
+        .limitedTime(reissueTriggerLifetimeLeft: 885433),
+        .onceOnly(batchSize: 10, reissueTriggerUnused: 4)
+      ]
+    )
+
+    // Encode
+    let encoded = try JSONEncoder().encode(original)
+
+    // Decode
+    let decoded = try JSONDecoder().decode(CredentialReusePolicy.self, from: encoded)
+
+    // Verify
+    XCTAssertEqual(decoded.id, original.id)
+    XCTAssertEqual(decoded.options.count, original.options.count)
+
+    // Verify first policy
+    if case .limitedTime(let reissueTriggerLifetimeLeft) = decoded.options[0] {
+      XCTAssertEqual(reissueTriggerLifetimeLeft, 885433)
+    } else {
+      XCTFail("Expected limitedTime policy")
+    }
+
+    // Verify second policy
+    if case .onceOnly(let batchSize, let reissueTriggerUnused) = decoded.options[1] {
+      XCTAssertEqual(batchSize, 10)
+      XCTAssertEqual(reissueTriggerUnused, 4)
+    } else {
+      XCTFail("Expected onceOnly policy")
+    }
+  }
+}

--- a/Tests/Entities/ReusePolicyTests.swift
+++ b/Tests/Entities/ReusePolicyTests.swift
@@ -1,0 +1,265 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import XCTest
+@testable import OpenID4VCI
+
+class ReusePolicyTests: XCTestCase {
+
+  // MARK: - Individual Policy Creation Tests
+  func testOnceOnly_IsValidWithBatchSizeAndReissueTriggerUnused() {
+    let policy = ReusePolicy.onceOnly(batchSize: 10, reissueTriggerUnused: 4)
+
+    if case .onceOnly(let batchSize, let reissueTriggerUnused) = policy {
+      XCTAssertEqual(batchSize, 10)
+      XCTAssertEqual(reissueTriggerUnused, 4)
+      XCTAssertEqual(policy.batchSize, 10)
+    } else {
+      XCTFail("Expected onceOnly policy")
+    }
+
+    XCTAssertNoThrow(try policy.validate())
+  }
+
+  func testLimitedTime_IsValidWithReissueTriggerLifetimeLeft() {
+    let policy = ReusePolicy.limitedTime(reissueTriggerLifetimeLeft: 885433)
+
+    if case .limitedTime(let reissueTriggerLifetimeLeft) = policy {
+      XCTAssertEqual(reissueTriggerLifetimeLeft, 885433)
+      XCTAssertNil(policy.batchSize)
+    } else {
+      XCTFail("Expected limitedTime policy")
+    }
+
+    XCTAssertNoThrow(try policy.validate())
+  }
+
+  func testRotatingBatch_IsValid() {
+    let policy = ReusePolicy.rotatingBatch(batchSize: 20, reissueTriggerLifetimeLeft: 100000)
+
+    if case .rotatingBatch(let batchSize, let reissueTriggerLifetimeLeft) = policy {
+      XCTAssertEqual(batchSize, 20)
+      XCTAssertEqual(reissueTriggerLifetimeLeft, 100000)
+      XCTAssertEqual(policy.batchSize, 20)
+    } else {
+      XCTFail("Expected rotatingBatch policy")
+    }
+
+    XCTAssertNoThrow(try policy.validate())
+  }
+
+  func testPerRelyingParty_IsValid() {
+    let policy = ReusePolicy.perRelyingParty(
+      batchSize: 5,
+      reissueTriggerUnused: 3,
+      reissueTriggerLifetimeLeft: 655433
+    )
+
+    if case .perRelyingParty(let batchSize, let reissueTriggerUnused, let reissueTriggerLifetimeLeft) = policy {
+      XCTAssertEqual(batchSize, 5)
+      XCTAssertEqual(reissueTriggerUnused, 3)
+      XCTAssertEqual(reissueTriggerLifetimeLeft, 655433)
+      XCTAssertEqual(policy.batchSize, 5)
+    } else {
+      XCTFail("Expected perRelyingParty policy")
+    }
+
+    XCTAssertNoThrow(try policy.validate())
+  }
+
+  // MARK: - fromDetails Expansion Tests
+
+  func testFromDetails_FailsWhenDetailsIsEmpty() {
+    XCTAssertThrowsError(
+      try ReusePolicy.fromDetails(
+        details: [],
+        batchSize: nil,
+        reissueTriggerUnused: nil,
+        reissueTriggerLifetimeLeft: nil
+      )
+    )
+  }
+
+  func testFromDetails_FailsWhenRotatingBatchIsUsedWithoutBaseDetail() {
+    XCTAssertThrowsError(
+      try ReusePolicy.fromDetails(
+        details: [.rotatingBatch],
+        batchSize: 10,
+        reissueTriggerUnused: nil,
+        reissueTriggerLifetimeLeft: 100
+      )
+    )
+  }
+
+  func testFromDetails_FailsWhenPerRelyingPartyIsUsedWithoutBaseDetail() {
+    XCTAssertThrowsError(
+      try ReusePolicy.fromDetails(
+        details: [.perRelyingParty],
+        batchSize: 10,
+        reissueTriggerUnused: 2,
+        reissueTriggerLifetimeLeft: 100
+      )
+    )
+  }
+
+  func testFromDetails_FailsWhenDetailsContainsBothOnceOnlyAndLimitedTime() {
+    XCTAssertThrowsError(
+      try ReusePolicy.fromDetails(
+        details: [.onceOnly, .limitedTime],
+        batchSize: 10,
+        reissueTriggerUnused: 2,
+        reissueTriggerLifetimeLeft: 100
+      )
+    )
+  }
+
+  func testFromDetails_FailsWhenOnceOnlyIsMissingBatchSize() {
+    XCTAssertThrowsError(
+      try ReusePolicy.fromDetails(
+        details: [.onceOnly],
+        batchSize: nil,
+        reissueTriggerUnused: 2,
+        reissueTriggerLifetimeLeft: nil
+      )
+    )
+  }
+
+  func testFromDetails_FailsWhenOnceOnlyIsMissingReissueTriggerUnused() {
+    XCTAssertThrowsError(
+      try ReusePolicy.fromDetails(
+        details: [.onceOnly],
+        batchSize: 10,
+        reissueTriggerUnused: nil,
+        reissueTriggerLifetimeLeft: nil
+      )
+    )
+  }
+
+  func testFromDetails_FailsWhenReissueTriggerUnusedIsNotLowerThanBatchSize() {
+    XCTAssertThrowsError(
+      try ReusePolicy.fromDetails(
+        details: [.onceOnly],
+        batchSize: 10,
+        reissueTriggerUnused: 10, // Should be < batchSize
+        reissueTriggerLifetimeLeft: nil
+      )
+    )
+  }
+
+  func testFromDetails_FailsWhenLimitedTimeIsMissingReissueTriggerLifetimeLeft() {
+    XCTAssertThrowsError(
+      try ReusePolicy.fromDetails(
+        details: [.limitedTime],
+        batchSize: nil,
+        reissueTriggerUnused: nil,
+        reissueTriggerLifetimeLeft: nil
+      )
+    )
+  }
+
+  func testFromDetails_FailsWhenRotatingBatchIsMissingBatchSize() {
+    XCTAssertThrowsError(
+      try ReusePolicy.fromDetails(
+        details: [.limitedTime, .rotatingBatch],
+        batchSize: nil,
+        reissueTriggerUnused: nil,
+        reissueTriggerLifetimeLeft: 100
+      )
+    )
+  }
+
+  func testFromDetails_ReturnsOneOptionPerDetailEntry() throws {
+    let policies = try ReusePolicy.fromDetails(
+      details: [.limitedTime, .rotatingBatch, .perRelyingParty],
+      batchSize: 5,
+      reissueTriggerUnused: 3,
+      reissueTriggerLifetimeLeft: 655433
+    )
+
+    XCTAssertEqual(policies.count, 3)
+
+    // First: LimitedTime
+    if case .limitedTime(let reissueTriggerLifetimeLeft) = policies[0] {
+      XCTAssertEqual(reissueTriggerLifetimeLeft, 655433)
+    } else {
+      XCTFail("Expected limitedTime policy")
+    }
+
+    // Second: RotatingBatch
+    if case .rotatingBatch(let batchSize, let reissueTriggerLifetimeLeft) = policies[1] {
+      XCTAssertEqual(batchSize, 5)
+      XCTAssertEqual(reissueTriggerLifetimeLeft, 655433)
+    } else {
+      XCTFail("Expected rotatingBatch policy")
+    }
+
+    // Third: PerRelyingParty
+    if case .perRelyingParty(let batchSize, let reissueTriggerUnused, let reissueTriggerLifetimeLeft) = policies[2] {
+      XCTAssertEqual(batchSize, 5)
+      XCTAssertEqual(reissueTriggerUnused, 3)
+      XCTAssertEqual(reissueTriggerLifetimeLeft, 655433)
+    } else {
+      XCTFail("Expected perRelyingParty policy")
+    }
+  }
+
+
+  func testFromDetails_ReturnsOnceOnlyAndPerRelyingPartyOptions() throws {
+    let policies = try ReusePolicy.fromDetails(
+      details: [.onceOnly, .perRelyingParty],
+      batchSize: 10,
+      reissueTriggerUnused: 3,
+      reissueTriggerLifetimeLeft: 200
+    )
+
+    
+    XCTAssertEqual(policies.count, 2)
+
+    // First: OnceOnly
+    if case .onceOnly(let batchSize, let reissueTriggerUnused) = policies[0] {
+      XCTAssertEqual(batchSize, 10)
+      XCTAssertEqual(reissueTriggerUnused, 3)
+    } else {
+      XCTFail("Expected onceOnly policy")
+    }
+
+    // Second: PerRelyingParty
+    if case .perRelyingParty(let batchSize, let reissueTriggerUnused, let reissueTriggerLifetimeLeft) = policies[1] {
+      XCTAssertEqual(batchSize, 10)
+      XCTAssertEqual(reissueTriggerUnused, 3)
+      XCTAssertEqual(reissueTriggerLifetimeLeft, 200)
+    } else {
+      XCTFail("Expected perRelyingParty policy")
+    }
+  }
+
+  // MARK: - Method Property Tests
+
+  func testMethod_ReturnsCorrectReuseMethod() {
+    XCTAssertEqual(ReusePolicy.onceOnly(batchSize: 10, reissueTriggerUnused: 4).method, .onceOnly)
+    XCTAssertEqual(ReusePolicy.limitedTime(reissueTriggerLifetimeLeft: 100).method, .limitedTime)
+    XCTAssertEqual(ReusePolicy.rotatingBatch(batchSize: 10, reissueTriggerLifetimeLeft: 100).method, .rotatingBatch)
+    XCTAssertEqual(ReusePolicy.perRelyingParty(batchSize: 10, reissueTriggerUnused: 2, reissueTriggerLifetimeLeft: 100).method, .perRelyingParty)
+  }
+
+  // MARK: - Batch Size Tests
+
+  func testBatchSize_ReturnsCorrectValue() {
+    XCTAssertEqual(ReusePolicy.onceOnly(batchSize: 10, reissueTriggerUnused: 4).batchSize, 10)
+    XCTAssertNil(ReusePolicy.limitedTime(reissueTriggerLifetimeLeft: 100).batchSize)
+    XCTAssertEqual(ReusePolicy.rotatingBatch(batchSize: 20, reissueTriggerLifetimeLeft: 100).batchSize, 20)
+    XCTAssertEqual(ReusePolicy.perRelyingParty(batchSize: 30, reissueTriggerUnused: 5, reissueTriggerLifetimeLeft: 100).batchSize, 30)
+  }
+}

--- a/Tests/Main/ReusePolicyValidatorTests.swift
+++ b/Tests/Main/ReusePolicyValidatorTests.swift
@@ -1,0 +1,250 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import XCTest
+@testable import OpenID4VCI
+
+class ReusePolicyValidatorTests: XCTestCase {
+
+  // MARK: - Policy Selection Tests
+
+  func testSelectMatchingPolicy_ReturnsFirstMatchingPolicy() throws {
+    let policy = CredentialReusePolicy(
+      id: "arf_annex_ii",
+      options: [
+        .limitedTime(reissueTriggerLifetimeLeft: 885433),
+        .onceOnly(batchSize: 10, reissueTriggerUnused: 4)
+      ]
+    )
+
+    let walletConfig = SupportedCredentialReusePolicies.supported([.onceOnly])
+
+    let selected = try CredentialReusePolicyValidator.selectMatchingPolicy(
+      issuerPolicy: policy,
+      walletSupported: walletConfig
+    )
+
+    // Wallet only supports onceOnly, should select the OnceOnly policy (second in list)
+    if case .onceOnly(let batchSize, let reissueTriggerUnused) = selected {
+      XCTAssertEqual(batchSize, 10)
+      XCTAssertEqual(reissueTriggerUnused, 4)
+    } else {
+      XCTFail("Expected onceOnly policy")
+    }
+  }
+
+  func testSelectMatchingPolicy_SelectsFirstWhenMultipleSupported() throws {
+    let policy = CredentialReusePolicy(
+      id: "arf_annex_ii",
+      options: [
+        .limitedTime(reissueTriggerLifetimeLeft: 885433),
+        .rotatingBatch(batchSize: 40, reissueTriggerLifetimeLeft: 655433),
+        .onceOnly(batchSize: 10, reissueTriggerUnused: 4)
+      ]
+    )
+
+    // Wallet supports both limited_time and once_only
+    let walletConfig = SupportedCredentialReusePolicies.supported([.limitedTime, .onceOnly])
+
+    let selected = try CredentialReusePolicyValidator.selectMatchingPolicy(
+      issuerPolicy: policy,
+      walletSupported: walletConfig
+    )
+
+    // Should select first matching (limitedTime)
+    if case .limitedTime(let reissueTriggerLifetimeLeft) = selected {
+      XCTAssertEqual(reissueTriggerLifetimeLeft, 885433)
+    } else {
+      XCTFail("Expected limitedTime policy (first matching)")
+    }
+  }
+
+  func testSelectMatchingPolicy_ThrowsWhenNoMatch() {
+    let policy = CredentialReusePolicy(
+      id: "arf_annex_ii",
+      options: [
+        .rotatingBatch(batchSize: 40, reissueTriggerLifetimeLeft: 655433),
+        .perRelyingParty(batchSize: 60, reissueTriggerUnused: 10, reissueTriggerLifetimeLeft: 777543)
+      ]
+    )
+
+    // Wallet only supports once_only (not in issuer's list)
+    let walletConfig = SupportedCredentialReusePolicies.supported([.onceOnly])
+
+    XCTAssertThrowsError(
+      try CredentialReusePolicyValidator.selectMatchingPolicy(
+        issuerPolicy: policy,
+        walletSupported: walletConfig
+      )
+    ) { error in
+      guard case CredentialReusePolicyError.noSupportedPolicyFound = error else {
+        XCTFail("Expected noSupportedPolicyFound error")
+        return
+      }
+    }
+  }
+
+  func testSelectMatchingPolicy_RequiredWallet_IssuerHasNoPolicy_Throws() {
+    let walletConfig = SupportedCredentialReusePolicies.required([.onceOnly, .limitedTime])
+
+    XCTAssertThrowsError(
+      try CredentialReusePolicyValidator.selectMatchingPolicy(
+        issuerPolicy: nil,
+        walletSupported: walletConfig
+      )
+    ) { error in
+      guard case CredentialReusePolicyError.noSupportedPolicyFound = error else {
+        XCTFail("Expected noSupportedPolicyFound error")
+        return
+      }
+    }
+  }
+
+  func testSelectMatchingPolicy_SupportedWallet_IssuerHasNoPolicy_ReturnsNil() throws {
+    let walletConfig = SupportedCredentialReusePolicies.supported([.onceOnly, .limitedTime])
+
+    let selected = try CredentialReusePolicyValidator.selectMatchingPolicy(
+      issuerPolicy: nil,
+      walletSupported: walletConfig
+    )
+
+    XCTAssertNil(selected)
+  }
+
+  func testSelectMatchingPolicy_NotSupportedWallet_IssuerHasPolicy_ReturnsNil() {
+    let policy = CredentialReusePolicy(
+      id: "arf_annex_ii",
+      options: [
+        .onceOnly(batchSize: 10, reissueTriggerUnused: 4)
+      ]
+    )
+
+    let walletConfig = SupportedCredentialReusePolicies.notSupported
+
+    XCTAssertNoThrow(
+      try {
+        let result = try CredentialReusePolicyValidator.selectMatchingPolicy(
+          issuerPolicy: policy,
+          walletSupported: walletConfig
+        )
+        XCTAssertNil(result, "Should return nil when wallet doesn't support policies")
+      }()
+    )
+  }
+
+  func testSelectMatchingPolicy_UnknownPolicyId_Throws() {
+    let policy = CredentialReusePolicy(
+      id: "some_unknown_policy",
+      options: [
+        .onceOnly(batchSize: 10, reissueTriggerUnused: 4)
+      ]
+    )
+
+    let walletConfig = SupportedCredentialReusePolicies.supported([.onceOnly])
+
+    XCTAssertThrowsError(
+      try CredentialReusePolicyValidator.selectMatchingPolicy(
+        issuerPolicy: policy,
+        walletSupported: walletConfig
+      )
+    ) { error in
+      guard case CredentialReusePolicyError.unsupportedPolicyId(let id) = error else {
+        XCTFail("Expected unsupportedPolicyId error")
+        return
+      }
+      XCTAssertEqual(id, "some_unknown_policy")
+    }
+  }
+
+  // MARK: - Batch Size Determination Tests
+
+  func testDetermineBatchSize_ReusePolicyWins() {
+    let policy = ReusePolicy.onceOnly(batchSize: 10, reissueTriggerUnused: 4)
+    let issuerBatchSize = 50
+
+    let effectiveBatchSize = CredentialReusePolicyValidator.determineBatchSize(
+      selectedPolicy: policy,
+      issuerBatchSize: issuerBatchSize
+    )
+
+    XCTAssertEqual(effectiveBatchSize, 10) // Policy wins, not 50
+  }
+
+  func testDetermineBatchSize_FallbackToIssuerBatchSize() {
+    let policy = ReusePolicy.limitedTime(reissueTriggerLifetimeLeft: 885433) // No batch size
+    let issuerBatchSize = 50
+
+    let effectiveBatchSize = CredentialReusePolicyValidator.determineBatchSize(
+      selectedPolicy: policy,
+      issuerBatchSize: issuerBatchSize
+    )
+
+    XCTAssertEqual(effectiveBatchSize, 50) // Fallback to issuer
+  }
+
+  func testDetermineBatchSize_NoBatchSize() {
+    let effectiveBatchSize = CredentialReusePolicyValidator.determineBatchSize(
+      selectedPolicy: nil,
+      issuerBatchSize: nil
+    )
+
+    XCTAssertNil(effectiveBatchSize)
+  }
+
+  func testDetermineBatchSize_OnlyIssuerBatchSize() {
+    let effectiveBatchSize = CredentialReusePolicyValidator.determineBatchSize(
+      selectedPolicy: nil,
+      issuerBatchSize: 25
+    )
+
+    XCTAssertEqual(effectiveBatchSize, 25)
+  }
+
+  // MARK: - Proof Count Validation Tests
+
+  func testValidateProofCount_MatchingCount_Succeeds() {
+    XCTAssertNoThrow(
+      try CredentialReusePolicyValidator.validateProofCount(
+        proofCount: 10,
+        requiredBatchSize: 10
+      )
+    )
+  }
+
+  func testValidateProofCount_MismatchCount_Throws() {
+    XCTAssertThrowsError(
+      try CredentialReusePolicyValidator.validateProofCount(
+        proofCount: 5,
+        requiredBatchSize: 10
+      )
+    ) { error in
+      guard case CredentialReusePolicyError.batchSizeMismatch(let required, let provided) = error else {
+        XCTFail("Expected batchSizeMismatch error")
+        return
+      }
+      XCTAssertEqual(required, 10)
+      XCTAssertEqual(provided, 5)
+    }
+  }
+
+  func testValidateProofCount_NoRequirement_Succeeds() {
+    XCTAssertNoThrow(
+      try CredentialReusePolicyValidator.validateProofCount(
+        proofCount: 100,
+        requiredBatchSize: nil
+      )
+    )
+  }
+}


### PR DESCRIPTION
# Description of change

This PR implements comprehensive support for Credential Reuse Policies in the OpenID4VCI library, fully aligned with ETSI TS 119 472-3 and ARF Annex II specifications

Closes: #231 

## Type of change

  1. Domain Models (Sources/Entities/CredentialReuse/)
  - ReuseMethod - Enum representing the 4 ARF Annex II methods
  - ReusePolicy - Enum with associated values for each method's parameters (batch_size, reissue triggers, etc.)
  - CredentialReusePolicy - Issuer metadata policy with id ("arf_annex_ii") and options array
  - SupportedCredentialReusePolicies - Wallet configuration (.supported, .required, .notSupported)
  - ReusePolicyOption - Internal JSON parsing helper
  - CredentialReusePolicyError - Comprehensive error types

  2. Validation Logic (Sources/Main/Validators/)
  - CredentialReusePolicyValidator - Policy matching and validation
    - Selects best matching policy between issuer and wallet
    - Determines batch size (policy vs metadata priority)
    - Validates proof count matches batch size requirements

  3. Integration Points
  - Issuer metadata parsing with credential_reuse_policy field
  - Batch credential issuance support
  - Proof generation aligned with batch requirements




- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes