### PR TITLE
Add encryption for deferred credential request and response

### DIFF
--- a/Sources/Entities/CredentialIssuer/CredentialIssuerMetadata.swift
+++ b/Sources/Entities/CredentialIssuer/CredentialIssuerMetadata.swift
@@ -81,7 +81,10 @@ public struct CredentialIssuerMetadata: Decodable, Equatable, Sendable {
     self.batchCredentialIssuance = batchCredentialIssuance
   }
   
-  public init(deferredCredentialEndpoint: CredentialIssuerEndpoint?) throws {
+  public init(
+    deferredCredentialEndpoint: CredentialIssuerEndpoint?,
+    credentialRequestEncryption: CredentialRequestEncryption? = nil
+  ) throws {
     try self.init(
       credentialIssuerIdentifier: .init(Constants.url),
       authorizationServers: [],
@@ -89,6 +92,7 @@ public struct CredentialIssuerMetadata: Decodable, Equatable, Sendable {
       deferredCredentialEndpoint: deferredCredentialEndpoint,
       nonceEndpoint: nil,
       notificationEndpoint: nil,
+      credentialRequestEncryption: credentialRequestEncryption ?? .notSupported,
       credentialConfigurationsSupported: [:],
       display: nil
     )

--- a/Sources/Entities/Types/TransactionId.swift
+++ b/Sources/Entities/Types/TransactionId.swift
@@ -30,7 +30,9 @@ public struct TransactionId: Codable, Sendable {
 
 public extension TransactionId {
   
-  func toDeferredRequestTO() -> DeferredIssuanceRequestTO {
-    DeferredIssuanceRequestTO(transactionId: value)
+  func toDeferredRequestTO(
+    credentialResponseEncryption: CredentialResponseEncryptionSpecTO? = nil
+  ) -> DeferredIssuanceRequestTO {
+    DeferredIssuanceRequestTO(transactionId: value, credentialResponseEncryption: credentialResponseEncryption)
   }
 }

--- a/Sources/Entities/Types/Types.swift
+++ b/Sources/Entities/Types/Types.swift
@@ -244,13 +244,16 @@ public struct Claim: Codable, Sendable {
 
 public struct DeferredIssuanceRequestTO: Codable {
   public let transactionId: String
-  
+  public let credentialResponseEncryption: CredentialResponseEncryptionSpecTO?
+
   private enum CodingKeys: String, CodingKey {
     case transactionId = "transaction_id"
+    case credentialResponseEncryption = "credential_response_encryption"
   }
   
-  public init(transactionId: String) {
+  public init(transactionId: String, credentialResponseEncryption: CredentialResponseEncryptionSpecTO? = nil) {
     self.transactionId = transactionId
+    self.credentialResponseEncryption = credentialResponseEncryption
   }
 }
 

--- a/Sources/Issuers/IssuanceRequester.swift
+++ b/Sources/Issuers/IssuanceRequester.swift
@@ -60,7 +60,8 @@ public protocol IssuanceRequesterType: Sendable {
     transactionId: TransactionId,
     dPopNonce: Nonce?,
     maxRetries: Int,
-    issuanceResponseEncryptionSpec: IssuanceResponseEncryptionSpec?
+    issuanceResponseEncryptionSpec: IssuanceResponseEncryptionSpec?,
+    encryptionSpec: EncryptionSpec?
   ) async throws -> DeferredCredentialIssuanceResponse
   
   /// Sends a notification to the credential issuer.
@@ -245,7 +246,8 @@ public actor IssuanceRequester: IssuanceRequesterType {
     transactionId: TransactionId,
     dPopNonce: Nonce?,
     maxRetries: Int = Constants.MAX_RETRIES,
-    issuanceResponseEncryptionSpec: IssuanceResponseEncryptionSpec?
+    issuanceResponseEncryptionSpec: IssuanceResponseEncryptionSpec?,
+    encryptionSpec: EncryptionSpec?
   ) async throws -> DeferredCredentialIssuanceResponse {
     guard let deferredCredentialEndpoint = issuerMetadata.deferredCredentialEndpoint else {
       throw CredentialError.issuerDoesNotSupportDeferredIssuance
@@ -256,16 +258,22 @@ public actor IssuanceRequester: IssuanceRequesterType {
       dPopNonce: dPopNonce,
       endpoint: deferredCredentialEndpoint.url
     )
-    
-    let encodedRequest: [String: any Sendable] = try JSON(transactionId.toDeferredRequestTO().toDictionary()).dictionaryValue
-    
+
+    let credentialResponseEncryption = makeCredentialResponseEncryption(
+      from: issuanceResponseEncryptionSpec
+    )
+
+    let encodedRequest: [String: any Sendable] = try JSON(
+      transactionId.toDeferredRequestTO(credentialResponseEncryption: credentialResponseEncryption).toDictionary()
+    ).dictionaryValue
+
     do {
       let response: ResponseWithHeaders<DeferredCredentialIssuanceResponse> = try await service.formPost(
         poster: poster,
         url: deferredCredentialEndpoint.url,
         headers: authorizationHeader,
         body: encodedRequest,
-        encryptionSpec: nil
+        encryptionSpec: encryptionSpec
       )
       
       if let interval = response.body.interval {
@@ -287,7 +295,8 @@ public actor IssuanceRequester: IssuanceRequesterType {
         transactionId: transactionId,
         dPopNonce: nonce,
         maxRetries: maxRetries - 1,
-        issuanceResponseEncryptionSpec: issuanceResponseEncryptionSpec
+        issuanceResponseEncryptionSpec: issuanceResponseEncryptionSpec,
+		encryptionSpec: encryptionSpec
       )
         
     } catch CredentialIssuanceError.deferredCredentialIssuancePending(let interval) {
@@ -376,7 +385,24 @@ public actor IssuanceRequester: IssuanceRequesterType {
 }
 
 private extension IssuanceRequester {
-  
+
+  private func makeCredentialResponseEncryption(
+    from spec: IssuanceResponseEncryptionSpec?
+  ) -> CredentialResponseEncryptionSpecTO? {
+    guard let spec else { return nil }
+    guard let jwkString = spec.jwk?.jsonString(), !jwkString.isEmpty else { return nil }
+
+    let jwk = JSON(parseJSON: jwkString)
+    guard jwk.type != .null else { return nil }
+
+    return CredentialResponseEncryptionSpecTO(
+      jwk: jwk,
+      encryptionAlgorithm: spec.algorithm.name,
+      encryptionMethod: spec.encryptionMethod.name,
+      compressionMethod: spec.compressionMethod?.rawValue
+    )
+  }
+
   func ensureJwtAlgIsSupported(
     credentialConfigurationIdentifier: CredentialConfigurationIdentifier?,
     issuerMetadata: CredentialIssuerMetadata,

--- a/Sources/Issuers/Issuer.swift
+++ b/Sources/Issuers/Issuer.swift
@@ -713,6 +713,7 @@ public extension Issuer {
   
   static func createDeferredIssuer(
     deferredCredentialEndpoint: CredentialIssuerEndpoint?,
+    credentialRequestEncryption: CredentialRequestEncryption? = nil,
     deferredRequesterPoster: PostingType,
     config: OpenId4VCIConfig
   ) throws -> Issuer {
@@ -725,7 +726,8 @@ public extension Issuer {
         )
       ),
       issuerMetadata: .init(
-        deferredCredentialEndpoint: deferredCredentialEndpoint
+        deferredCredentialEndpoint: deferredCredentialEndpoint,
+        credentialRequestEncryption: credentialRequestEncryption
       ),
       config: config,
       deferredRequesterPoster: deferredRequesterPoster
@@ -844,13 +846,16 @@ public extension Issuer {
     transactionId: TransactionId,
     dPopNonce: Nonce?
   ) async throws -> DeferredCredentialIssuanceResponse {
-    
+
+    let encryptionSpec = try encryptionSpec()
+
     return try await deferredIssuanceRequester.placeDeferredCredentialRequest(
       accessToken: request.accessToken,
       transactionId: transactionId,
       dPopNonce: dPopNonce,
       maxRetries: Constants.MAX_RETRIES,
-      issuanceResponseEncryptionSpec: deferredResponseEncryptionSpec
+      issuanceResponseEncryptionSpec: deferredResponseEncryptionSpec,
+      encryptionSpec: encryptionSpec
     )
   }
   


### PR DESCRIPTION
# Description of change

This PR adds encryption support for deferred credential requests and responses in the issuance flow. The upstream package currently did not cover the behavior we needed for deferred issuance encryption, so this fork introduces the missing support in a backward-compatible way.

### What was changed
- Added support to include `credential_response_encryption` in deferred credential requests.
- Propagated deferred request encryption settings through the call chain so deferred endpoint requests can be sent with request-level encryption when configured.
- Extended deferred request DTO mapping so a transaction-based deferred request can carry encryption parameters.
- Updated issuer/deferred issuer creation APIs to accept encryption-related metadata/configuration for deferred flows.
- Added internal mapping logic from issuance response encryption config to deferred request payload format.

### Standards rationale (OpenID4VCI 1.0, Section 9)
This implementation aligns with [OpenID4VCI 1.0 Section 9](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-deferred-credential-endpoin) (Deferred Credential Endpoint):
- Section 9.1 allows Deferred Credential Requests to include credential_response_encryption (as defined in Section 8.2).
- Section 9.1 also states Deferred Credential Requests MAY be encrypted using credential_request_encryption metadata, and MUST be encrypted when encryption_required = true.
- Section 9.2 requires that if credential_response_encryption is provided, the issuer uses it to encrypt the Deferred Credential Response, regardless of response content.
- Section 9.2 explicitly allows the deferred request’s credential_response_encryption object to differ from the one used in the initial credential request, to simplify key management for longer deferred issuance flows.

### Backward compatibility
- Existing flows remain unchanged when encryption parameters are not provided.
- New parameters are optional where possible and default to current behavior.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes