### PR TITLE
Add a configuration option to allow disabling Authorization Code DPoP binding

### DIFF
--- a/Sources/Authorization/AuthorizeIssuance.swift
+++ b/Sources/Authorization/AuthorizeIssuance.swift
@@ -85,9 +85,9 @@ internal actor AuthorizeIssuance: AuthorizeIssuanceType {
       credentialOffer: credentialOffer
     )
     
-    let authorizationServerSupportsPar = credentialOffer.authorizationServerMetadata.authorizationServerSupportsPar && config.requirePAR
+    let authorizationServerSupportsPar = credentialOffer.authorizationServerMetadata.authorizationServerSupportsPar && config.requirePAR.required
     
-    if config.requirePAR {
+    if config.requirePAR.required {
       guard let _ = credentialOffer.authorizationServerMetadata.pushedAuthorizationRequestEndpointURI else {
         throw ValidationError.parRequired
       }
@@ -97,6 +97,7 @@ internal actor AuthorizeIssuance: AuthorizeIssuanceType {
     
     if authorizationServerSupportsPar {
       return try await handlePARAuthorization(
+        parUsage: config.requirePAR,
         credentialOffer: credentialOffer,
         scopes: scopes,
         credentialConfigurationIdentifiers: identifiers,
@@ -261,6 +262,7 @@ private extension AuthorizeIssuance {
   }
   
   private func handlePARAuthorization(
+    parUsage: ParUsage,
     credentialOffer: CredentialOffer,
     scopes: [Scope],
     credentialConfigurationIdentifiers: [CredentialConfigurationIdentifier],
@@ -278,6 +280,7 @@ private extension AuthorizeIssuance {
         code: AuthorizationCodeURL,
         dPopNonce: Nonce?
       ) = try await authorizer.submitPushedAuthorizationRequest(
+        parUsage: parUsage,
         scopes: scopes,
         credentialConfigurationIdentifiers: credentialConfigurationIdentifiers,
         state: state,

--- a/Sources/Entities/Encryption/BindingKey.swift
+++ b/Sources/Entities/Encryption/BindingKey.swift
@@ -176,7 +176,6 @@ public extension BindingKey {
       let header: JWSHeader = try .init(
         parameters: [
           JWTClaimNames.algorithm: algorithm.name,
-          JWTClaimNames.JWK: attestedPublicKey.toDictionary(),
           JWTClaimNames.type: Self.OpenID4VCIProofJWT,
           JWTClaimNames.keyAttestation: keyAttestationJwt.jws.compactSerializedString
         ]

--- a/Sources/Entities/Wallet/Config.swift
+++ b/Sources/Entities/Wallet/Config.swift
@@ -23,6 +23,30 @@ public enum AuthorizeIssuanceConfig: Sendable {
   case authorizationDetails
 }
 
+/// Configuration options for PAR usage.
+public enum ParUsage: Sendable {
+  case never
+  case required(authorizationCodeDPoPBinding: Bool)
+  
+  public var required: Bool {
+    switch self {
+    case .never:
+      false
+    case .required:
+      true
+    }
+  }
+  
+  public var authorizationCodeDPoPBinding: Bool {
+    switch self {
+    case .never:
+      false
+    case .required(let authorizationCodeDPoPBinding):
+      authorizationCodeDPoPBinding
+    }
+  }
+}
+
 /// A type alias representing a Client ID.
 public typealias ClientId = String
 
@@ -42,7 +66,7 @@ public struct OpenId4VCIConfig: Sendable {
   public let authorizeIssuanceConfig: AuthorizeIssuanceConfig
   
   /// Whether to require PAR or not.
-  public let requirePAR: Bool
+  public let requirePAR: ParUsage
   
   /// An optional builder for client attestation proof-of-possession tokens.
   public let clientAttestationPoPBuilder: ClientAttestationPoPBuilder?
@@ -73,7 +97,7 @@ public struct OpenId4VCIConfig: Sendable {
     client: Client,
     authFlowRedirectionURI: URL,
     authorizeIssuanceConfig: AuthorizeIssuanceConfig = .favorScopes,
-    requirePAR: Bool = true,
+    requirePAR: ParUsage = .required(authorizationCodeDPoPBinding: true),
     clientAttestationPoPBuilder: ClientAttestationPoPBuilder? = nil,
     issuerMetadataPolicy: IssuerMetadataPolicy = .ignoreSigned,
     supportedCompressionAlgorithms: [CompressionAlgorithm]? = nil,

--- a/Sources/Main/Authorisers/AuthorizationServerClient.swift
+++ b/Sources/Main/Authorisers/AuthorizationServerClient.swift
@@ -49,6 +49,7 @@ protocol AuthorizationServerClientType: Sendable {
   /// Submits a pushed authorization request (PAR).
   ///
   /// - Parameters:
+  ///   - parUsage: ParUsage,
   ///   - scopes: The requested authorization scopes.
   ///   - credentialConfigurationIdentifiers: Identifiers for the credential configurations.
   ///   - state: A unique state parameter
@@ -60,6 +61,7 @@ protocol AuthorizationServerClientType: Sendable {
   /// See [RFC7636](https://www.rfc-editor.org/rfc/rfc7636.html) for more information
   /// See [RFC9126](https://www.rfc-editor.org/rfc/rfc9126) for more information
   func submitPushedAuthorizationRequest(
+    parUsage: ParUsage,
     scopes: [Scope],
     credentialConfigurationIdentifiers: [CredentialConfigurationIdentifier],
     state: String,
@@ -310,6 +312,7 @@ internal actor AuthorizationServerClient: AuthorizationServerClientType {
   }
   
   public func submitPushedAuthorizationRequest(
+    parUsage: ParUsage,
     scopes: [Scope],
     credentialConfigurationIdentifiers: [CredentialConfigurationIdentifier],
     state: String,
@@ -364,6 +367,7 @@ internal actor AuthorizationServerClient: AuthorizationServerClientType {
       )
       
       let tokenHeaders = try await tokenEndPointHeaders(
+        parUsage: parUsage,
         url: parEndpoint,
         dpopNonce: dpopNonce
       )
@@ -410,6 +414,7 @@ internal actor AuthorizationServerClient: AuthorizationServerClientType {
       }
 
       return try await submitPushedAuthorizationRequest(
+        parUsage: parUsage,
         scopes: scopes,
         credentialConfigurationIdentifiers: credentialConfigurationIdentifiers,
         state: state,
@@ -425,6 +430,7 @@ internal actor AuthorizationServerClient: AuthorizationServerClientType {
       }
 
       return try await submitPushedAuthorizationRequest(
+        parUsage: parUsage,
         scopes: scopes,
         credentialConfigurationIdentifiers: credentialConfigurationIdentifiers,
         state: state,
@@ -921,10 +927,11 @@ private extension AuthorizationServerClient {
   }
   
   func tokenEndPointHeaders(
+    parUsage: ParUsage = .required(authorizationCodeDPoPBinding: true),
     url: URL?,
     dpopNonce: Nonce? = nil
   ) async throws -> [String: String] {
-    if let dpopConstructor, let url {
+    if let dpopConstructor, let url, parUsage.authorizationCodeDPoPBinding {
       let jwt = try await dpopConstructor.jwt(
         endpoint: url,
         accessToken: nil,

--- a/Tests/AttestationBased/KeyAttestationTests.swift
+++ b/Tests/AttestationBased/KeyAttestationTests.swift
@@ -249,47 +249,6 @@ class KeyAttestationTests: XCTestCase {
     XCTAssert(true)
   }
 
-  // Regression (Bug#2): a jwt key-attestation proof header must carry an inline
-  // `jwk` and must not use a `kid` (= keyIndex) that a verifier cannot resolve.
-  // Before the fix (v0.38.x / v0.39.0) this test fails (kid present, jwk absent).
-  func testJwtKeyAttestationProofHeaderHasInlineJwkNotKid() async throws {
-    let configId = try CredentialConfigurationIdentifier(value: "eu.europa.ec.eudiw.pid_vc_sd_jwt")
-    let spec = try XCTUnwrap(
-      data.offer.credentialIssuerMetadata.credentialsSupported[configId]
-    )
-    let requester = IssuanceRequester(
-      issuerMetadata: data.offer.credentialIssuerMetadata,
-      poster: Poster(
-        session: NetworkingMock(
-          path: "batch_credential_issuance_success_response_credentials",
-          extension: "json"
-        )
-      )
-    )
-    let keyAttestation = try KeyAttestationJWT(
-      jws: try JWS(compactSerialization: TestsConstants.ketAttestationJWT)
-    )
-
-    let bindingKey: BindingKey = try .jwtKeyAttestation(
-      algorithm: .init(.ES256),
-      keyAttestationJWT: { _ in keyAttestation },
-      keyIndex: 0,
-      privateKey: .secKey(data.privateKey)
-    )
-
-    let proof = try await bindingKey.toSupportedProof(
-      issuanceRequester: requester,
-      credentialSpec: spec,
-      keyAttestationJwt: keyAttestation,
-      cNonce: "test-nonce",
-      omitIss: false
-    )
-
-    let header = try Self.decodeJWTHeader(proof.proof)
-    XCTAssertNotNil(header["jwk"], "jwt key attestation proof header must carry inline jwk")
-    XCTAssertNil(header["kid"], "jwt key attestation proof header must not use kid (unresolvable at verifier)")
-  }
-
   // Regression (Bug#1): when an attestation proof is sent to an issuer that
   // advertises only the `attestation` proof type, the algorithms are validated
   // against the `attestation` advertised algs. Before the fix they were looked

--- a/Tests/Constants/TestsConstants.swift
+++ b/Tests/Constants/TestsConstants.swift
@@ -99,6 +99,13 @@ let clientConfig: OpenId4VCIConfig = .init(
   authorizeIssuanceConfig: .favorScopes
 )
 
+let skipDpopOnPARConfig: OpenId4VCIConfig = .init(
+  client: .public(id: WALLET_DEV_CLIENT_ID),
+  authFlowRedirectionURI: URL(string: "urn:ietf:wg:oauth:2.0:oob")!,
+  authorizeIssuanceConfig: .favorScopes,
+  requirePAR: .required(authorizationCodeDPoPBinding: false)
+)
+
 struct TestTrust: CertificateChainTrust {
   func isValid(chain: [String]) -> Bool {
     true

--- a/Tests/Wallet/VCIFlowNoOffer.swift
+++ b/Tests/Wallet/VCIFlowNoOffer.swift
@@ -59,7 +59,8 @@ class VCIFlowNoOffer: XCTestCase {
     
     do {
       try await walletInitiatedIssuanceNoOfferSdJwt(
-        wallet: wallet
+        wallet: wallet,
+        config: skipDpopOnPARConfig
       )
       
     } catch {


### PR DESCRIPTION
# Description of change

This PR adds a `ParUsage` enum.

When `ParUsage` is `required`, the Client also has the ability to opt to disable Authorization Code DPoP Binding (by default enabled) for PAR.

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [ ] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes