### PR TITLE
Refine validation for cryptographic binding methods and proof types

### DIFF
--- a/Sources/Entities/Profiles/MsoMdocFormat.swift
+++ b/Sources/Entities/Profiles/MsoMdocFormat.swift
@@ -351,11 +351,13 @@ public extension MsoMdocFormat {
       switch credentialConfigurationsSupported.value {
       case .msoMdoc(let profile):
         
-        // Validation: proof_types_supported must be present if cryptographic_binding_methods_supported is present
-        if !profile.cryptographicBindingMethodsSupported.isEmpty {
-          guard let proofTypes = profile.proofTypesSupported, !proofTypes.isEmpty else {
-            throw ValidationError.error(reason: "Property `proof_types_supported` must be present if `cryptographic_binding_methods_supported` is present")
-          }
+        let hasBindingMethods = !profile.cryptographicBindingMethodsSupported.isEmpty
+        let hasProofTypes = profile.proofTypesSupported?.isEmpty == false
+
+        if hasBindingMethods != hasProofTypes {
+          throw ValidationError.error(
+            reason: "Properties `proof_types_supported` and `cryptographic_binding_methods_supported` must both be present or both be omitted"
+          )
         }
         
         return .msoMdoc(.init(docType: docType, scope: profile.scope))

--- a/Sources/Entities/Profiles/SdJwtVcFormat.swift
+++ b/Sources/Entities/Profiles/SdJwtVcFormat.swift
@@ -404,11 +404,13 @@ public extension SdJwtVcFormat {
       switch credentialConfigurationsSupported.value {
       case .sdJwtVc(let profile):
         
-        // Validation: proof_types_supported must be present if cryptographic_binding_methods_supported is present
-        if !profile.cryptographicBindingMethodsSupported.isEmpty {
-          guard let proofTypes = profile.proofTypesSupported, !proofTypes.isEmpty else {
-            throw ValidationError.error(reason: "Property `proof_types_supported` must be present if `cryptographic_binding_methods_supported` is present")
-          }
+        let hasBindingMethods = !profile.cryptographicBindingMethodsSupported.isEmpty
+        let hasProofTypes = profile.proofTypesSupported?.isEmpty == false
+
+        if hasBindingMethods != hasProofTypes {
+          throw ValidationError.error(
+            reason: "Properties `proof_types_supported` and `cryptographic_binding_methods_supported` must both be present or both be omitted"
+          )
         }
         
         return .sdJwtVc(.init(

--- a/Sources/Entities/Profiles/W3CJsonLdDataIntegrityFormat.swift
+++ b/Sources/Entities/Profiles/W3CJsonLdDataIntegrityFormat.swift
@@ -300,11 +300,13 @@ public extension W3CJsonLdDataIntegrityFormat {
       switch credentialConfigurationsSupported.value {
       case .w3CJsonLdDataIntegrity(let profile):
         
-        // Validation: proof_types_supported must be present if cryptographic_binding_methods_supported is present
-        if !profile.cryptographicBindingMethodsSupported.isEmpty {
-          guard let proofTypes = profile.proofTypesSupported, !proofTypes.isEmpty else {
-            throw ValidationError.error(reason: "Property `proof_types_supported` must be present if `cryptographic_binding_methods_supported` is present")
-          }
+        let hasBindingMethods = !profile.cryptographicBindingMethodsSupported.isEmpty
+        let hasProofTypes = profile.proofTypesSupported?.isEmpty == false
+
+        if hasBindingMethods != hasProofTypes {
+          throw ValidationError.error(
+            reason: "Properties `proof_types_supported` and `cryptographic_binding_methods_supported` must both be present or both be omitted"
+          )
         }
         
         return .w3CJsonLdDataIntegrity(.init(

--- a/Sources/Entities/Profiles/W3CJsonLdSignedJwtFormat.swift
+++ b/Sources/Entities/Profiles/W3CJsonLdSignedJwtFormat.swift
@@ -287,11 +287,13 @@ public extension W3CJsonLdSignedJwtFormat {
       switch credentialConfigurationsSupported.value {
       case .w3CJsonLdSignedJwt(let profile):
         
-        // Validation: proof_types_supported must be present if cryptographic_binding_methods_supported is present
-        if !profile.cryptographicBindingMethodsSupported.isEmpty {
-          guard let proofTypes = profile.proofTypesSupported, !proofTypes.isEmpty else {
-            throw ValidationError.error(reason: "Property `proof_types_supported` must be present if `cryptographic_binding_methods_supported` is present")
-          }
+        let hasBindingMethods = !profile.cryptographicBindingMethodsSupported.isEmpty
+        let hasProofTypes = profile.proofTypesSupported?.isEmpty == false
+
+        if hasBindingMethods != hasProofTypes {
+          throw ValidationError.error(
+            reason: "Properties `proof_types_supported` and `cryptographic_binding_methods_supported` must both be present or both be omitted"
+          )
         }
         
         return .w3CJsonLdSignedJwt(.init(

--- a/Sources/Entities/Profiles/W3CSignedJwtFormat.swift
+++ b/Sources/Entities/Profiles/W3CSignedJwtFormat.swift
@@ -357,11 +357,13 @@ public extension W3CSignedJwtFormat {
       switch credentialConfigurationsSupported.value {
       case .w3CSignedJwt(let profile):
         
-        // Validation: proof_types_supported must be present if cryptographic_binding_methods_supported is present
-        if !profile.cryptographicBindingMethodsSupported.isEmpty {
-          guard let proofTypes = profile.proofTypesSupported, !proofTypes.isEmpty else {
-            throw ValidationError.error(reason: "Property `proof_types_supported` must be present if `cryptographic_binding_methods_supported` is present")
-          }
+        let hasBindingMethods = !profile.cryptographicBindingMethodsSupported.isEmpty
+        let hasProofTypes = profile.proofTypesSupported?.isEmpty == false
+
+        if hasBindingMethods != hasProofTypes {
+          throw ValidationError.error(
+            reason: "Properties `proof_types_supported` and `cryptographic_binding_methods_supported` must both be present or both be omitted"
+          )
         }
         
         return .w3CSignedJwt(.init(


### PR DESCRIPTION
# Description of change

Addresses the additional info added in #242 

This PR implements the following validation: 

ΙΑ 2024/2979 mentions the following in Annex Ib:
TR_KA-4.1: Where a credential issuer issues non-device-bound credentials, it shall omit the "proof_types_supported" and the "cryptographic_binding_methods_supported" parameters in the Credential Issuer Metadata.

Either both cryptographic_binding_methods_supported and proof_types_supported should be present in a credential configuration or both missing

