### PR TITLE
fix(issuance): make key-attestation credential issuance work (attestation alg lookup + jwtKeyAttestation inline jwk)

### DIFF
--- a/Sources/Entities/Encryption/BindingKey.swift
+++ b/Sources/Entities/Encryption/BindingKey.swift
@@ -161,10 +161,22 @@ public extension BindingKey {
         break
       }
       
+      // OID4VCI Appendix F: a jwt proof header identifies the signing key with
+      // exactly one of jwk / kid / x5c. A verifier (e.g. the OpenID Foundation
+      // conformance suite) resolves kid against a pre-established client jwks,
+      // not against the key_attestation's attested_keys. So put the attested
+      // public key (attested_keys[keyIndex]) inline as jwk instead of kid; this
+      // lets a jwt proof that carries a key_attestation resolve its key.
+      guard Int(keyIndex) < keyAttestationJwt.attestedKeys.count else {
+        throw ValidationError.todo(
+          reason: ".jwtKeyAttestation: keyIndex (\(keyIndex)) out of range for attested_keys (count: \(keyAttestationJwt.attestedKeys.count))"
+        )
+      }
+      let attestedPublicKey = keyAttestationJwt.attestedKeys[Int(keyIndex)]
       let header: JWSHeader = try .init(
         parameters: [
           JWTClaimNames.algorithm: algorithm.name,
-          JWTClaimNames.kid: "\(keyIndex)",
+          JWTClaimNames.JWK: attestedPublicKey.toDictionary(),
           JWTClaimNames.type: Self.OpenID4VCIProofJWT,
           JWTClaimNames.keyAttestation: keyAttestationJwt.jws.compactSerializedString
         ]

--- a/Sources/Issuers/IssuanceRequester.swift
+++ b/Sources/Issuers/IssuanceRequester.swift
@@ -409,7 +409,7 @@ private extension IssuanceRequester {
     // Validate KeyAttestation proofs
     if !attestations.isEmpty {
       let advertised = try advertisedAlgs(
-        for: .jwt,
+        for: .attestation,
         configId: configId,
         issuerMetadata: issuerMetadata
       )

--- a/Sources/Resources/well-known/openid-credential-issuer_attestation_only.json
+++ b/Sources/Resources/well-known/openid-credential-issuer_attestation_only.json
@@ -1,0 +1,404 @@
+{
+  "credential_issuer": "https://credential-issuer.example.com",
+  "authorization_servers": [
+    "https://auth-server.example.com"
+  ],
+  "credential_endpoint": "https://credential-issuer.example.com/credentials",
+  "nonce_endpoint": "https://credential-issuer.example.com/nonce",
+  "deferred_credential_endpoint": "https://credential-issuer.example.com/credentials/deferred",
+  "notification_endpoint": "https://credential-issuer.example.com/notification",
+  "credential_request_encryption": {
+    "jwks": {
+      "keys": [
+        {
+          "kty": "EC",
+          "use": "enc",
+          "crv": "P-256",
+          "alg": "ECDH-ES",
+          "kid": "encKey-0",
+          "x": "TmcsNF6JpWjP85wKfBXKybHaJNowtp6jCuToppDosdw",
+          "y": "egzDuJuSxyypCE0qUoo1oKOnslpaw1Om-flQ4knafas",
+          "iat": 1755352588
+        }
+      ]
+    },
+    "enc_values_supported": [
+      "XC20P",
+      "A128GCM"
+    ],
+    "zip_values_supported": [
+      "DEF"
+    ],
+    "encryption_required": true
+  },
+  "credential_response_encryption": {
+    "alg_values_supported": [
+      "RSA-OAEP",
+      "RSA-OAEP-256",
+      "ECDH-ES"
+    ],
+    "enc_values_supported": [
+      "A128CBC-HS256",
+      "A128GCM"
+    ],
+    "encryption_required": false
+  },
+  "batch_credential_issuance": {
+    "batch_size": 3
+  },
+  "credential_identifiers_supported": true,
+  "credential_configurations_supported": {
+    "eu.europa.ec.eudiw.pid_vc_sd_jwt": {
+      "format": "dc+sd-jwt",
+      "scope": "eu.europa.ec.eudiw.pid_vc_sd_jwt",
+      "cryptographic_binding_methods_supported": [
+        "jwk"
+      ],
+      "credential_signing_alg_values_supported": [
+        "RS256"
+      ],
+      "proof_types_supported": {
+        "attestation": {
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ],
+          "key_attestations_required": {}
+        }
+      },
+      "vct": "eu.europa.ec.eudiw.pid.1",
+      "claims": [
+        {
+          "path": [
+            "given_name"
+          ],
+          "display": [
+            {
+              "name": "Given Name",
+              "locale": "en-US"
+            }
+          ]
+        },
+        {
+          "path": [
+            "family_name"
+          ],
+          "display": [
+            {
+              "name": "Surname",
+              "locale": "en-US"
+            }
+          ]
+        },
+        {
+          "path": [
+            "birth_date"
+          ]
+        }
+      ],
+      "display": [
+        {
+          "name": "Personal Identification Data ",
+          "locale": "en-US",
+          "logo": {
+            "uri": "https://examplestate.com/public/pid.png",
+            "alt_text": "a square logo of a university"
+          },
+          "background_color": "#12107c",
+          "text_color": "#FFFFFF"
+        }
+      ]
+    },
+    "eu.europa.ec.eudiw.pid_mso_mdoc": {
+      "format": "mso_mdoc",
+      "scope": "eu.europa.ec.eudiw.pid_mso_mdoc",
+      "doctype": "org.iso.18013.5.1.PID",
+      "cryptographic_binding_methods_supported": [
+        "jwk"
+      ],
+      "credential_signing_alg_values_supported": [
+        "RS256"
+      ],
+      "proof_types_supported": {
+        "jwt": {
+          "proof_signing_alg_values_supported": [
+            "RS256",
+            "ES256"
+          ]
+        }
+      },
+      "display": [
+        {
+          "name": "Personal Identification Data",
+          "locale": "en-US",
+          "logo": {
+            "uri": "https://examplestate.com/public/pid.png",
+            "alt_text": "a square figure of a mobile driving license"
+          },
+          "background_color": "#12107c",
+          "background_image": {
+            "uri": "https://examplestate.com/public/background.png"
+          },
+          "text_color": "#FFFFFF"
+        }
+      ],
+      "claims": [
+        {
+          "path": [
+            "org.iso.18013.5.1",
+            "given_name"
+          ],
+          "display": [
+            {
+              "name": "Given Name",
+              "locale": "en-US"
+            }
+          ]
+        },
+        {
+          "path": [
+            "org.iso.18013.5.1",
+            "family_name"
+          ],
+          "display": [
+            {
+              "name": "Surname",
+              "locale": "en-US"
+            }
+          ]
+        },
+        {
+          "path": [
+            "org.iso.18013.5.1",
+            "birth_date"
+          ]
+        },
+        {
+          "path": [
+            "org.iso.18013.5.1.aamva",
+            "organ_donor"
+          ]
+        }
+      ]
+    },
+    "UniversityDegree_mso_mdoc": {
+      "format": "mso_mdoc",
+      "scope": "UniversityDegree",
+      "doctype": "org.iso.18013.5.1.Degree",
+      "cryptographic_binding_methods_supported": [
+        "jwk"
+      ],
+      "credential_signing_alg_values_supported": [
+        "RS256"
+      ],
+      "proof_types_supported": {
+        "jwt": {
+          "proof_signing_alg_values_supported": [
+            "RS256",
+            "ES256"
+          ]
+        }
+      },
+      "display": [
+        {
+          "name": "Mobile Driving License",
+          "locale": "en-US",
+          "logo": {
+            "uri": "https://examplestate.com/public/mdl.png",
+            "alt_text": "a square figure of a mobile driving license"
+          },
+          "background_color": "#12107c",
+          "background_image": {
+            "uri": "https://examplestate.com/public/background.png"
+          },
+          "text_color": "#FFFFFF"
+        }
+      ],
+      "claims": [
+        {
+          "path": [
+            "org.iso.18013.5.1",
+            "given_name"
+          ],
+          "display": [
+            {
+              "name": "Given Name",
+              "locale": "en-US"
+            }
+          ]
+        },
+        {
+          "path": [
+            "org.iso.18013.5.1",
+            "family_name"
+          ],
+          "display": [
+            {
+              "name": "Surname",
+              "locale": "en-US"
+            }
+          ]
+        },
+        {
+          "path": [
+            "org.iso.18013.5.1",
+            "birth_date"
+          ]
+        },
+        {
+          "path": [
+            "org.iso.18013.5.1.aamva",
+            "organ_donor"
+          ]
+        }
+      ]
+    },
+    "UniversityDegree_jwt_vc_json": {
+      "format": "jwt_vc_json",
+      "scope": "UniversityDegree",
+      "cryptographic_binding_methods_supported": [
+        "did:example"
+      ],
+      "credential_signing_alg_values_supported": [
+        "ES256"
+      ],
+      "credential_definition": {
+        "type": [
+          "VerifiableCredential",
+          "UniversityDegreeCredential"
+        ]
+      },
+      "proof_types_supported": {
+        "jwt": {
+          "proof_signing_alg_values_supported": [
+            "RS256",
+            "ES256"
+          ]
+        }
+      },
+      "display": [
+        {
+          "name": "University Credential",
+          "locale": "en-US",
+          "logo": {
+            "url": "https://university.example.edu/public/logo.png",
+            "alt_text": "a square logo of a university"
+          },
+          "background_color": "#12107c",
+          "text_color": "#FFFFFF"
+        }
+      ],
+      "claims": [
+        {
+          "path": [
+            "given_name"
+          ],
+          "display": [
+            {
+              "name": "Given Name",
+              "locale": "en-US"
+            }
+          ]
+        },
+        {
+          "path": [
+            "family_name"
+          ],
+          "display": [
+            {
+              "name": "Surname",
+              "locale": "en-US"
+            }
+          ]
+        },
+        {
+          "path": [
+            "degree"
+          ]
+        },
+        {
+          "path": [
+            "gpa"
+          ],
+          "display": [
+            {
+              "name": "name",
+              "locale": "GPA"
+            }
+          ]
+        }
+      ]
+    },
+    "MobileDrivingLicense_msoMdoc": {
+      "format": "mso_mdoc",
+      "scope": "MobileDrivingLicense_msoMdoc",
+      "doctype": "org.iso.18013.5.1.mDL",
+      "cryptographic_binding_methods_supported": [
+        "cose_key"
+      ],
+      "credential_signing_alg_values_supported": [
+        "ES256",
+        "ES384",
+        "ES512"
+      ],
+      "display": [
+        {
+          "name": "Mobile Driving License",
+          "locale": "en-US",
+          "logo": {
+            "uri": "https://examplestate.com/public/mdl.png",
+            "alt_text": "a square figure of a mobile driving license"
+          },
+          "background_color": "#12107c",
+          "background_image": {
+            "uri": "https://examplestate.com/public/background.png"
+          },
+          "text_color": "#FFFFFF"
+        }
+      ],
+      "claims": [
+        {
+          "path": [
+            "org.iso.18013.5.1",
+            "given_name"
+          ],
+          "display": [
+            {
+              "name": "Given Name",
+              "locale": "en-US"
+            }
+          ]
+        },
+        {
+          "path": [
+            "org.iso.18013.5.1",
+            "family_name"
+          ],
+          "display": [
+            {
+              "name": "Surname",
+              "locale": "en-US"
+            }
+          ]
+        },
+        {
+          "path": [
+            "org.iso.18013.5.1",
+            "birth_date"
+          ]
+        },
+        {
+          "path": [
+            "org.iso.18013.5.1.aamva",
+            "organ_donor"
+          ]
+        }
+      ]
+    }
+  },
+  "display": [
+    {
+      "name": "credential-issuer.example.com",
+      "locale": "en-US"
+    }
+  ]
+}

--- a/Sources/Resources/well-known/openid-credential-issuer_key_attestation_required.json
+++ b/Sources/Resources/well-known/openid-credential-issuer_key_attestation_required.json
@@ -71,6 +71,19 @@
               "iso_18045_moderate"
             ]
           }
+        },
+        "attestation": {
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ],
+          "key_attestations_required": {
+            "key_storage": [
+              "iso_18045_moderate"
+            ],
+            "user_authentication": [
+              "iso_18045_moderate"
+            ]
+          }
         }
       },
       "vct": "eu.europa.ec.eudiw.pid.1",

--- a/Tests/AttestationBased/KeyAttestationTests.swift
+++ b/Tests/AttestationBased/KeyAttestationTests.swift
@@ -245,8 +245,107 @@ class KeyAttestationTests: XCTestCase {
         key: data.privateKey
       )!
     ))
-    
+
     XCTAssert(true)
+  }
+
+  // Regression (Bug#2): a jwt key-attestation proof header must carry an inline
+  // `jwk` and must not use a `kid` (= keyIndex) that a verifier cannot resolve.
+  // Before the fix (v0.38.x / v0.39.0) this test fails (kid present, jwk absent).
+  func testJwtKeyAttestationProofHeaderHasInlineJwkNotKid() async throws {
+    let configId = try CredentialConfigurationIdentifier(value: "eu.europa.ec.eudiw.pid_vc_sd_jwt")
+    let spec = try XCTUnwrap(
+      data.offer.credentialIssuerMetadata.credentialsSupported[configId]
+    )
+    let requester = IssuanceRequester(
+      issuerMetadata: data.offer.credentialIssuerMetadata,
+      poster: Poster(
+        session: NetworkingMock(
+          path: "batch_credential_issuance_success_response_credentials",
+          extension: "json"
+        )
+      )
+    )
+    let keyAttestation = try KeyAttestationJWT(
+      jws: try JWS(compactSerialization: TestsConstants.ketAttestationJWT)
+    )
+
+    let bindingKey: BindingKey = try .jwtKeyAttestation(
+      algorithm: .init(.ES256),
+      keyAttestationJWT: { _ in keyAttestation },
+      keyIndex: 0,
+      privateKey: .secKey(data.privateKey)
+    )
+
+    let proof = try await bindingKey.toSupportedProof(
+      issuanceRequester: requester,
+      credentialSpec: spec,
+      keyAttestationJwt: keyAttestation,
+      cNonce: "test-nonce",
+      omitIss: false
+    )
+
+    let header = try Self.decodeJWTHeader(proof.proof)
+    XCTAssertNotNil(header["jwk"], "jwt key attestation proof header must carry inline jwk")
+    XCTAssertNil(header["kid"], "jwt key attestation proof header must not use kid (unresolvable at verifier)")
+  }
+
+  // Regression (Bug#1): when an attestation proof is sent to an issuer that
+  // advertises only the `attestation` proof type, the algorithms are validated
+  // against the `attestation` advertised algs. Before the fix they were looked
+  // up with `for: .jwt`, always failing with "Issuer did not advertise any
+  // algorithms for JWT proofs".
+  func testAttestationProofValidatedAgainstAttestationAlgsNotJwt() async throws {
+    let offerOptional = await TestsConstants.createMockCredentialOfferAttestationOnly()
+    let offer = try XCTUnwrap(offerOptional)
+    let spec = data.spec
+    let issuer = try Issuer(
+      authorizationServerMetadata: offer.authorizationServerMetadata,
+      issuerMetadata: offer.credentialIssuerMetadata,
+      config: config,
+      parPoster: Poster(session: NetworkingMock(path: "pushed_authorization_request_response", extension: "json")),
+      tokenPoster: Poster(session: NetworkingMock(path: "access_token_request_response_no_proof", extension: "json")),
+      requesterPoster: Poster(session: NetworkingMock(path: "batch_credential_issuance_success_response_credentials", extension: "json")),
+      noncePoster: Poster(session: NetworkingMock(path: "mock_cnonce_endpoint_response", extension: "json")),
+      dpopConstructor: dpopConstructor(algorithms: offer.authorizationServerMetadata.dpopSigningAlgValuesSupported)
+    )
+
+    let authorized = try await issuer.authorizeWithAuthorizationCode(
+      serverState: TestsConstants.unAuthorizedRequest.state,
+      request: TestsConstants.unAuthorizedRequest,
+      authorizationCode: try AuthorizationCode(value: "MZqG9bsQ8UALhsGNlY39Yw=="),
+      grant: offer.grants!
+    )
+
+    let keyBindingKey: BindingKey = .attestation(
+      keyAttestationJWT: { _ in
+        try! .init(jws: try! .init(compactSerialization: TestsConstants.ketAttestationJWT))
+      }
+    )
+    let payload: IssuanceRequestPayload = .configurationBased(
+      credentialConfigurationIdentifier: try .init(value: "eu.europa.ec.eudiw.pid_vc_sd_jwt")
+    )
+
+    do {
+      _ = try await issuer.requestCredential(
+        request: authorized,
+        bindingKeys: [keyBindingKey],
+        requestPayload: payload,
+        responseEncryptionSpecProvider: { _ in spec }
+      )
+    } catch {
+      XCTFail("attestation proof was rejected by an attestation-only issuer (Bug#1): \(error.localizedDescription)")
+    }
+  }
+
+  private static func decodeJWTHeader(_ jwt: String) throws -> [String: Any] {
+    let segment = String(jwt.split(separator: ".").first ?? "")
+    var base64 = segment
+      .replacingOccurrences(of: "-", with: "+")
+      .replacingOccurrences(of: "_", with: "/")
+    while base64.count % 4 != 0 { base64 += "=" }
+    let bytes = try XCTUnwrap(Data(base64Encoded: base64))
+    return try XCTUnwrap(JSONSerialization.jsonObject(with: bytes) as? [String: Any])
   }
 }
 

--- a/Tests/Constants/TestsConstants.swift
+++ b/Tests/Constants/TestsConstants.swift
@@ -312,7 +312,39 @@ struct TestsConstants {
       policy: .ignoreSigned
     ).get()
   }
-  
+
+  // An issuer whose proof_types_supported advertises only `attestation` (no jwt).
+  // Used to reproduce the attestation-proof algorithm-validation bug (Bug#1).
+  static func createMockCredentialOfferAttestationOnly() async -> CredentialOffer? {
+    let credentialIssuerMetadataResolver = CredentialIssuerMetadataResolver(
+      fetcher: MetadataFetcher(rawFetcher: RawDataFetcher(session: NetworkingMock(
+        path: "openid-credential-issuer_attestation_only",
+        extension: "json",
+        headers: ["Content-type": "application/json"]
+      ))))
+
+    let authorizationServerMetadataResolver = AuthorizationServerMetadataResolver(
+      oidcFetcher: Fetcher<OIDCProviderMetadata>(session: NetworkingMock(
+        path: "oidc_authorization_server_metadata",
+        extension: "json"
+      ))
+    )
+
+    let credentialOfferRequestResolver = CredentialOfferRequestResolver(
+      fetcher: Fetcher<CredentialOfferRequestObject>(session: NetworkingMock(
+        path: "credential_offer_with_blank_pre_authorized_code",
+        extension: "json"
+      )),
+      credentialIssuerMetadataResolver: credentialIssuerMetadataResolver,
+      authorizationServerMetadataResolver: authorizationServerMetadataResolver
+    )
+
+    return try? await credentialOfferRequestResolver.resolve(
+      source: .fetchByReference(url: .stub()),
+      policy: .ignoreSigned
+    ).get()
+  }
+
   static func createMockCredentialOfferValidEncryptionWithBatchLimit() async -> CredentialOffer? {
     let credentialIssuerMetadataResolver = CredentialIssuerMetadataResolver(
       fetcher: MetadataFetcher(rawFetcher: RawDataFetcher(session: NetworkingMock(


### PR DESCRIPTION
# Description of change

Two fixes that make key-attestation credential issuance succeed at a spec-compliant Credential Endpoint. Both are described in #277.

**Fix 1 — attestation proofs validated against attestation algorithms.** `IssuanceRequester.validateProofs()` looked up advertised algorithms with `for: .jwt` in the attestation-proof branch, so an issuer that advertises only the `attestation` proof type rejected every attestation proof with *"Issuer did not advertise any algorithms for JWT proofs"*. Changed to `for: .attestation`.

**Fix 2 — jwtKeyAttestation proof header carries an inline jwk.** `BindingKey.toSupportedProof` built the `.jwtKeyAttestation` header with `kid: "<keyIndex>"` and no `jwk`. Verifiers resolve `kid` against a pre-established key set, not the `key_attestation`'s `attested_keys`, so these proofs failed with *"Could not resolve Key ID (kid) ... / Couldn't find public JWK in proof_jwt header.jwk"*. Now uses `attested_keys[keyIndex]` as the inline `jwk`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Added two regression tests in `Tests/AttestationBased/KeyAttestationTests.swift` (plus an attestation-only metadata fixture and `createMockCredentialOfferAttestationOnly()`):

- `testAttestationProofValidatedAgainstAttestationAlgsNotJwt` — an issuer advertising only the `attestation` proof type + an attestation proof. Fails on the unmodified library with the JWT-algorithms error; passes with the fix.
- `testJwtKeyAttestationProofHeaderHasInlineJwkNotKid` — builds a `.jwtKeyAttestation` proof via `toSupportedProof` and inspects the header. On the unmodified library the header has `kid: "0"` and no `jwk`; with the fix it carries an inline `jwk` and no `kid`.

Both fail on the unmodified library and pass with the fixes. The full test suite passes locally (**246 tests, 0 failures**). The fixes also cherry-pick cleanly onto v0.38.3 and v0.39.0. End-to-end, both fixes let a key-attestation issuance pass the OpenID Foundation conformance suite for the `attestation` and `jwt`(+`key_attestation`) proof types.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Addresses #277
