### PR TITLE
Validate ClientAttestationJWT as a TS3 Wallet Instance Attestation

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,15 @@ interactions use the newly provided DPoP Nonce value.
 
 ### OAUTH2 Attestation-Based Client Authentication
 
-Library supports [OAUTH2 Attestation-Based Client Authentication - Draft 03](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-03.html)
+Library supports [OAUTH2 Attestation-Based Client Authentication - Draft 03](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-03.html).
+
+When a `Client.attested(...)` is used, the provided `ClientAttestationJWT` is eagerly validated as a **Wallet Instance Attestation per [TS3 v1.5 §2.3](https://github.com/eu-digital-identity-wallet/eudi-doc-standards-and-technical-specifications/blob/main/docs/technical-specifications/ts3-wallet-unit-attestation.md#23-content)**. The JWT must:
+
+- be signed with `ES256`, `ES384`, or `ES512`
+- carry header `typ` of `oauth-client-attestation+jwt` (when set)
+- contain the required claims: `iss`, `sub`, `exp`, `cnf.jwk` (public key), `wallet_name`, `wallet_version`, `wallet_solution_certification_information`, and `client_status` (with nested `status_list` reference and `exp`)
+
+Parsed values are available via the typed `attestation.claimsSet` (e.g. `attestation.claimsSet.walletName.value`, `attestation.publicKey`). Wallet Provider back-ends MUST issue WIAs that include every required claim, otherwise construction fails with a specific `ClientAttestationError` naming the missing or invalid claim.
 
 An example can be found in this test: `testNoOfferSdJWTClientAuthentication()`
 

--- a/Sources/Entities/Types/JWTClaimNames.swift
+++ b/Sources/Entities/Types/JWTClaimNames.swift
@@ -53,4 +53,19 @@ public extension JWTClaimNames {
   static let kid = "kid"
   static let keyAttestation = "key_attestation"
   static let challenge = "challenge"
+  static let walletName = "wallet_name"
+  static let walletVersion = "wallet_version"
+  static let walletLink = "wallet_link"
+  static let walletSolutionCertificationInformation = "wallet_solution_certification_information"
+  static let clientStatus = "client_status"
+  static let status = "status"
+  static let statusList = "status_list"
+  static let idx = "idx"
+  static let uri = "uri"
+}
+
+public struct AttestationBasedClientAuthenticationSpec {
+  public static let attestationJwtType = "oauth-client-attestation+jwt"
+  public static let attestationPopJwtType = "oauth-client-attestation-pop+jwt"
+  private init() {}
 }

--- a/Sources/Main/AttestationBasedClient/ClientAttestation.swift
+++ b/Sources/Main/AttestationBasedClient/ClientAttestation.swift
@@ -17,25 +17,49 @@ import Foundation
 @preconcurrency import JOSESwift
 @preconcurrency import SwiftyJSON
 
+/// A `ClientAttestationJWT` is the Wallet Instance Attestation (WIA) sent by the wallet
+/// to the authorization server when using attestation-based client authentication.
+///
+/// Construction eagerly validates that the JWT is a valid WIA
+/// header `typ` is `oauth-client-attestation+jwt`, the signing algorithm is one of
+/// ES256/ES384/ES512, and the claim set contains every required claim
+/// (`iss`, `sub`, `exp`, `cnf.jwk`, `wallet_name`, `wallet_version`,
+/// `wallet_solution_certification_information`, `client_status`).
 public struct ClientAttestationJWT: Sendable {
+
   public let jws: JWS
-  private let payload: JSON
-  
+  public let claimsSet: ClientAttestationJWTClaims
+
+  public var header: JWSHeader { jws.header }
+  public var clientId: ClientId { claimsSet.subject.value }
+  public var cnf: ConfirmationClaim { claimsSet.confirmation }
+  public var publicKey: JWK { claimsSet.confirmation.jwk }
+
+  /// Backward-compatible accessor. Prefer `publicKey`.
+  @available(*, deprecated, renamed: "publicKey")
+  public var pubKey: JWK? { publicKey }
+
   private static let allowedAlgorithms: Set<SignatureAlgorithm> = [
     .ES256, .ES384, .ES512
   ]
-  
-  public init(jws: JWS, validateCnf: Bool = true) throws {
-    self.jws = jws
-    
+
+  public init(jws: JWS) throws {
     guard let algorithm = jws.header.algorithm else {
       throw ClientAttestationError.notSigned
     }
-    
     guard Self.allowedAlgorithms.contains(algorithm) else {
-      throw ClientAttestationError.invalidAlgorithm(allowedAlgorithms: Self.allowedAlgorithms.map { $0.rawValue})
+      throw ClientAttestationError.invalidAlgorithm(
+        allowedAlgorithms: Self.allowedAlgorithms.map { $0.rawValue }
+      )
     }
-    
+
+    if let typ = jws.header.typ, typ != AttestationBasedClientAuthenticationSpec.attestationJwtType {
+      throw ClientAttestationError.invalidTypHeader(
+        expected: AttestationBasedClientAuthenticationSpec.attestationJwtType,
+        got: typ
+      )
+    }
+
     let payloadData = jws.payload.data()
     guard let jsonObject = try JSONSerialization.jsonObject(
       with: payloadData,
@@ -43,37 +67,15 @@ public struct ClientAttestationJWT: Sendable {
     ) as? [String: Any] else {
       throw ClientAttestationError.invalidPayload
     }
-    self.payload = JSON(jsonObject)
-    
-    if validateCnf {
-      guard let cnf = payload[JWTClaimNames.cnf].dictionary else {
-        throw ClientAttestationError.missingCnfClaim
-      }
-      
-      guard cnf[JWTClaimNames.JWK] != nil else {
-        throw ClientAttestationError.missingJwkClaim
-      }
-    }
-    
-    guard payload[JWTClaimNames.expirationTime].number != nil else {
-      throw ClientAttestationError.missingExpirationClaim
-    }
+    let payload = JSON(jsonObject)
+
+    self.claimsSet = try ClientAttestationJWTClaims.parse(payload: payload)
+    self.jws = jws
   }
-  
-  public var clientId: ClientId {
-    return payload[JWTClaimNames.subject].string ?? ""
-  }
-  
-  public var cnf: JSON {
-    return JSON(payload[JWTClaimNames.cnf])
-  }
-  
-  public var pubKey: JWK? {
-    if let rsa = try? RSAPublicKey(data: cnf[JWTClaimNames.JWK].rawData()) {
-      return rsa
-    } else if let ec = try? ECPublicKey(data: cnf[JWTClaimNames.JWK].rawData()) {
-      return ec
-    }
-    return nil
+
+  /// Convenience initializer accepting the compact-serialized JWT string.
+  public init(jwt: String) throws {
+    let jws = try JWS(compactSerialization: jwt)
+    try self.init(jws: jws)
   }
 }

--- a/Sources/Main/AttestationBasedClient/ClientAttestationClaims.swift
+++ b/Sources/Main/AttestationBasedClient/ClientAttestationClaims.swift
@@ -1,0 +1,271 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Foundation
+@preconcurrency import JOSESwift
+@preconcurrency import SwiftyJSON
+
+public struct NonBlankString: Sendable, Hashable, CustomStringConvertible {
+  public let value: String
+
+  public init(_ value: String) throws {
+    guard !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+      throw ClientAttestationError.blankClaim(name: "<unknown>")
+    }
+    self.value = value
+  }
+
+  public init(_ value: String, claimName: String) throws {
+    guard !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+      throw ClientAttestationError.blankClaim(name: claimName)
+    }
+    self.value = value
+  }
+
+  public var description: String { value }
+}
+
+public struct ConfirmationClaim: Sendable {
+  public let jwk: JWK
+
+  public init(jwk: JWK) throws {
+    guard jwk.isPublicKey else {
+      throw ClientAttestationError.cnfJwkNotPublic
+    }
+    self.jwk = jwk
+  }
+}
+
+public struct StatusListTokenClaim: Sendable {
+  public let index: Int
+  public let uri: NonBlankString
+
+  public init(index: Int, uri: NonBlankString) throws {
+    guard index >= 0 else {
+      throw ClientAttestationError.invalidStatusListReference(reason: "`idx` must be non-negative")
+    }
+    self.index = index
+    self.uri = uri
+  }
+}
+
+public struct StatusClaim: Sendable {
+  public let statusList: StatusListTokenClaim
+
+  public init(statusList: StatusListTokenClaim) {
+    self.statusList = statusList
+  }
+}
+
+public struct ClientStatusClaim: Sendable {
+  public let status: StatusClaim
+  public let expiresAt: Date
+
+  public init(status: StatusClaim, expiresAt: Date) {
+    self.status = status
+    self.expiresAt = expiresAt
+  }
+}
+
+/// `wallet_solution_certification_information` — TS3 leaves the inner schema open-ended,
+/// so the value is exposed as a generic JSON element.
+public typealias WalletSolutionCertificationInformation = JSON
+
+public struct ClientAttestationJWTClaims: Sendable {
+  public let issuer: NonBlankString
+  public let subject: NonBlankString
+  public let expirationTime: Date
+  public let confirmation: ConfirmationClaim
+  public let issuedAt: Date?
+  public let notBefore: Date?
+  public let walletName: NonBlankString
+  public let walletLink: NonBlankString?
+  public let status: StatusClaim?
+  public let walletVersion: NonBlankString
+  public let walletSolutionCertificationInformation: WalletSolutionCertificationInformation
+  public let clientStatus: ClientStatusClaim
+
+  public init(
+    issuer: NonBlankString,
+    subject: NonBlankString,
+    expirationTime: Date,
+    confirmation: ConfirmationClaim,
+    issuedAt: Date?,
+    notBefore: Date?,
+    walletName: NonBlankString,
+    walletLink: NonBlankString?,
+    status: StatusClaim?,
+    walletVersion: NonBlankString,
+    walletSolutionCertificationInformation: WalletSolutionCertificationInformation,
+    clientStatus: ClientStatusClaim
+  ) {
+    self.issuer = issuer
+    self.subject = subject
+    self.expirationTime = expirationTime
+    self.confirmation = confirmation
+    self.issuedAt = issuedAt
+    self.notBefore = notBefore
+    self.walletName = walletName
+    self.walletLink = walletLink
+    self.status = status
+    self.walletVersion = walletVersion
+    self.walletSolutionCertificationInformation = walletSolutionCertificationInformation
+    self.clientStatus = clientStatus
+  }
+}
+
+// MARK: - Parsing from JSON payload
+
+extension ClientAttestationJWTClaims {
+
+  static func parse(payload: JSON) throws -> ClientAttestationJWTClaims {
+    // iss — required, non-blank
+    guard let issString = payload[JWTClaimNames.issuer].string else {
+      throw ClientAttestationError.missingIssuerClaim
+    }
+    let issuer = try NonBlankString(issString, claimName: JWTClaimNames.issuer)
+
+    // sub — required, non-blank
+    guard let subString = payload[JWTClaimNames.subject].string else {
+      throw ClientAttestationError.missingSubject
+    }
+    let subject = try NonBlankString(subString, claimName: JWTClaimNames.subject)
+
+    // exp — required
+    guard let expSeconds = payload[JWTClaimNames.expirationTime].double else {
+      throw ClientAttestationError.missingExpirationClaim
+    }
+    let expirationTime = Date(timeIntervalSince1970: expSeconds)
+
+    // cnf — required, must contain public JWK
+    guard payload[JWTClaimNames.cnf].dictionary != nil else {
+      throw ClientAttestationError.missingCnfClaim
+    }
+    let cnfJson = payload[JWTClaimNames.cnf]
+    guard cnfJson[JWTClaimNames.JWK].dictionary != nil else {
+      throw ClientAttestationError.missingJwkClaim
+    }
+    let jwk = try Self.parseJWK(from: cnfJson[JWTClaimNames.JWK])
+    let confirmation = try ConfirmationClaim(jwk: jwk)
+
+    // iat — optional
+    let issuedAt: Date? = payload[JWTClaimNames.issuedAt].double.map(Date.init(timeIntervalSince1970:))
+
+    // nbf — optional
+    let notBefore: Date? = payload[JWTClaimNames.notBefore].double.map(Date.init(timeIntervalSince1970:))
+
+    // wallet_name — required, non-blank
+    guard let walletNameString = payload[JWTClaimNames.walletName].string else {
+      throw ClientAttestationError.missingWalletName
+    }
+    let walletName = try NonBlankString(walletNameString, claimName: JWTClaimNames.walletName)
+
+    // wallet_link — optional, non-blank when present
+    let walletLink: NonBlankString?
+    if let walletLinkString = payload[JWTClaimNames.walletLink].string {
+      walletLink = try NonBlankString(walletLinkString, claimName: JWTClaimNames.walletLink)
+    } else {
+      walletLink = nil
+    }
+
+    // status — optional top-level status
+    let status: StatusClaim?
+    if payload[JWTClaimNames.status].dictionary != nil {
+      status = try Self.parseStatusClaim(from: payload[JWTClaimNames.status])
+    } else {
+      status = nil
+    }
+
+    // wallet_version — required, non-blank
+    guard let walletVersionString = payload[JWTClaimNames.walletVersion].string else {
+      throw ClientAttestationError.missingWalletVersion
+    }
+    let walletVersion = try NonBlankString(walletVersionString, claimName: JWTClaimNames.walletVersion)
+
+    // wallet_solution_certification_information — required, any JSON shape
+    let wsci = payload[JWTClaimNames.walletSolutionCertificationInformation]
+    guard wsci.exists() && wsci.type != .null else {
+      throw ClientAttestationError.missingWalletSolutionCertificationInformation
+    }
+
+    // client_status — required
+    guard payload[JWTClaimNames.clientStatus].dictionary != nil else {
+      throw ClientAttestationError.missingClientStatus
+    }
+    let clientStatus = try Self.parseClientStatus(from: payload[JWTClaimNames.clientStatus])
+
+    return ClientAttestationJWTClaims(
+      issuer: issuer,
+      subject: subject,
+      expirationTime: expirationTime,
+      confirmation: confirmation,
+      issuedAt: issuedAt,
+      notBefore: notBefore,
+      walletName: walletName,
+      walletLink: walletLink,
+      status: status,
+      walletVersion: walletVersion,
+      walletSolutionCertificationInformation: wsci,
+      clientStatus: clientStatus
+    )
+  }
+
+  private static func parseJWK(from json: JSON) throws -> JWK {
+    let data: Data
+    do {
+      data = try json.rawData()
+    } catch {
+      throw ClientAttestationError.invalidJwk(reason: "cannot serialize jwk")
+    }
+    if let ec = try? ECPublicKey(data: data) {
+      return ec
+    }
+    if let rsa = try? RSAPublicKey(data: data) {
+      return rsa
+    }
+    throw ClientAttestationError.invalidJwk(reason: "unsupported key type")
+  }
+
+  private static func parseStatusClaim(from json: JSON) throws -> StatusClaim {
+    guard json[JWTClaimNames.statusList].dictionary != nil else {
+      throw ClientAttestationError.invalidStatusListReference(reason: "missing `status_list`")
+    }
+    let listJson = json[JWTClaimNames.statusList]
+    guard let idx = listJson[JWTClaimNames.idx].int else {
+      throw ClientAttestationError.invalidStatusListReference(reason: "missing or non-integer `idx`")
+    }
+    guard let uriString = listJson[JWTClaimNames.uri].string else {
+      throw ClientAttestationError.invalidStatusListReference(reason: "missing `uri`")
+    }
+    let uri = try NonBlankString(uriString, claimName: JWTClaimNames.uri)
+    let listRef = try StatusListTokenClaim(index: idx, uri: uri)
+    return StatusClaim(statusList: listRef)
+  }
+
+  private static func parseClientStatus(from json: JSON) throws -> ClientStatusClaim {
+    guard json[JWTClaimNames.status].dictionary != nil else {
+      throw ClientAttestationError.invalidClientStatus(reason: "missing `status`")
+    }
+    let status = try Self.parseStatusClaim(from: json[JWTClaimNames.status])
+
+    guard let expSeconds = json[JWTClaimNames.expirationTime].double else {
+      throw ClientAttestationError.invalidClientStatus(reason: "missing `exp`")
+    }
+    return ClientStatusClaim(
+      status: status,
+      expiresAt: Date(timeIntervalSince1970: expSeconds)
+    )
+  }
+}

--- a/Sources/Main/AttestationBasedClient/ClientAttestationError.swift
+++ b/Sources/Main/AttestationBasedClient/ClientAttestationError.swift
@@ -17,7 +17,7 @@ import Foundation
 
 enum ClientAttestationError: Error, LocalizedError {
   case notSigned
-  case invalidAlgorithm(allowedAlgorithms:[String])
+  case invalidAlgorithm(allowedAlgorithms: [String])
   case invalidPayload
   case invalidClientId
   case missingSubject
@@ -28,7 +28,19 @@ enum ClientAttestationError: Error, LocalizedError {
   case missingJtiClaim
   case missingAudienceClaim
   case invalidClient
-  
+
+  // TS3 Wallet Instance Attestation validation
+  case invalidTypHeader(expected: String, got: String?)
+  case blankClaim(name: String)
+  case missingWalletName
+  case missingWalletVersion
+  case missingWalletSolutionCertificationInformation
+  case missingClientStatus
+  case invalidClientStatus(reason: String)
+  case invalidStatusListReference(reason: String)
+  case cnfJwkNotPublic
+  case invalidJwk(reason: String)
+
   var errorDescription: String? {
     switch self {
     case .notSigned: return "Invalid Attestation JWT. Not properly signed."
@@ -36,15 +48,35 @@ enum ClientAttestationError: Error, LocalizedError {
       let list = allowed.sorted().joined(separator: ", ")
       return "Invalid Attestation JWT. Signature algorithm must be one of: \(list)."
     case .invalidPayload: return "Invalid Attestation JWT. Cannot parse payload."
-    case .missingSubject: return "Invalid Attestation JWT. Missing subject claim."
-    case .missingCnfClaim: return "Invalid Attestation JWT. Missing cnf claim."
-    case .missingJwkClaim: return "Invalid Attestation JWT. Missing jwk claim from cnf."
-    case .missingExpirationClaim: return "Invalid Attestation JWT. Missing exp claim."
-    case .missingIssuerClaim: return "Invalid Attestation JWT. Missing issuer claim."
-    case .missingJtiClaim: return "Invalid Attestation JWT. Missing jti claim."
-    case .missingAudienceClaim: return "Invalid Attestation JWT. Missing aud claim."
+    case .missingSubject: return "Invalid Attestation JWT. Misses `sub` claim."
+    case .missingCnfClaim: return "Invalid Attestation JWT. Misses `cnf` claim."
+    case .missingJwkClaim: return "Invalid Attestation JWT. Misses `jwk` claim from `cnf`."
+    case .missingExpirationClaim: return "Invalid Attestation JWT. Misses `exp` claim."
+    case .missingIssuerClaim: return "Invalid Attestation JWT. Misses `iss` claim."
+    case .missingJtiClaim: return "Invalid Attestation JWT. Misses `jti` claim."
+    case .missingAudienceClaim: return "Invalid Attestation JWT. Misses `aud` claim."
     case .invalidClientId: return "Invalid client ID"
     case .invalidClient: return "Invalid Client"
+    case .invalidTypHeader(let expected, let got):
+      return "Invalid Attestation JWT. Header `typ` must be `\(expected)`, got `\(got ?? "<missing>")`."
+    case .blankClaim(let name):
+      return "Invalid Attestation JWT. Claim `\(name)` must not be blank."
+    case .missingWalletName:
+      return "Invalid Attestation JWT. Misses `wallet_name` claim."
+    case .missingWalletVersion:
+      return "Invalid Attestation JWT. Misses `wallet_version` claim."
+    case .missingWalletSolutionCertificationInformation:
+      return "Invalid Attestation JWT. Misses `wallet_solution_certification_information` claim."
+    case .missingClientStatus:
+      return "Invalid Attestation JWT. Misses `client_status` claim."
+    case .invalidClientStatus(let reason):
+      return "Invalid Attestation JWT. Invalid `client_status`: \(reason)."
+    case .invalidStatusListReference(let reason):
+      return "Invalid Attestation JWT. Invalid status list reference: \(reason)."
+    case .cnfJwkNotPublic:
+      return "Invalid Attestation JWT. `cnf.jwk` must be a public key."
+    case .invalidJwk(let reason):
+      return "Invalid Attestation JWT. Invalid `cnf.jwk`: \(reason)."
     }
   }
 }

--- a/Tests/AttestationBased/AttestationBasedTests.swift
+++ b/Tests/AttestationBased/AttestationBasedTests.swift
@@ -23,15 +23,17 @@ import SwiftyJSON
 class AttestationBasedTests: XCTestCase {
   
   func testClientAttestation() async throws {
-    
+
+    let jwt = try makeWIAJWT()
     let clientAttestation = try ClientAttestationJWT(
-      jws: JWS(
-        compactSerialization: TestsConstants.CNF_JWT
-      )
+      jws: JWS(compactSerialization: jwt)
     )
-    
-    let jwk = clientAttestation.pubKey
-    XCTAssertNotNil(jwk)
+
+    XCTAssertEqual(clientAttestation.clientId, "test-client")
+    XCTAssertEqual(clientAttestation.claimsSet.walletName.value, "Test Wallet Solution")
+    XCTAssertEqual(clientAttestation.claimsSet.walletVersion.value, "1.0.0")
+    XCTAssertEqual(clientAttestation.claimsSet.clientStatus.status.statusList.index, 0)
+    XCTAssertNotNil(clientAttestation.publicKey)
   }
   
   func testClientAttestationPopJwt() async throws {
@@ -201,5 +203,189 @@ class AttestationBasedTests: XCTestCase {
     base64String = base64String.replacingOccurrences(of: "+", with: "-")
     base64String = base64String.replacingOccurrences(of: "=", with: "")
     return base64String
+  }
+
+  // MARK: - TS3 WIA validation tests
+
+  func testWIA_missingWalletName_shouldFail() throws {
+    let jwt = try makeWIAJWT { payload in
+      payload.removeValue(forKey: "wallet_name")
+    }
+    XCTAssertThrowsError(try ClientAttestationJWT(jws: JWS(compactSerialization: jwt))) { error in
+      guard case ClientAttestationError.missingWalletName = error else {
+        XCTFail("Expected missingWalletName, got \(error)"); return
+      }
+    }
+  }
+
+  func testWIA_missingWalletVersion_shouldFail() throws {
+    let jwt = try makeWIAJWT { payload in
+      payload.removeValue(forKey: "wallet_version")
+    }
+    XCTAssertThrowsError(try ClientAttestationJWT(jws: JWS(compactSerialization: jwt))) { error in
+      guard case ClientAttestationError.missingWalletVersion = error else {
+        XCTFail("Expected missingWalletVersion, got \(error)"); return
+      }
+    }
+  }
+
+  func testWIA_missingWalletSolutionCertificationInformation_shouldFail() throws {
+    let jwt = try makeWIAJWT { payload in
+      payload.removeValue(forKey: "wallet_solution_certification_information")
+    }
+    XCTAssertThrowsError(try ClientAttestationJWT(jws: JWS(compactSerialization: jwt))) { error in
+      guard case ClientAttestationError.missingWalletSolutionCertificationInformation = error else {
+        XCTFail("Expected missingWalletSolutionCertificationInformation, got \(error)"); return
+      }
+    }
+  }
+
+  func testWIA_missingClientStatus_shouldFail() throws {
+    let jwt = try makeWIAJWT { payload in
+      payload.removeValue(forKey: "client_status")
+    }
+    XCTAssertThrowsError(try ClientAttestationJWT(jws: JWS(compactSerialization: jwt))) { error in
+      guard case ClientAttestationError.missingClientStatus = error else {
+        XCTFail("Expected missingClientStatus, got \(error)"); return
+      }
+    }
+  }
+
+  func testWIA_missingClientStatusExp_shouldFail() throws {
+    let jwt = try makeWIAJWT { payload in
+      var cs = payload["client_status"] as! [String: Any]
+      cs.removeValue(forKey: "exp")
+      payload["client_status"] = cs
+    }
+    XCTAssertThrowsError(try ClientAttestationJWT(jws: JWS(compactSerialization: jwt))) { error in
+      guard case ClientAttestationError.invalidClientStatus = error else {
+        XCTFail("Expected invalidClientStatus, got \(error)"); return
+      }
+    }
+  }
+
+  func testWIA_missingStatusList_shouldFail() throws {
+    let jwt = try makeWIAJWT { payload in
+      var cs = payload["client_status"] as! [String: Any]
+      cs["status"] = [String: Any]()
+      payload["client_status"] = cs
+    }
+    XCTAssertThrowsError(try ClientAttestationJWT(jws: JWS(compactSerialization: jwt))) { error in
+      guard case ClientAttestationError.invalidStatusListReference = error else {
+        XCTFail("Expected invalidStatusListReference, got \(error)"); return
+      }
+    }
+  }
+
+  func testWIA_blankWalletName_shouldFail() throws {
+    let jwt = try makeWIAJWT { payload in
+      payload["wallet_name"] = "   "
+    }
+    XCTAssertThrowsError(try ClientAttestationJWT(jws: JWS(compactSerialization: jwt))) { error in
+      guard case ClientAttestationError.blankClaim(let name) = error, name == "wallet_name" else {
+        XCTFail("Expected blankClaim(wallet_name), got \(error)"); return
+      }
+    }
+  }
+
+  func testWIA_wrongTypHeader_shouldFail() throws {
+    let jwt = try makeWIAJWT(typHeader: "wrong+jwt")
+    XCTAssertThrowsError(try ClientAttestationJWT(jws: JWS(compactSerialization: jwt))) { error in
+      guard case ClientAttestationError.invalidTypHeader(let expected, let got) = error,
+            expected == "oauth-client-attestation+jwt",
+            got == "wrong+jwt" else {
+        XCTFail("Expected invalidTypHeader, got \(error)"); return
+      }
+    }
+  }
+
+  func testWIA_missingIssuer_shouldFail() throws {
+    let jwt = try makeWIAJWT { payload in
+      payload.removeValue(forKey: "iss")
+    }
+    XCTAssertThrowsError(try ClientAttestationJWT(jws: JWS(compactSerialization: jwt))) { error in
+      guard case ClientAttestationError.missingIssuerClaim = error else {
+        XCTFail("Expected missingIssuerClaim, got \(error)"); return
+      }
+    }
+  }
+
+  func testWIA_missingSubject_shouldFail() throws {
+    let jwt = try makeWIAJWT { payload in
+      payload.removeValue(forKey: "sub")
+    }
+    XCTAssertThrowsError(try ClientAttestationJWT(jws: JWS(compactSerialization: jwt))) { error in
+      guard case ClientAttestationError.missingSubject = error else {
+        XCTFail("Expected missingSubject, got \(error)"); return
+      }
+    }
+  }
+
+  func testWIA_negativeStatusListIdx_shouldFail() throws {
+    let jwt = try makeWIAJWT { payload in
+      var cs = payload["client_status"] as! [String: Any]
+      var status = cs["status"] as! [String: Any]
+      var list = status["status_list"] as! [String: Any]
+      list["idx"] = -1
+      status["status_list"] = list
+      cs["status"] = status
+      payload["client_status"] = cs
+    }
+    XCTAssertThrowsError(try ClientAttestationJWT(jws: JWS(compactSerialization: jwt))) { error in
+      guard case ClientAttestationError.invalidStatusListReference = error else {
+        XCTFail("Expected invalidStatusListReference, got \(error)"); return
+      }
+    }
+  }
+
+  // MARK: - WIA builder
+
+  private func makeWIAJWT(
+    typHeader: String = "oauth-client-attestation+jwt",
+    algorithm: SignatureAlgorithm = .ES256,
+    mutate: ((inout [String: Any]) -> Void)? = nil
+  ) throws -> String {
+
+    let privateKey = try KeyController.generateECDHPrivateKey()
+    let publicJwk = try ECPublicKey(
+      publicKey: try KeyController.generateECDHPublicKey(from: privateKey)
+    )
+
+    let header = try JWSHeader(parameters: [
+      "alg": algorithm.rawValue,
+      "typ": typHeader
+    ])
+
+    let now = Date().timeIntervalSince1970
+    let exp = Date().addingTimeInterval(300).timeIntervalSince1970
+    var payload: [String: Any] = [
+      "iss": "test-client",
+      "aud": "test-client",
+      "sub": "test-client",
+      "iat": now,
+      "exp": exp,
+      "cnf": ["jwk": try publicJwk.toDictionary()],
+      "wallet_name": "Test Wallet Solution",
+      "wallet_version": "1.0.0",
+      "wallet_solution_certification_information": [
+        "certification_body": "Test CAB",
+        "certification_number": "TEST-CERT-001"
+      ],
+      "client_status": [
+        "status": [
+          "status_list": [
+            "idx": 0,
+            "uri": "https://wallet-provider.example.org/status-lists/clients/1"
+          ]
+        ],
+        "exp": Date().addingTimeInterval(7 * 24 * 3600).timeIntervalSince1970
+      ]
+    ]
+    mutate?(&payload)
+
+    let payloadData = try JSONSerialization.data(withJSONObject: payload, options: [])
+    let signer = Signer(signatureAlgorithm: algorithm, key: privateKey)!
+    let jws = try JWS(header: header, payload: Payload(payloadData), signer: signer)
+    return jws.compactSerializedString
   }
 }

--- a/Tests/Helpers/SelfSignedClientAttestation.swift
+++ b/Tests/Helpers/SelfSignedClientAttestation.swift
@@ -39,11 +39,16 @@ internal func jwkProviderSignedClient(
       "jwk": publicKeyJWK.toDictionary()
     ]
   )
-  
+
+  // Pre-validate the WIA here so TS3 parsing failures surface as throws.
+  let attestationJWT = try ClientAttestationJWT(
+    jws: JWS(compactSerialization: attestation.walletInstanceAttestation)
+  )
+
   @Sendable func getSignerFrom(authServer: URL) -> SigningKeyProxy {
     .secKey(privateKey)
   }
-  
+
   return try .attested(
     id: clientId,
     alg: .init(.ES256),
@@ -54,14 +59,7 @@ internal func jwkProviderSignedClient(
       typ: "oauth-client-attestation-pop+jwt"
     ),
     clientAttestationProvider: { authServer in
-      return (
-        try! .init(
-          jws: .init(
-            compactSerialization: attestation.walletInstanceAttestation
-          )
-        ),
-        getSignerFrom(authServer: authServer)
-      )
+      (attestationJWT, getSignerFrom(authServer: authServer))
     }
   )
 }
@@ -90,11 +88,16 @@ internal func jwkSetProviderSignedClient(
       ]
     ]
   )
-  
+
+  // Pre-validate the WIA here so TS3 parsing failures surface as throws,
+  let attestationJWT = try ClientAttestationJWT(
+    jws: JWS(compactSerialization: attestation.walletUnitAttestation)
+  )
+
   @Sendable func getSignerFrom(authServer: URL) -> SigningKeyProxy {
     .secKey(privateKey)
   }
-  
+
   return try .attested(
     id: clientId,
     alg: .init(.ES256),
@@ -105,14 +108,7 @@ internal func jwkSetProviderSignedClient(
       typ: "oauth-client-attestation-pop+jwt"
     ),
     clientAttestationProvider: { authServer in
-      return (
-        try! .init(
-          jws: .init(
-            compactSerialization: attestation.walletUnitAttestation
-          )
-        ),
-        getSignerFrom(authServer: authServer)
-      )
+      (attestationJWT, getSignerFrom(authServer: authServer))
     }
   )
 }
@@ -155,6 +151,21 @@ internal func selfSignedClient(
     "exp": exp,
     "cnf": [
       "jwk": jwk.toDictionary()
+    ],
+    "wallet_name": "Test Wallet Solution",
+    "wallet_version": "1.0.0",
+    "wallet_solution_certification_information": [
+      "certification_body": "Test CAB",
+      "certification_number": "TEST-CERT-001"
+    ],
+    "client_status": [
+      "status": [
+        "status_list": [
+          "idx": 0,
+          "uri": "https://wallet-provider.example.org/status-lists/clients/1"
+        ]
+      ],
+      "exp": Date().addingTimeInterval(7 * 24 * 3600).timeIntervalSince1970
     ]
   ].toThrowingJSONData())
   


### PR DESCRIPTION
# Description of change

Restructure ClientAttestationJWT to eagerly parse and validate the JWT as a valid Wallet Instance Attestation (WIA) per TS3 v1.5

Previously the library only validated structural essentials on the JWT used in attestation-based client authentication (signing algorithm, presence of cnf/cnf.jwk, presence of exp). It did not verify that the attestation was a TS3-compliant Wallet Instance Attestation, meaning non-compliant or downgraded attestations could be forwarded to the authorization server unchecked.
  
  Validation now enforces, at construction time:
  - header typ (when present) is oauth-client-attestation+jwt
  - signing algorithm is one of ES256 / ES384 / ES512
  - required claims: iss, sub, exp, cnf.jwk (public key), wallet_name, wallet_version, wallet_solution_certification_information, client_status
  (with nested status_list reference and exp)
  - optional claims: iat, nbf, wallet_link, top-level status
  - cnf.jwk must be a public key
  - status_list.idx must be a non-negative integer; string claims must be non-blank

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update


# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes