### PR TITLE
Support OAuth-Client-Attestation-Challenge response header

### DIFF
--- a/Sources/Main/Authorisers/AuthorizationServerClient.swift
+++ b/Sources/Main/Authorisers/AuthorizationServerClient.swift
@@ -26,6 +26,15 @@ package extension ResponseWithHeaders {
     }
     return nil
   }
+
+  /// Extracts a fresh attestation challenge from the
+  /// `OAuth-Client-Attestation-Challenge` response header
+  func attestationChallenge() -> Nonce? {
+    if let value = headers.value(forCaseInsensitiveKey: Constants.OAUTH_CLIENT_ATTESTATION_CHALLENGE) as? String {
+      return Nonce(value: value)
+    }
+    return nil
+  }
 }
 
 /// A protocol defining the interface for an authorization server client.
@@ -378,7 +387,11 @@ internal actor AuthorizationServerClient: AuthorizationServerClientType {
         request: authRequest,
         headers: clientAttestationHeaders + tokenHeaders
       )
-      
+
+      if let freshChallenge = response.attestationChallenge() {
+        await challenger?.setChallenge(freshChallenge)
+      }
+
       switch response.body {
       case .success(let requestURI, _):
         let verifier = try PKCEVerifier(
@@ -488,7 +501,11 @@ internal actor AuthorizationServerClient: AuthorizationServerClientType {
         headers: clientAttestationHeaders + tokenHeaders,
         parameters: parameters.toDictionary().convertToDictionaryOfStrings()
       )
-      
+
+      if let freshChallenge = response.attestationChallenge() {
+        await challenger?.setChallenge(freshChallenge)
+      }
+
       switch response.body {
       case .success(let tokenType, let accessToken, let refreshToken, let refreshTokenExpiresIn, let expiresIn, _, let identifiers):
         return (
@@ -587,7 +604,11 @@ internal actor AuthorizationServerClient: AuthorizationServerClientType {
         ),
         parameters: parameters.toDictionary().convertToDictionaryOfStrings()
       )
-      
+
+      if let freshChallenge = response.attestationChallenge() {
+        await challenger?.setChallenge(freshChallenge)
+      }
+
       switch response.body {
       case .success(
         let tokenType,
@@ -670,6 +691,10 @@ internal actor AuthorizationServerClient: AuthorizationServerClientType {
         parameters: parameters.toDictionary().convertToDictionaryOfStrings()
       )
       
+      if let freshChallenge = response.attestationChallenge() {
+        await challenger?.setChallenge(freshChallenge)
+      }
+
       switch response.body {
       case .success(
         let tokenType,
@@ -714,6 +739,18 @@ internal actor AuthorizationServerClient: AuthorizationServerClientType {
         client: client,
         refreshToken: refreshToken,
         dpopNonce: nonce,
+        maxRetries: maxRetries - 1
+      )
+    } catch PostError.useAttestationNonce(let challenge) {
+      guard maxRetries > 0 else {
+        throw ValidationError.retryFailedAfterDpopNonce
+      }
+
+      await challenger?.setChallenge(challenge)
+      return try await refreshAccessToken(
+        client: client,
+        refreshToken: refreshToken,
+        dpopNonce: dpopNonce,
         maxRetries: maxRetries - 1
       )
     }
@@ -768,6 +805,10 @@ internal actor AuthorizationServerClient: AuthorizationServerClientType {
           parameters: parameters.toDictionary().convertToDictionaryOfStrings()
         )
         
+        if let freshChallenge = response.attestationChallenge() {
+          await challenger?.setChallenge(freshChallenge)
+        }
+
         switch response.body {
         case .success(
           let tokenType,

--- a/Sources/Main/Challenge/ChallengeEndpointClient.swift
+++ b/Sources/Main/Challenge/ChallengeEndpointClient.swift
@@ -16,13 +16,20 @@
 import Foundation
 
 public protocol ChallengeEndpointClientType: Sendable {
+
   func getChallenge() async throws -> (challenge: Nonce, dpopNonce: Nonce?)
+
+  /// Stores a challenge that the authorization server provided through the
+  /// `OAuth-Client-Attestation-Challenge` HTTP response header on a previous
+  /// response.
+  func setChallenge(_ challenge: Nonce) async
 }
 
 public actor ChallengeEndpointClient: ChallengeEndpointClientType {
   
   public let challengeEndpoint: URL
   let poster: PostingType
+  private var cachedChallenge: Nonce?
   
   public init(
     poster: PostingType = Poster(),
@@ -32,7 +39,16 @@ public actor ChallengeEndpointClient: ChallengeEndpointClientType {
     self.challengeEndpoint = challengeEndpoint
   }
   
+  public func setChallenge(_ challenge: Nonce) async {
+    self.cachedChallenge = challenge
+  }
+
   public func getChallenge() async throws -> (challenge: Nonce, dpopNonce: Nonce?) {
+
+    if let cached = cachedChallenge {
+      cachedChallenge = nil
+      return (challenge: cached, dpopNonce: nil)
+    }
 
     var request = URLRequest(url: challengeEndpoint)
     request.httpMethod = HTTPMethod.POST.rawValue


### PR DESCRIPTION

# Description of change

"Providing Challenges on Previous Responses" on the client side, so the library can pick up a fresh attestation challenge from a prior AS response instead of always round-tripping to the dedicated challenge endpoint

## Type of change

- [x] New feature (non-breaking change which adds functionality)


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes