### PR TITLE
fix: propagate notification_id and align notify payload with OpenID4VCI

### DIFF
--- a/Sources/Entities/Issuance/NotificationObject.swift
+++ b/Sources/Entities/Issuance/NotificationObject.swift
@@ -43,19 +43,19 @@ public struct NotificationObject: Sendable {
 }
 
 public enum NotifiedEvent: String, Sendable {
-  case credentialAccepted = "CREDENTIAL_ACCEPTED"
-  case credentialFailure = "CREDENTIAL_FAILURE"
-  case credentialDeleted = "CREDENTIAL_DELETED"
+  case credentialAccepted = "credential_accepted"
+  case credentialFailure = "credential_failure"
+  case credentialDeleted = "credential_deleted"
 }
 
 extension NotificationObject {
   func toDictionary() -> [String: Any] {
     var dictionary: [String: Any] = [
-      "id": id.value,
+      "notification_id": id.value,
       "event": event.rawValue
     ]
     if let eventDescription = eventDescription {
-      dictionary["eventDescription"] = eventDescription
+      dictionary["event_description"] = eventDescription
     }
     return dictionary
   }

--- a/Sources/Entities/Profiles/SingleIssuanceSuccessResponse.swift
+++ b/Sources/Entities/Profiles/SingleIssuanceSuccessResponse.swift
@@ -94,7 +94,7 @@ public extension SingleIssuanceSuccessResponse {
           .issued(
             format: nil,
             credential: .string(string),
-            notificationId: nil,
+            notificationId: notificationId,
             additionalInfo: nil
           )
         ]
@@ -106,7 +106,7 @@ public extension SingleIssuanceSuccessResponse {
           .issued(
             format: nil,
             credential: .json(JSON(credentials)),
-            notificationId: nil,
+            notificationId: notificationId,
             additionalInfo: nil
           )
         ]

--- a/Sources/Issuers/IssuanceRequester.swift
+++ b/Sources/Issuers/IssuanceRequester.swift
@@ -558,7 +558,7 @@ private extension SingleIssuanceSuccessResponse {
           .issued(
             format: nil,
             credential: .string(string),
-            notificationId: nil,
+            notificationId: notificationId,
             additionalInfo: nil
           )
         ]
@@ -570,7 +570,7 @@ private extension SingleIssuanceSuccessResponse {
           .issued(
             format: nil,
             credential: .json(JSON(credentials)),
-            notificationId: nil,
+            notificationId: notificationId,
             additionalInfo: nil
           )
         ]

--- a/Sources/Issuers/Issuer.swift
+++ b/Sources/Issuers/Issuer.swift
@@ -90,12 +90,12 @@ public protocol IssuerType: Sendable {
   ///
   /// - Parameters:
   ///   - authorizedRequest: The authorized request linked to the notification.
-  ///   - notificationId: The ID of the notification.
+  ///   - notification: The notification object to send.
   ///   - dPopNonce: An optional nonce for DPoP security.
   /// - Returns: A result containing either `Void` if successful or an `Error` otherwise.
   func notify(
     authorizedRequest: AuthorizedRequest,
-    notificationId: NotificationObject,
+    notification: NotificationObject,
     dPopNonce: Nonce?
   ) async throws
   
@@ -856,12 +856,12 @@ public extension Issuer {
   
   func notify(
     authorizedRequest: AuthorizedRequest,
-    notificationId: NotificationObject,
+    notification: NotificationObject,
     dPopNonce: Nonce?
   ) async throws {
     try await notifyIssuer.notify(
       authorizedRequest: authorizedRequest,
-      notification: notificationId,
+      notification: notification,
       dPopNonce: dPopNonce
     )
   }

--- a/Sources/Resources/responses/single_issuance_success_response_credential.json
+++ b/Sources/Resources/responses/single_issuance_success_response_credential.json
@@ -1,6 +1,7 @@
 {
   "format": "dc+sd-jwt",
   "credential": "1234565768122",
+  "notification_id": "b7a3ae54-4bac-4e74-b665-ebbd6905cb6b",
   "c_nonce": "wlbQc6pCJp",
   "c_nonce_expires_in": 86400
 }

--- a/Tests/Issuance/IssuanceNotificationTest.swift
+++ b/Tests/Issuance/IssuanceNotificationTest.swift
@@ -120,12 +120,13 @@ class IssuanceNotificationTest: XCTestCase {
                 switch result {
                 case .deferred:
                   XCTAssert(false, "Unexpected deferred")
-                case .issued(_, let credential, _, _):
+                case .issued(_, let credential, let notificationId, _):
                   XCTAssert(true, "credential: \(credential)")
-                  
+                  XCTAssertNotNil(notificationId, "notificationId should be present in credential response")
+
                   try await issuer.notify(
                     authorizedRequest: authorizedRequest,
-                    notificationId: .stub(),
+                    notification: try .stub(),
                     dPopNonce: nil
                   )
                 }
@@ -236,12 +237,17 @@ class IssuanceNotificationTest: XCTestCase {
                 switch result {
                 case .deferred:
                   XCTAssert(false, "Unexpected deferred")
-                case .issued(_, let credential, _, _):
+                case .issued(_, let credential, let notificationId, _):
                   XCTAssert(true, "credential: \(credential)")
-                  
+
+                  guard notificationId != nil else {
+                    // notificationId absent: notify not called (expected behaviour)
+                    return
+                  }
+
                   try await issuer.notify(
                     authorizedRequest: authorizedRequest,
-                    notificationId: .stub(),
+                    notification: try .stub(),
                     dPopNonce: nil
                   )
                   XCTAssert(false, "Success not expected")

--- a/Tests/Stubs/Issuance+Stub.swift
+++ b/Tests/Stubs/Issuance+Stub.swift
@@ -26,7 +26,7 @@ extension NotificationObject: Stubbable {
   static func stub() throws -> NotificationObject {
     .init(
       id: try .init(value: "String"),
-      event: .init(rawValue: "CREDENTIAL_ACCEPTED")!,
+      event: .credentialAccepted,
       eventDescription: "String?"
     )
   }


### PR DESCRIPTION
### Context

The OpenID4VCI spec (§11) defines a `notification_endpoint` that issuers may advertise in their metadata. After a successful credential issuance, the wallet is expected to POST a notification to that endpoint carrying the `notification_id` received in the credential response.

Two independent bugs were preventing this from working at all.

---

### Changes

#### 1 — Non spec-compliant notification payload (`NotificationObject`)

`toDictionary()` was serializing keys and event values in a non-compliant way:

| Field | Before | After | Spec ref |
|---|---|---|---|
| notification ID key | `"id"` | `"notification_id"` | §11.1 |
| event description key | `"eventDescription"` | `"event_description"` | §11.1 |
| event values | `"CREDENTIAL_ACCEPTED"` etc. | `"credential_accepted"` etc. | §11.1 |

`NotificationTO` already had the correct `CodingKeys` but was unused in the HTTP call path. `toDictionary()` is now aligned with the spec.

#### 2 — `notification_id` silently dropped from credential response

`SingleIssuanceSuccessResponse.toDomain()` and the private `toSingleIssuanceResponse()` extension in `IssuanceRequester` correctly decoded `notification_id` from the HTTP response JSON, but then constructed `IssuedCredential.issued(...)` with `notificationId: nil` hardcoded in all four call sites.

The value received from the issuer was therefore silently discarded before reaching the caller, making it impossible for `EudiWalletKit` to send the notification.

**Fix:** replaced `notificationId: nil` with `notificationId: notificationId` (self) at all four sites.

#### 3 — Misleading parameter name in `Issuer.notify()`

The `notificationId:` parameter label in `IssuerType.notify()` and its implementation had type `NotificationObject` — not a bare ID string. Renamed to `notification:` to match both the actual type and the existing parameter name used in `NotifyIssuer.notify()`.

---

### What this does NOT include

The actual call to the notification endpoint after issuance is the responsibility of the upper layer (`eudi-lib-ios-wallet-kit`). A follow-up PR on that repository will add the fire-and-forget logic that, after storing the issued document, uses the `notification_id` now correctly propagated to POST `credential_accepted` to the issuer's `notification_endpoint` (if present in the metadata).

---

### Testing

- Existing `IssuanceNotificationTest` tests updated to assert `notificationId` is present in the credential response and use `NotificationObject.stub()` for the notify call (mock server does not validate the notification_id value).
- Test stub JSON (`single_issuance_success_response_credential.json`) updated to include `notification_id`, which was missing and caused the assertion to fail.
- `NotificationObject.stub()` event value aligned to `credentialAccepted` (was using the now-invalid uppercase raw value).
