### PR TITLE
feat: add kid to header on issuance

### DIFF
--- a/Sources/Main/Services/AuthorisationService.swift
+++ b/Sources/Main/Services/AuthorisationService.swift
@@ -189,6 +189,11 @@ private extension AuthorisationService {
     /// If the spec's key is a JWK, embed it in the header.
     if let jwkDict = try? spec.recipientKey.toDictionary() {
       headerParams["jwk"] = jwkDict
+        
+      /// Per OpenID4VCI 1.0 Section 10: add kid to root if present in JWK
+      if let kid = jwkDict["kid"] as? String {
+        headerParams["kid"] = kid
+      }
     }
 
     let header = try JWEHeader(parameters: headerParams)


### PR DESCRIPTION
# Description of change

This PR updates AuthorisationService.makeJWE() to include the kid (Key ID) parameter at the root level of the JWE header when the recipient JWK contains a kid.

This change aligns the implementation with the OpenID4VCI 1.0 specification requirements for encrypted credential requests and responses.

Specification Reference

Per OpenID4VCI 1.0 Section 10:

If the selected public key contains a kid parameter, the JWE MUST include the same value in the kid JWE Header Parameter

Source: [OpenID4VCI 1.0 Section 10](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-encrypted-credential-reques)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
