### PR TITLE
Remove plain jwt proof, enforce attested proof types in issuer metadata.

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,22 +308,41 @@ public struct OpenId4VCIConfig: Sendable {
 
 ### Proof Types Policy Configuration
 
-The library supports configuring which proof types your wallet will accept for credential issuance.
+The library enforces device-bound attestations. Only the following proof types are
+accepted for credential issuance:
 
-#### Policy Options
+- `proof_type: attestation`
+- `proof_type: jwt` with `key_attestation` in the protected header
 
-**1. Accept All (Default - Backward Compatible)**
-Accepts any proof type including simple JWT proofs without key attestation. Use for testing or legacy compatibility.
+Plain JWT proofs (no `key_attestation`) are not supported.
 
-**2. Device Bound (HAIP Compliant - Recommended for Production)**
-Enforces HAIP v1 / ETSI TS 119 472-3 compliance:
-- Accepts JWT proofs WITH key attestation
-- Accepts attestation proofs
-- Rejects simple JWT proofs without key attestation
-- Ensures device-bound credentials are properly secured with hardware-backed keys
+Issuer metadata is validated:
 
-**3. Flexible Policy**
-Allows custom configuration supporting both device-bound and non-device-bound credentials.
+- A credential configuration whose `proof_types_supported` is missing or empty
+  is treated as "no proof required" and accepted.
+- A non-empty `proof_types_supported` MUST advertise BOTH `jwt` AND
+  `attestation`, and BOTH MUST carry `key_attestations_required`. Any other
+  shape is rejected with `CredentialIssuanceError.issuerMetadataNoAttestedProofType`.
+
+`ProofTypesPolicy` is a struct that declares the wallet's supported signing
+algorithms and supported attested proof types:
+
+```swift
+public struct ProofTypesPolicy: Sendable {
+  public let supportedAlgorithms: [JWSAlgorithm]
+  public let supportedProofTypes: Set<AttestedProofType>
+}
+
+public enum AttestedProofType: String, Sendable {
+  case jwtWithKeyAttestation
+  case attestation
+}
+```
+
+The default for `OpenId4VCIConfig.proofTypesPolicy` is `.haipCompliant()`, which
+accepts `ES256` and both attested proof types. Provide a custom
+`ProofTypesPolicy(supportedAlgorithms:, supportedProofTypes:)` to narrow the
+algorithms or the attested proof types your wallet is willing to produce.
 
 
 ## Features supported
@@ -345,7 +364,12 @@ endpoints.
 OpenId4VCI specification defines several extension points to accommodate the differences across Credential formats. The current version of the library fully supports **ISO mDL** profile and gives some initial support for **IETF SD-JWT VC** profile.  
 
 #### Proof Types
-OpenId4VCI specification (draft 14) defines proofs that can be included in a credential issuance request, JWT proof type in particular. The current version of the library supports JWT proof types.
+OpenId4VCI specification (draft 14) defines proofs that can be included in a credential issuance request. The library supports the two attested proof types only:
+
+- `attestation` proof.
+- `jwt` proof with `key_attestation` in the protected header.
+
+Plain JWT proofs (without `key_attestation`) are intentionally not supported. See [Proof Types Policy Configuration](#proof-types-policy-configuration) above.
 
 ### Demonstrating Proof of Possession (DPoP)
 

--- a/Sources/Entities/Encryption/BindingKey.swift
+++ b/Sources/Entities/Encryption/BindingKey.swift
@@ -18,13 +18,6 @@
 
 public enum BindingKey: Sendable, Equatable {
   
-  case jwt(
-    algorithm: JWSAlgorithm,
-    jwk: JWK,
-    privateKey: SigningKeyProxy,
-    issuer: String? = nil
-  )
-  
   case attestation(
     keyAttestationJWT: @Sendable (_ nonce: String?) async throws -> KeyAttestationJWT
   )
@@ -48,8 +41,7 @@ public extension BindingKey {
   
   static func == (lhs: BindingKey, rhs: BindingKey) -> Bool {
     switch (lhs, rhs) {
-    case (.jwt, .jwt),
-      (.did, .did),
+    case (.did, .did),
       (.x509, .x509),
       (.jwtKeyAttestation, .jwtKeyAttestation),
       (.attestation, .attestation):
@@ -67,75 +59,6 @@ public extension BindingKey {
     omitIss: Bool
   ) async throws -> Proof {
     switch self {
-    case .jwt(
-      let algorithm,
-      let jwk,
-      let privateKey,
-      let issuer
-    ):
-      let proofTypesSupported = credentialSpec.proofTypesSupported
-      let suites = proofTypesSupported?["jwt"]?.algorithms.contains { $0 == algorithm.name } ??  true
-      guard suites else {
-        throw CredentialIssuanceError.cryptographicSuiteNotSupported(algorithm.name)
-      }
-      
-      let keyAttestationRequirement = proofTypesSupported?["jwt"]?.keyAttestationRequirement
-      switch keyAttestationRequirement {
-      case .required, .requiredNoConstraints:
-        throw CredentialIssuanceError.proofTypeKeyAttestationRequired
-      default: break
-      }
-      
-      let proofs = proofTypesSupported?.keys.contains { $0 == "jwt" } ?? true
-      guard proofs else {
-        throw CredentialIssuanceError.proofTypeNotSupported
-      }
-      
-      let aud = issuanceRequester.issuerMetadata.credentialIssuerIdentifier.url.absoluteString
-      
-      let header: JWSHeader = try .init(parameters: [
-        JWTClaimNames.type: Self.OpenID4VCIProofJWT,
-        JWTClaimNames.algorithm: algorithm.name,
-        JWTClaimNames.JWK: jwk.toDictionary()
-      ])
-      
-      let dictionary: [String: Any] = [
-        JWTClaimNames.issuedAt: Int(Date().timeIntervalSince1970.rounded()),
-        JWTClaimNames.audience: aud,
-        JWTClaimNames.nonce: cNonce ?? "",
-        JWTClaimNames.issuer: issuer ?? ""
-      ].filter { key, value in
-        if let string = value as? String, string.isEmpty {
-          return false
-        }
-        
-        if key == JWTClaimNames.issuer, omitIss {
-          return false
-        }
-        
-        return true
-      }
-      
-      let payload = Payload(try dictionary.toThrowingJSONData())
-      
-      guard let signatureAlgorithm = SignatureAlgorithm(rawValue: algorithm.name) else {
-        throw CredentialIssuanceError.cryptographicAlgorithmNotSupported
-      }
-      
-      let signer: Signer = try await Self.createSigner(
-        with: header,
-        and: payload,
-        for: privateKey,
-        and: signatureAlgorithm
-      )
-      
-      let jws = try JWS(
-        header: header,
-        payload: payload,
-        signer: signer
-      )
-      
-      return .jwt(jws.compactSerializedString)
     case .jwtKeyAttestation(
       let algorithm,
       _,

--- a/Sources/Entities/Errors/CredentialIssuanceError.swift
+++ b/Sources/Entities/Errors/CredentialIssuanceError.swift
@@ -50,7 +50,7 @@ public enum CredentialIssuanceError: Error, LocalizedError {
   
   case proofTypesNotSupportedByCredentialConfiguration
   case proofTypeNotSupportedByWalletPolicy
-  case proofTypeJwtWithoutKeyAttestationNotAllowedByPolicy
+  case issuerMetadataNoAttestedProofType
   case bindingKeyNotAttestationCapable
   case noMatchingAlgorithmForProofType
   case keyIndexOutOfBounds(index: UInt, available: Int)
@@ -123,8 +123,8 @@ public enum CredentialIssuanceError: Error, LocalizedError {
       return "Credential configuration does not support proof types required by wallet policy."
     case .proofTypeNotSupportedByWalletPolicy:
       return "The credential configuration requires a proof type that is not supported by the wallet's policy."
-    case .proofTypeJwtWithoutKeyAttestationNotAllowedByPolicy:
-      return "The credential configuration requires JWT proof without key attestation, which is not allowed by the wallet's policy."
+    case .issuerMetadataNoAttestedProofType:
+      return "Issuer metadata does not advertise an attested proof type. Device-bound attestations require either proof_type 'attestation' or proof_type 'jwt' with key_attestation in the protected header."
     case .bindingKeyNotAttestationCapable:
       return "The binding key is not attestation-capable but the credential configuration or wallet policy requires key attestation."
     case .noMatchingAlgorithmForProofType:

--- a/Sources/Entities/Wallet/Config.swift
+++ b/Sources/Entities/Wallet/Config.swift
@@ -59,11 +59,10 @@ public struct OpenId4VCIConfig: Sendable {
   /// Wallet's supported credential reuse policies
   public let supportedCredentialReusePolicies: SupportedCredentialReusePolicies
   
-  /// Policy defining which proof types the wallet supports.
-  /// Wallets should reject credentials that require plain JWT proofs without key attestation
-  /// for device-bound attestations.
+  /// Policy defining which signing algorithms and attested proof types the
+  /// wallet supports. Plain `jwt` proofs (no key attestation) are not supported.
   ///
-  /// Default is `.acceptAll` for backward compatibility.
+  /// Default is `.haipCompliant()`.
   public let proofTypesPolicy: ProofTypesPolicy
   
   /// Initializes an `OpenId4VCIConfig` instance with the given parameters.
@@ -75,7 +74,7 @@ public struct OpenId4VCIConfig: Sendable {
   ///   - clientAttestationPoPBuilder: An optional client attestation PoP builder (default: `nil`).
   ///   - issuerMetadataPolicy: Policy defining how issuer metadata should be handled (default: `.ignoreSigned`).
   ///   - requireDpop: If dpop is supported then use it, otherwise always don't
-  ///   - proofTypesPolicy: Policy defining which proof types the wallet supports (default: `.acceptAll`).
+  ///   - proofTypesPolicy: Policy defining which proof types the wallet supports (default: `.haipCompliant()`).
   ///   - supportedCredentialReusePolicies: Wallet's supported credential reuse policies (default: `.notSupported`).
   public init(
     client: Client,
@@ -85,7 +84,7 @@ public struct OpenId4VCIConfig: Sendable {
     clientAttestationPoPBuilder: ClientAttestationPoPBuilder? = nil,
     issuerMetadataPolicy: IssuerMetadataPolicy = .ignoreSigned,
     supportedCompressionAlgorithms: [CompressionAlgorithm]? = nil,
-    proofTypesPolicy: ProofTypesPolicy = .acceptAll,
+    proofTypesPolicy: ProofTypesPolicy = .haipCompliant(),
     requireDpop: Bool = true,
     supportedCredentialReusePolicies: SupportedCredentialReusePolicies = .notSupported
   ) {

--- a/Sources/Entities/Wallet/ProofTypesPolicy.swift
+++ b/Sources/Entities/Wallet/ProofTypesPolicy.swift
@@ -16,198 +16,120 @@
 import Foundation
 import JOSESwift
 
-/// Policy defining which proof types the wallet supports for credential issuance.
+/// Proof types accepted by the wallet.
 ///
-/// For device-bound attestations, proofs of type JWT cannot be used alone
-/// - Wallet must use either:
-///   - Proof of type `attestation`
-///   - Proof of type `jwt` + `key_attestation`
-/// - Plain JWT proofs (without key_attestation) are not allowed for device-bound credentials
-public enum ProofTypesPolicy: Sendable {
-  /// Default policy: accepts any proof type including plain JWT without key attestation.
-  /// This is the legacy behavior for backward compatibility.
-  case acceptAll
-
-  /// Rejects credential configurations that require plain JWT proofs without key attestation.
-  /// - Parameter policy: The device-bound proof policy specifying supported algorithms and proof types.
-  case deviceBound(DeviceBoundProofPolicy)
-
-  /// Flexible policy: supports both device-bound and non-device-bound attestations.
-  /// - Parameters:
-  ///   - deviceBound: Policy for device-bound credentials
-  ///   - allowNonDeviceBound: Whether to allow non-device-bound credentials (no proofs required)
-  case flexible(deviceBound: DeviceBoundProofPolicy, allowNonDeviceBound: Bool)
+public enum AttestedProofType: String, Hashable, Sendable {
+  case jwtWithKeyAttestation = "jwt_with_key_attestation"
+  case attestation = "attestation"
 }
 
-/// Policy configuration for device-bound proof types.
-public struct DeviceBoundProofPolicy: Sendable {
+/// Wallet's policy for credential-request proofs.
+///
+/// Defines which signing algorithms and which attested proof types the wallet
+/// is willing to produce. Used to validate that the issuer's
+/// `proof_types_supported` advertises a compatible option.
+public struct ProofTypesPolicy: Sendable {
   public let supportedAlgorithms: [JWSAlgorithm]
-  public let supportedProofTypes: Set<DeviceBoundProofType>
+  public let supportedProofTypes: Set<AttestedProofType>
 
   public init(
     supportedAlgorithms: [JWSAlgorithm],
-    supportedProofTypes: Set<DeviceBoundProofType>
+    supportedProofTypes: Set<AttestedProofType>
   ) {
     self.supportedAlgorithms = supportedAlgorithms
     self.supportedProofTypes = supportedProofTypes
   }
 
-  /// Creates a HAIP compliant policy.
-  /// This policy only accepts JWT with key attestation or attestation proofs.
-  /// - Parameter algorithms: Supported signing algorithms. Defaults to ES256.
-  /// - Returns: A compliant device-bound proof policy.
+  /// HAIP-compliant policy: ES256 with both attested proof types.
   public static func haipCompliant(
     algorithms: [JWSAlgorithm] = [JWSAlgorithm(.ES256)]
-  ) -> DeviceBoundProofPolicy {
-    return DeviceBoundProofPolicy(
+  ) -> ProofTypesPolicy {
+    return ProofTypesPolicy(
       supportedAlgorithms: algorithms,
       supportedProofTypes: [.jwtWithKeyAttestation, .attestation]
     )
   }
 }
 
-/// Types of proofs accepted for device-bound credentials.
-///
-/// Per the device-bound proof rule, only proofs that carry a key attestation
-/// are valid: either a JWT proof with `key_attestation` in its protected header,
-/// or an `attestation` proof. Plain JWT proofs (without key attestation) are
-/// intentionally not modeled here; permission to send them is controlled by
-/// `ProofTypesPolicy.flexible(_, allowNonDeviceBound:)`.
-public enum DeviceBoundProofType: String, Hashable, Sendable {
-
-  case jwtWithKeyAttestation = "jwt_with_key_attestation"
-  case attestation = "attestation"
-}
-
 // MARK: - Validation
 
 public extension ProofTypesPolicy {
 
-  /// Validates whether a credential configuration is compatible with this policy.
+  /// Validates issuer metadata for a credential configuration up front, before
+  /// any binding key is built.
   ///
-  /// - Parameters:
-  ///   - credentialConfiguration: The credential configuration to validate.
-  ///   - bindingKey: The binding key that will be used for the proof.
-  /// - Throws: `CredentialIssuanceError` if the configuration violates the policy.
+  /// Rules
+  ///   - If `proof_types_supported` is missing or empty, the configuration
+  ///     does not require a proof; this method returns successfully.
+  ///   - Otherwise, the configuration MUST advertise BOTH `proof_type: jwt`
+  ///     AND `proof_type: attestation`, and BOTH MUST carry
+  ///     `key_attestations_required`.
+  ///   - At least one of the two advertised attested proof types must be in
+  ///     the wallet's `supportedProofTypes`, with at least one matching
+  ///     algorithm in `supportedAlgorithms`.
+  ///
+  /// Throws:
+  ///   - `CredentialIssuanceError.issuerMetadataNoAttestedProofType` when the
+  ///     metadata invariant is violated.
+  ///   - `CredentialIssuanceError.proofTypeNotSupportedByWalletPolicy` when no
+  ///     advertised type intersects the wallet's `supportedProofTypes`.
+  ///   - `CredentialIssuanceError.noMatchingAlgorithmForProofType` when no
+  ///     advertised algorithm intersects the wallet's `supportedAlgorithms`.
+  func validateIssuerMetadata(
+    credentialConfiguration: CredentialSupported
+  ) throws {
+    guard let proofTypesSupported = credentialConfiguration.proofTypesSupported,
+          !proofTypesSupported.isEmpty else {
+      return
+    }
+
+    guard let jwtMeta = proofTypesSupported["jwt"],
+          let attestationMeta = proofTypesSupported["attestation"],
+          Self.requiresKeyAttestation(jwtMeta),
+          Self.requiresKeyAttestation(attestationMeta) else {
+      throw CredentialIssuanceError.issuerMetadataNoAttestedProofType
+    }
+
+    let walletSupported: [(AttestedProofType, ProofTypeSupportedMeta)] = [
+      (.jwtWithKeyAttestation, jwtMeta),
+      (.attestation, attestationMeta)
+    ].filter { supportedProofTypes.contains($0.0) }
+
+    guard !walletSupported.isEmpty else {
+      throw CredentialIssuanceError.proofTypeNotSupportedByWalletPolicy
+    }
+
+    let hasMatchingAlgorithm = walletSupported.contains { (_, meta) in
+      meta.algorithms.contains { issuerAlg in
+        supportedAlgorithms.contains { walletAlg in
+          walletAlg.name == issuerAlg
+        }
+      }
+    }
+    guard hasMatchingAlgorithm else {
+      throw CredentialIssuanceError.noMatchingAlgorithmForProofType
+    }
+  }
+
+  /// Validates that a chosen binding key is compatible with the credential
+  /// configuration. Assumes `validateIssuerMetadata` has already succeeded.
   func validate(
     credentialConfiguration: CredentialSupported,
     bindingKey: BindingKey
   ) throws {
-    switch self {
-    case .acceptAll:
-      // Accept everything - no validation needed
-      return
-
-    case .deviceBound(let policy):
-      try validateDeviceBound(
-        credentialConfiguration: credentialConfiguration,
-        policy: policy,
-        bindingKey: bindingKey,
-        allowNonDeviceBound: false
-      )
-
-    case .flexible(let policy, let allowNonDeviceBound):
-      try validateDeviceBound(
-        credentialConfiguration: credentialConfiguration,
-        policy: policy,
-        bindingKey: bindingKey,
-        allowNonDeviceBound: allowNonDeviceBound
-      )
-    }
-  }
-
-  private func validateDeviceBound(
-    credentialConfiguration: CredentialSupported,
-    policy: DeviceBoundProofPolicy,
-    bindingKey: BindingKey,
-    allowNonDeviceBound: Bool
-  ) throws {
-    guard let proofTypesSupported = credentialConfiguration.proofTypesSupported else {
-      if allowNonDeviceBound {
-        return
-      } else {
-        throw CredentialIssuanceError.proofTypesNotSupportedByCredentialConfiguration
-      }
-    }
-
-    if let jwtProofMeta = proofTypesSupported["jwt"] {
-      try validateJwtProof(
-        jwtProofMeta: jwtProofMeta,
-        policy: policy,
-        bindingKey: bindingKey,
-        allowNonDeviceBound: allowNonDeviceBound
-      )
-    }
-
-    if let attestationProofMeta = proofTypesSupported["attestation"] {
-      try validateAttestationProof(
-        attestationProofMeta: attestationProofMeta,
-        policy: policy,
-        bindingKey: bindingKey
-      )
-    }
-  }
-
-  private func validateJwtProof(
-    jwtProofMeta: ProofTypeSupportedMeta,
-    policy: DeviceBoundProofPolicy,
-    bindingKey: BindingKey,
-    allowNonDeviceBound: Bool
-  ) throws {
-
-    let hasMatchingAlgorithm = jwtProofMeta.algorithms.contains { issuerAlg in
-      policy.supportedAlgorithms.contains { walletAlg in
-        walletAlg.name == issuerAlg
-      }
-    }
-
-    guard hasMatchingAlgorithm else {
-      throw CredentialIssuanceError.noMatchingAlgorithmForProofType
-    }
-
-    let keyAttestationRequired = jwtProofMeta.keyAttestationRequirement != nil &&
-                                 jwtProofMeta.keyAttestationRequirement != .notRequired
-
-    if keyAttestationRequired {
-      guard policy.supportedProofTypes.contains(.jwtWithKeyAttestation) else {
-        throw CredentialIssuanceError.proofTypeNotSupportedByWalletPolicy
-      }
-
-      guard bindingKey.isAttestationCapable else {
-        throw CredentialIssuanceError.bindingKeyNotAttestationCapable
-      }
-    } else {
-      // Issuer's jwt proof type does not require key attestation: this is a
-      // non-device-bound JWT proof. Under strict device-bound policy it is
-      // always rejected; under flexible mode it is permitted only when the
-      // wallet has opted in via allowNonDeviceBound.
-      guard allowNonDeviceBound else {
-        throw CredentialIssuanceError.proofTypeJwtWithoutKeyAttestationNotAllowedByPolicy
-      }
-    }
-  }
-
-  private func validateAttestationProof(
-    attestationProofMeta: ProofTypeSupportedMeta,
-    policy: DeviceBoundProofPolicy,
-    bindingKey: BindingKey
-  ) throws {
-    guard policy.supportedProofTypes.contains(.attestation) else {
-      throw CredentialIssuanceError.proofTypeNotSupportedByWalletPolicy
-    }
+    try validateIssuerMetadata(credentialConfiguration: credentialConfiguration)
 
     guard bindingKey.isAttestationCapable else {
       throw CredentialIssuanceError.bindingKeyNotAttestationCapable
     }
+  }
 
-    let hasMatchingAlgorithm = attestationProofMeta.algorithms.contains { issuerAlg in
-      policy.supportedAlgorithms.contains { walletAlg in
-        walletAlg.name == issuerAlg
-      }
-    }
-
-    guard hasMatchingAlgorithm else {
-      throw CredentialIssuanceError.noMatchingAlgorithmForProofType
+  private static func requiresKeyAttestation(_ meta: ProofTypeSupportedMeta) -> Bool {
+    switch meta.keyAttestationRequirement {
+    case .some(.required), .some(.requiredNoConstraints):
+      return true
+    default:
+      return false
     }
   }
 }

--- a/Sources/Issuers/Issuer.swift
+++ b/Sources/Issuers/Issuer.swift
@@ -483,14 +483,18 @@ internal extension Issuer {
       .credentialsSupported[credentialConfigurationIdentifier] else {
       throw ValidationError.error(reason: "Invalid Supported credential for requestSingle")
     }
-    
+
+    try config.proofTypesPolicy.validateIssuerMetadata(
+      credentialConfiguration: supportedCredential
+    )
+
     for bindingKey in bindingKeys {
       try config.proofTypesPolicy.validate(
         credentialConfiguration: supportedCredential,
         bindingKey: bindingKey
       )
     }
-
+    
     let proofs = try await obtainProofs(
       authorizedRequest: authorizedRequest,
       batchCredentialIssuance: issuerMetadata.batchCredentialIssuance,
@@ -531,6 +535,10 @@ internal extension Issuer {
     try Self.validateRequestPayload(
       requestPayload: issuancePayload,
       authorizationDetails: authorizedRequest.credentialIdentifiers ?? [:]
+    )
+    
+    try config.proofTypesPolicy.validateIssuerMetadata(
+      credentialConfiguration: supportedCredential
     )
     
     for bindingKey in bindingKeys {
@@ -648,7 +656,7 @@ internal extension Issuer {
     /// Filter for keys we care about
     let eligibleKeys = bindingKeys.filter {
       switch $0 {
-      case .jwt, .jwtKeyAttestation, .attestation: true
+      case .jwtKeyAttestation, .attestation: true
       default: false
       }
     }

--- a/Sources/Resources/europa/credential_issuer_metadata.json
+++ b/Sources/Resources/europa/credential_issuer_metadata.json
@@ -1,24 +1,26 @@
 {
   "credential_issuer": "https://credential-issuer.example.com",
-  "authorization_servers": ["https://example.com/realms/pid-issuer-realm"],
+  "authorization_servers": [
+    "https://example.com/realms/pid-issuer-realm"
+  ],
   "credential_endpoint": "https://credential-issuer.example.com/credentials",
   "nonce_endpoint": "https://credential-issuer.example.com/nonce",
   "deferred_credential_endpoint": "https://credential-issuer.example.com/credentials/deferred",
   "notification_endpoint": "https://credential-issuer.example.com/notification",
   "credential_request_encryption": {
     "jwks": {
-        "keys": [
-          {
-            "kty": "EC",
-            "use": "enc",
-            "crv": "P-256",
-            "alg": "ECDH-ES",
-            "kid": "encKey-0",
-            "x": "TmcsNF6JpWjP85wKfBXKybHaJNowtp6jCuToppDosdw",
-            "y": "egzDuJuSxyypCE0qUoo1oKOnslpaw1Om-flQ4knafas",
-            "iat": 1755352588
-          }
-        ]
+      "keys": [
+        {
+          "kty": "EC",
+          "use": "enc",
+          "crv": "P-256",
+          "alg": "ECDH-ES",
+          "kid": "encKey-0",
+          "x": "TmcsNF6JpWjP85wKfBXKybHaJNowtp6jCuToppDosdw",
+          "y": "egzDuJuSxyypCE0qUoo1oKOnslpaw1Om-flQ4knafas",
+          "iat": 1755352588
+        }
+      ]
     },
     "enc_values_supported": [
       "XC20P",
@@ -127,7 +129,28 @@
           "proof_signing_alg_values_supported": [
             "RS256",
             "ES256"
-          ]
+          ],
+          "key_attestations_required": {
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
+          }
+        },
+        "attestation": {
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ],
+          "key_attestations_required": {
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
+          }
         }
       }
     },
@@ -161,7 +184,10 @@
         ],
         "claims": [
           {
-            "path": [ "org.iso.18013.5.1", "given_name" ],
+            "path": [
+              "org.iso.18013.5.1",
+              "given_name"
+            ],
             "display": [
               {
                 "name": "Given Name",
@@ -170,7 +196,10 @@
             ]
           },
           {
-            "path": [ "org.iso.18013.5.1", "family_name" ],
+            "path": [
+              "org.iso.18013.5.1",
+              "family_name"
+            ],
             "display": [
               {
                 "name": "Surname",
@@ -179,10 +208,16 @@
             ]
           },
           {
-            "path": [ "org.iso.18013.5.1", "birth_date" ]
+            "path": [
+              "org.iso.18013.5.1",
+              "birth_date"
+            ]
           },
           {
-            "path": [ "org.iso.18013.5.1.aamva", "organ_donor" ]
+            "path": [
+              "org.iso.18013.5.1.aamva",
+              "organ_donor"
+            ]
           }
         ]
       },
@@ -192,7 +227,27 @@
             "RS256",
             "ES256"
           ],
-          "key_attestations_required": {}
+          "key_attestations_required": {
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
+          }
+        },
+        "attestation": {
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ],
+          "key_attestations_required": {
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
+          }
         }
       }
     },
@@ -276,7 +331,25 @@
             "ES256"
           ],
           "key_attestations_required": {
-            "key_storage": ["iso_18045_high", "iso_18045_enhanced-basic"]
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
+          }
+        },
+        "attestation": {
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ],
+          "key_attestations_required": {
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
           }
         }
       }
@@ -361,8 +434,25 @@
             "ES256"
           ],
           "key_attestations_required": {
-            "key_storage": ["iso_18045_high", "iso_18045_enhanced-basic"],
-            "user_authentication": ["iso_18045_high", "iso_18045_enhanced-basic"]
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
+          }
+        },
+        "attestation": {
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ],
+          "key_attestations_required": {
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
           }
         }
       }

--- a/Sources/Resources/europa/credential_issuer_metadata_multiple_auth_servers.json
+++ b/Sources/Resources/europa/credential_issuer_metadata_multiple_auth_servers.json
@@ -29,7 +29,28 @@
           "proof_signing_alg_values_supported": [
             "RS256",
             "ES256"
-          ]
+          ],
+          "key_attestations_required": {
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
+          }
+        },
+        "attestation": {
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ],
+          "key_attestations_required": {
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
+          }
         }
       }
     }

--- a/Sources/Resources/europa/credential_issuer_metadata_no_asymmetric_algs.json
+++ b/Sources/Resources/europa/credential_issuer_metadata_no_asymmetric_algs.json
@@ -9,18 +9,18 @@
   "notification_endpoint": "https://credential-issuer.example.com/notification",
   "credential_request_encryption": {
     "jwks": {
-        "keys": [
-          {
-            "kty": "EC",
-            "use": "enc",
-            "crv": "P-256",
-            "alg": "ECDH-ES",
-            "kid": "encKey-0",
-            "x": "TmcsNF6JpWjP85wKfBXKybHaJNowtp6jCuToppDosdw",
-            "y": "egzDuJuSxyypCE0qUoo1oKOnslpaw1Om-flQ4knafas",
-            "iat": 1755352588
-          }
-        ]
+      "keys": [
+        {
+          "kty": "EC",
+          "use": "enc",
+          "crv": "P-256",
+          "alg": "ECDH-ES",
+          "kid": "encKey-0",
+          "x": "TmcsNF6JpWjP85wKfBXKybHaJNowtp6jCuToppDosdw",
+          "y": "egzDuJuSxyypCE0qUoo1oKOnslpaw1Om-flQ4knafas",
+          "iat": 1755352588
+        }
+      ]
     },
     "enc_values_supported": [
       "XC20P",
@@ -68,7 +68,28 @@
           "proof_signing_alg_values_supported": [
             "RS256",
             "ES256"
-          ]
+          ],
+          "key_attestations_required": {
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
+          }
+        },
+        "attestation": {
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ],
+          "key_attestations_required": {
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
+          }
         }
       },
       "credential_metadata": {
@@ -143,7 +164,28 @@
           "proof_signing_alg_values_supported": [
             "RS256",
             "ES256"
-          ]
+          ],
+          "key_attestations_required": {
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
+          }
+        },
+        "attestation": {
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ],
+          "key_attestations_required": {
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
+          }
         }
       },
       "credential_metadata": {
@@ -223,7 +265,28 @@
           "proof_signing_alg_values_supported": [
             "RS256",
             "ES256"
-          ]
+          ],
+          "key_attestations_required": {
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
+          }
+        },
+        "attestation": {
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ],
+          "key_attestations_required": {
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
+          }
         }
       },
       "credential_metadata": {
@@ -305,7 +368,28 @@
           "proof_signing_alg_values_supported": [
             "RS256",
             "ES256"
-          ]
+          ],
+          "key_attestations_required": {
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
+          }
+        },
+        "attestation": {
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ],
+          "key_attestations_required": {
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
+          }
         }
       },
       "credential_metadata": {

--- a/Sources/Resources/europa/credential_issuer_metadata_no_request_encryption.json
+++ b/Sources/Resources/europa/credential_issuer_metadata_no_request_encryption.json
@@ -51,7 +51,28 @@
           "proof_signing_alg_values_supported": [
             "RS256",
             "ES256"
-          ]
+          ],
+          "key_attestations_required": {
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
+          }
+        },
+        "attestation": {
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ],
+          "key_attestations_required": {
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
+          }
         }
       },
       "credential_metadata": {
@@ -139,7 +160,10 @@
         ],
         "claims": [
           {
-            "path": [ "org.iso.18013.5.1", "given_name" ],
+            "path": [
+              "org.iso.18013.5.1",
+              "given_name"
+            ],
             "display": [
               {
                 "name": "Given Name",
@@ -148,7 +172,10 @@
             ]
           },
           {
-            "path": [ "org.iso.18013.5.1", "family_name" ],
+            "path": [
+              "org.iso.18013.5.1",
+              "family_name"
+            ],
             "display": [
               {
                 "name": "Surname",
@@ -157,10 +184,16 @@
             ]
           },
           {
-            "path": [ "org.iso.18013.5.1", "birth_date" ]
+            "path": [
+              "org.iso.18013.5.1",
+              "birth_date"
+            ]
           },
           {
-            "path": [ "org.iso.18013.5.1.aamva", "organ_donor" ]
+            "path": [
+              "org.iso.18013.5.1.aamva",
+              "organ_donor"
+            ]
           }
         ]
       }
@@ -191,7 +224,25 @@
             "ES256"
           ],
           "key_attestations_required": {
-            "key_storage": ["iso_18045_high", "iso_18045_enhanced-basic"]
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
+          }
+        },
+        "attestation": {
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ],
+          "key_attestations_required": {
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
           }
         }
       },
@@ -276,8 +327,25 @@
             "ES256"
           ],
           "key_attestations_required": {
-            "key_storage": ["iso_18045_high", "iso_18045_enhanced-basic"],
-            "user_authentication": ["iso_18045_high", "iso_18045_enhanced-basic"]
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
+          }
+        },
+        "attestation": {
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ],
+          "key_attestations_required": {
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
           }
         }
       },

--- a/Sources/Resources/europa/credential_issuer_metadata_no_request_encryption_optional_response.json
+++ b/Sources/Resources/europa/credential_issuer_metadata_no_request_encryption_optional_response.json
@@ -51,7 +51,28 @@
           "proof_signing_alg_values_supported": [
             "RS256",
             "ES256"
-          ]
+          ],
+          "key_attestations_required": {
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
+          }
+        },
+        "attestation": {
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ],
+          "key_attestations_required": {
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
+          }
         }
       },
       "credential_metadata": {
@@ -139,7 +160,10 @@
         ],
         "claims": [
           {
-            "path": [ "org.iso.18013.5.1", "given_name" ],
+            "path": [
+              "org.iso.18013.5.1",
+              "given_name"
+            ],
             "display": [
               {
                 "name": "Given Name",
@@ -148,7 +172,10 @@
             ]
           },
           {
-            "path": [ "org.iso.18013.5.1", "family_name" ],
+            "path": [
+              "org.iso.18013.5.1",
+              "family_name"
+            ],
             "display": [
               {
                 "name": "Surname",
@@ -157,10 +184,16 @@
             ]
           },
           {
-            "path": [ "org.iso.18013.5.1", "birth_date" ]
+            "path": [
+              "org.iso.18013.5.1",
+              "birth_date"
+            ]
           },
           {
-            "path": [ "org.iso.18013.5.1.aamva", "organ_donor" ]
+            "path": [
+              "org.iso.18013.5.1.aamva",
+              "organ_donor"
+            ]
           }
         ]
       }
@@ -191,7 +224,25 @@
             "ES256"
           ],
           "key_attestations_required": {
-            "key_storage": ["iso_18045_high", "iso_18045_enhanced-basic"]
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
+          }
+        },
+        "attestation": {
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ],
+          "key_attestations_required": {
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
           }
         }
       },
@@ -276,8 +327,25 @@
             "ES256"
           ],
           "key_attestations_required": {
-            "key_storage": ["iso_18045_high", "iso_18045_enhanced-basic"],
-            "user_authentication": ["iso_18045_high", "iso_18045_enhanced-basic"]
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
+          }
+        },
+        "attestation": {
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ],
+          "key_attestations_required": {
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
           }
         }
       },
@@ -348,5 +416,3 @@
     }
   ]
 }
-
-

--- a/Sources/Resources/europa/credential_issuer_metadata_valid.json
+++ b/Sources/Resources/europa/credential_issuer_metadata_valid.json
@@ -9,18 +9,18 @@
   "notification_endpoint": "https://credential-issuer.example.com/notification",
   "credential_request_encryption": {
     "jwks": {
-        "keys": [
-          {
-            "kty": "EC",
-            "use": "enc",
-            "crv": "P-256",
-            "alg": "ECDH-ES",
-            "kid": "encKey-0",
-            "x": "TmcsNF6JpWjP85wKfBXKybHaJNowtp6jCuToppDosdw",
-            "y": "egzDuJuSxyypCE0qUoo1oKOnslpaw1Om-flQ4knafas",
-            "iat": 1755352588
-          }
-        ]
+      "keys": [
+        {
+          "kty": "EC",
+          "use": "enc",
+          "crv": "P-256",
+          "alg": "ECDH-ES",
+          "kid": "encKey-0",
+          "x": "TmcsNF6JpWjP85wKfBXKybHaJNowtp6jCuToppDosdw",
+          "y": "egzDuJuSxyypCE0qUoo1oKOnslpaw1Om-flQ4knafas",
+          "iat": 1755352588
+        }
+      ]
     },
     "enc_values_supported": [
       "XC20P",
@@ -75,7 +75,28 @@
           "proof_signing_alg_values_supported": [
             "RS256",
             "ES256"
-          ]
+          ],
+          "key_attestations_required": {
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
+          }
+        },
+        "attestation": {
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ],
+          "key_attestations_required": {
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
+          }
         }
       },
       "credential_metadata": {
@@ -163,7 +184,10 @@
         ],
         "claims": [
           {
-            "path": [ "org.iso.18013.5.1", "given_name" ],
+            "path": [
+              "org.iso.18013.5.1",
+              "given_name"
+            ],
             "display": [
               {
                 "name": "Given Name",
@@ -172,7 +196,10 @@
             ]
           },
           {
-            "path": [ "org.iso.18013.5.1", "family_name" ],
+            "path": [
+              "org.iso.18013.5.1",
+              "family_name"
+            ],
             "display": [
               {
                 "name": "Surname",
@@ -181,10 +208,16 @@
             ]
           },
           {
-            "path": [ "org.iso.18013.5.1", "birth_date" ]
+            "path": [
+              "org.iso.18013.5.1",
+              "birth_date"
+            ]
           },
           {
-            "path": [ "org.iso.18013.5.1.aamva", "organ_donor" ]
+            "path": [
+              "org.iso.18013.5.1.aamva",
+              "organ_donor"
+            ]
           }
         ]
       }
@@ -215,7 +248,25 @@
             "ES256"
           ],
           "key_attestations_required": {
-            "key_storage": ["iso_18045_high", "iso_18045_enhanced-basic"]
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
+          }
+        },
+        "attestation": {
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ],
+          "key_attestations_required": {
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
           }
         }
       },
@@ -300,8 +351,25 @@
             "ES256"
           ],
           "key_attestations_required": {
-            "key_storage": ["iso_18045_high", "iso_18045_enhanced-basic"],
-            "user_authentication": ["iso_18045_high", "iso_18045_enhanced-basic"]
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
+          }
+        },
+        "attestation": {
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ],
+          "key_attestations_required": {
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
           }
         }
       },

--- a/Sources/Resources/well-known/openid-credential-issuer_encrypted_responses.json
+++ b/Sources/Resources/well-known/openid-credential-issuer_encrypted_responses.json
@@ -36,13 +36,36 @@
           "proof_signing_alg_values_supported": [
             "RS256",
             "ES256"
-          ]
+          ],
+          "key_attestations_required": {
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
+          }
+        },
+        "attestation": {
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ],
+          "key_attestations_required": {
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
+          }
         }
       },
       "vct": "eu.europa.ec.eudiw.pid.1",
       "claims": [
         {
-          "path": [ "given_name" ],
+          "path": [
+            "given_name"
+          ],
           "display": [
             {
               "name": "Given Name",
@@ -51,7 +74,9 @@
           ]
         },
         {
-          "path": [ "family_name" ],
+          "path": [
+            "family_name"
+          ],
           "display": [
             {
               "name": "Surname",
@@ -60,7 +85,9 @@
           ]
         },
         {
-          "path": [ "birth_date" ]
+          "path": [
+            "birth_date"
+          ]
         }
       ],
       "display": [
@@ -91,7 +118,28 @@
           "proof_signing_alg_values_supported": [
             "RS256",
             "ES256"
-          ]
+          ],
+          "key_attestations_required": {
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
+          }
+        },
+        "attestation": {
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ],
+          "key_attestations_required": {
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
+          }
         }
       },
       "display": [
@@ -111,7 +159,10 @@
       ],
       "claims": [
         {
-          "path": [ "org.iso.18013.5.1", "given_name" ],
+          "path": [
+            "org.iso.18013.5.1",
+            "given_name"
+          ],
           "display": [
             {
               "name": "Given Name",
@@ -120,7 +171,10 @@
           ]
         },
         {
-          "path": [ "org.iso.18013.5.1", "family_name" ],
+          "path": [
+            "org.iso.18013.5.1",
+            "family_name"
+          ],
           "display": [
             {
               "name": "Surname",
@@ -129,10 +183,16 @@
           ]
         },
         {
-          "path": [ "org.iso.18013.5.1", "birth_date" ]
+          "path": [
+            "org.iso.18013.5.1",
+            "birth_date"
+          ]
         },
         {
-          "path": [ "org.iso.18013.5.1.aamva", "organ_donor" ]
+          "path": [
+            "org.iso.18013.5.1.aamva",
+            "organ_donor"
+          ]
         }
       ]
     },
@@ -151,7 +211,28 @@
           "proof_signing_alg_values_supported": [
             "RS256",
             "ES256"
-          ]
+          ],
+          "key_attestations_required": {
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
+          }
+        },
+        "attestation": {
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ],
+          "key_attestations_required": {
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
+          }
         }
       },
       "display": [
@@ -171,7 +252,10 @@
       ],
       "claims": [
         {
-          "path": [ "org.iso.18013.5.1", "given_name" ],
+          "path": [
+            "org.iso.18013.5.1",
+            "given_name"
+          ],
           "display": [
             {
               "name": "Given Name",
@@ -180,7 +264,10 @@
           ]
         },
         {
-          "path": [ "org.iso.18013.5.1", "family_name" ],
+          "path": [
+            "org.iso.18013.5.1",
+            "family_name"
+          ],
           "display": [
             {
               "name": "Surname",
@@ -189,10 +276,16 @@
           ]
         },
         {
-          "path": [ "org.iso.18013.5.1", "birth_date" ]
+          "path": [
+            "org.iso.18013.5.1",
+            "birth_date"
+          ]
         },
         {
-          "path": [ "org.iso.18013.5.1.aamva", "organ_donor" ]
+          "path": [
+            "org.iso.18013.5.1.aamva",
+            "organ_donor"
+          ]
         }
       ]
     },
@@ -216,7 +309,28 @@
           "proof_signing_alg_values_supported": [
             "RS256",
             "ES256"
-          ]
+          ],
+          "key_attestations_required": {
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
+          }
+        },
+        "attestation": {
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ],
+          "key_attestations_required": {
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
+          }
         }
       },
       "display": [
@@ -233,7 +347,9 @@
       ],
       "claims": [
         {
-          "path": [ "given_name" ],
+          "path": [
+            "given_name"
+          ],
           "display": [
             {
               "name": "Given Name",
@@ -242,7 +358,9 @@
           ]
         },
         {
-          "path": [ "family_name" ],
+          "path": [
+            "family_name"
+          ],
           "display": [
             {
               "name": "Surname",
@@ -251,10 +369,14 @@
           ]
         },
         {
-          "path": [ "degree" ]
+          "path": [
+            "degree"
+          ]
         },
         {
-          "path": [ "gpa" ],
+          "path": [
+            "gpa"
+          ],
           "display": [
             {
               "name": "name",
@@ -293,7 +415,10 @@
       ],
       "claims": [
         {
-          "path": [ "org.iso.18013.5.1", "given_name" ],
+          "path": [
+            "org.iso.18013.5.1",
+            "given_name"
+          ],
           "display": [
             {
               "name": "Given Name",
@@ -302,7 +427,10 @@
           ]
         },
         {
-          "path": [ "org.iso.18013.5.1", "family_name" ],
+          "path": [
+            "org.iso.18013.5.1",
+            "family_name"
+          ],
           "display": [
             {
               "name": "Surname",
@@ -311,10 +439,16 @@
           ]
         },
         {
-          "path": [ "org.iso.18013.5.1", "birth_date" ]
+          "path": [
+            "org.iso.18013.5.1",
+            "birth_date"
+          ]
         },
         {
-          "path": [ "org.iso.18013.5.1.aamva", "organ_donor" ]
+          "path": [
+            "org.iso.18013.5.1.aamva",
+            "organ_donor"
+          ]
         }
       ]
     }

--- a/Sources/Resources/well-known/openid-credential-issuer_key_attestation_required.json
+++ b/Sources/Resources/well-known/openid-credential-issuer_key_attestation_required.json
@@ -9,18 +9,18 @@
   "notification_endpoint": "https://credential-issuer.example.com/notification",
   "credential_request_encryption": {
     "jwks": {
-        "keys": [
-          {
-            "kty": "EC",
-            "use": "enc",
-            "crv": "P-256",
-            "alg": "ECDH-ES",
-            "kid": "encKey-0",
-            "x": "TmcsNF6JpWjP85wKfBXKybHaJNowtp6jCuToppDosdw",
-            "y": "egzDuJuSxyypCE0qUoo1oKOnslpaw1Om-flQ4knafas",
-            "iat": 1755352588
-          }
-        ]
+      "keys": [
+        {
+          "kty": "EC",
+          "use": "enc",
+          "crv": "P-256",
+          "alg": "ECDH-ES",
+          "kid": "encKey-0",
+          "x": "TmcsNF6JpWjP85wKfBXKybHaJNowtp6jCuToppDosdw",
+          "y": "egzDuJuSxyypCE0qUoo1oKOnslpaw1Om-flQ4knafas",
+          "iat": 1755352588
+        }
+      ]
     },
     "enc_values_supported": [
       "XC20P",
@@ -65,10 +65,23 @@
           ],
           "key_attestations_required": {
             "key_storage": [
-              "iso_18045_moderate"
+              "iso_18045_high"
             ],
             "user_authentication": [
-              "iso_18045_moderate"
+              "iso_18045_high"
+            ]
+          }
+        },
+        "attestation": {
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ],
+          "key_attestations_required": {
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
             ]
           }
         }
@@ -131,7 +144,28 @@
           "proof_signing_alg_values_supported": [
             "RS256",
             "ES256"
-          ]
+          ],
+          "key_attestations_required": {
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
+          }
+        },
+        "attestation": {
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ],
+          "key_attestations_required": {
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
+          }
         }
       },
       "display": [
@@ -203,7 +237,28 @@
           "proof_signing_alg_values_supported": [
             "RS256",
             "ES256"
-          ]
+          ],
+          "key_attestations_required": {
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
+          }
+        },
+        "attestation": {
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ],
+          "key_attestations_required": {
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
+          }
         }
       },
       "display": [
@@ -280,7 +335,28 @@
           "proof_signing_alg_values_supported": [
             "RS256",
             "ES256"
-          ]
+          ],
+          "key_attestations_required": {
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
+          }
+        },
+        "attestation": {
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ],
+          "key_attestations_required": {
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
+          }
         }
       },
       "display": [

--- a/Sources/Resources/well-known/openid-credential-issuer_no_encryption.json
+++ b/Sources/Resources/well-known/openid-credential-issuer_no_encryption.json
@@ -1,6 +1,8 @@
 {
   "credential_issuer": "https://credential-issuer.example.com",
-  "authorization_servers": ["https://auth-server.example.com"],
+  "authorization_servers": [
+    "https://auth-server.example.com"
+  ],
   "credential_endpoint": "https://credential-issuer.example.com/credentials",
   "deferred_credential_endpoint": "https://credential-issuer.example.com/credentials/deferred",
   "notification_endpoint": "https://credential-issuer.example.com/notification",
@@ -24,7 +26,28 @@
           "proof_signing_alg_values_supported": [
             "RS256",
             "ES256"
-          ]
+          ],
+          "key_attestations_required": {
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
+          }
+        },
+        "attestation": {
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ],
+          "key_attestations_required": {
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
+          }
         }
       },
       "credential_definition": {
@@ -107,7 +130,10 @@
       ],
       "claims": [
         {
-          "path": [ "org.iso.18013.5.1", "given_name" ],
+          "path": [
+            "org.iso.18013.5.1",
+            "given_name"
+          ],
           "display": [
             {
               "name": "Given Name",
@@ -116,7 +142,10 @@
           ]
         },
         {
-          "path": [ "org.iso.18013.5.1", "family_name" ],
+          "path": [
+            "org.iso.18013.5.1",
+            "family_name"
+          ],
           "display": [
             {
               "name": "Surname",
@@ -125,10 +154,16 @@
           ]
         },
         {
-          "path": [ "org.iso.18013.5.1", "birth_date" ]
+          "path": [
+            "org.iso.18013.5.1",
+            "birth_date"
+          ]
         },
         {
-          "path": [ "org.iso.18013.5.1.aamva", "organ_donor" ]
+          "path": [
+            "org.iso.18013.5.1.aamva",
+            "organ_donor"
+          ]
         }
       ]
     },
@@ -156,7 +191,10 @@
       ],
       "claims": [
         {
-          "path": [ "org.iso.18013.5.1", "given_name" ],
+          "path": [
+            "org.iso.18013.5.1",
+            "given_name"
+          ],
           "display": [
             {
               "name": "Given Name",
@@ -165,7 +203,10 @@
           ]
         },
         {
-          "path": [ "org.iso.18013.5.1", "family_name" ],
+          "path": [
+            "org.iso.18013.5.1",
+            "family_name"
+          ],
           "display": [
             {
               "name": "Surname",
@@ -174,10 +215,16 @@
           ]
         },
         {
-          "path": [ "org.iso.18013.5.1", "birth_date" ]
+          "path": [
+            "org.iso.18013.5.1",
+            "birth_date"
+          ]
         },
         {
-          "path": [ "org.iso.18013.5.1.aamva", "organ_donor" ]
+          "path": [
+            "org.iso.18013.5.1.aamva",
+            "organ_donor"
+          ]
         }
       ]
     }

--- a/Sources/Resources/well-known/openid-credential-issuer_no_encryption_batch.json
+++ b/Sources/Resources/well-known/openid-credential-issuer_no_encryption_batch.json
@@ -1,6 +1,8 @@
 {
   "credential_issuer": "https://credential-issuer.example.com",
-  "authorization_servers": ["https://auth-server.example.com"],
+  "authorization_servers": [
+    "https://auth-server.example.com"
+  ],
   "credential_endpoint": "https://credential-issuer.example.com/credentials",
   "deferred_credential_endpoint": "https://credential-issuer.example.com/credentials/deferred",
   "notification_endpoint": "https://credential-issuer.example.com/notification",
@@ -27,7 +29,28 @@
           "proof_signing_alg_values_supported": [
             "RS256",
             "ES256"
-          ]
+          ],
+          "key_attestations_required": {
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
+          }
+        },
+        "attestation": {
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ],
+          "key_attestations_required": {
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
+          }
         }
       },
       "credential_definition": {
@@ -89,7 +112,10 @@
       ],
       "claims": [
         {
-          "path": [ "org.iso.18013.5.1", "given_name" ],
+          "path": [
+            "org.iso.18013.5.1",
+            "given_name"
+          ],
           "display": [
             {
               "name": "Given Name",
@@ -98,7 +124,10 @@
           ]
         },
         {
-          "path": [ "org.iso.18013.5.1", "family_name" ],
+          "path": [
+            "org.iso.18013.5.1",
+            "family_name"
+          ],
           "display": [
             {
               "name": "Surname",
@@ -107,10 +136,16 @@
           ]
         },
         {
-          "path": [ "org.iso.18013.5.1", "birth_date" ]
+          "path": [
+            "org.iso.18013.5.1",
+            "birth_date"
+          ]
         },
         {
-          "path": [ "org.iso.18013.5.1.aamva", "organ_donor" ]
+          "path": [
+            "org.iso.18013.5.1.aamva",
+            "organ_donor"
+          ]
         }
       ]
     },
@@ -138,7 +173,10 @@
       ],
       "claims": [
         {
-          "path": [ "org.iso.18013.5.1", "given_name" ],
+          "path": [
+            "org.iso.18013.5.1",
+            "given_name"
+          ],
           "display": [
             {
               "name": "Given Name",
@@ -147,7 +185,10 @@
           ]
         },
         {
-          "path": [ "org.iso.18013.5.1", "family_name" ],
+          "path": [
+            "org.iso.18013.5.1",
+            "family_name"
+          ],
           "display": [
             {
               "name": "Surname",
@@ -156,10 +197,16 @@
           ]
         },
         {
-          "path": [ "org.iso.18013.5.1", "birth_date" ]
+          "path": [
+            "org.iso.18013.5.1",
+            "birth_date"
+          ]
         },
         {
-          "path": [ "org.iso.18013.5.1.aamva", "organ_donor" ]
+          "path": [
+            "org.iso.18013.5.1.aamva",
+            "organ_donor"
+          ]
         }
       ]
     },
@@ -187,7 +234,10 @@
       ],
       "claims": [
         {
-          "path": [ "org.iso.18013.5.1", "given_name" ],
+          "path": [
+            "org.iso.18013.5.1",
+            "given_name"
+          ],
           "display": [
             {
               "name": "Given Name",
@@ -196,7 +246,10 @@
           ]
         },
         {
-          "path": [ "org.iso.18013.5.1", "family_name" ],
+          "path": [
+            "org.iso.18013.5.1",
+            "family_name"
+          ],
           "display": [
             {
               "name": "Surname",
@@ -205,10 +258,16 @@
           ]
         },
         {
-          "path": [ "org.iso.18013.5.1", "birth_date" ]
+          "path": [
+            "org.iso.18013.5.1",
+            "birth_date"
+          ]
         },
         {
-          "path": [ "org.iso.18013.5.1.aamva", "organ_donor" ]
+          "path": [
+            "org.iso.18013.5.1.aamva",
+            "organ_donor"
+          ]
         }
       ]
     }

--- a/Tests/Entities/ProofTypesPolicyTests.swift
+++ b/Tests/Entities/ProofTypesPolicyTests.swift
@@ -20,379 +20,204 @@ import JOSESwift
 
 final class ProofTypesPolicyTests: XCTestCase {
 
-  // MARK: - Policy Creation Tests
+  // MARK: - Construction
 
-  func testAcceptAllPolicy() throws {
-    let policy = ProofTypesPolicy.acceptAll
-
-    // Create a test credential configuration that requires JWT without key attestation
-    let proofTypesSupported: [String: ProofTypeSupportedMeta] = [
-      "jwt": ProofTypeSupportedMeta(
-        algorithms: ["ES256"],
-        keyAttestationRequirement: .notRequired
-      )
-    ]
-    let credentialConfig = createTestCredentialConfiguration(proofTypesSupported: proofTypesSupported)
-
-    // Create a plain JWT binding key
-    let bindingKey = try createJwtBindingKey()
-
-    // Should not throw with acceptAll policy
-    XCTAssertNoThrow(try policy.validate(
-      credentialConfiguration: credentialConfig,
-      bindingKey: bindingKey
-    ))
-  }
-
-  func testHaipCompliantPolicy() throws {
-    let policy = DeviceBoundProofPolicy.haipCompliant()
+  func testHaipCompliantPolicy() {
+    let policy = ProofTypesPolicy.haipCompliant()
 
     XCTAssertEqual(policy.supportedAlgorithms.count, 1)
     XCTAssertEqual(policy.supportedAlgorithms.first?.name, "ES256")
-    XCTAssertTrue(policy.supportedProofTypes.contains(.jwtWithKeyAttestation))
-    XCTAssertTrue(policy.supportedProofTypes.contains(.attestation))
-    XCTAssertEqual(policy.supportedProofTypes.count, 2)
+    XCTAssertEqual(policy.supportedProofTypes, [.jwtWithKeyAttestation, .attestation])
   }
 
-  func testDeviceBoundPolicyCreation() throws {
-    let policy = DeviceBoundProofPolicy(
-      supportedAlgorithms: [JWSAlgorithm(.ES256), JWSAlgorithm(.ES384)],
-      supportedProofTypes: [.jwtWithKeyAttestation, .attestation]
-    )
+  // MARK: - validateIssuerMetadata: no-proof case
 
-    XCTAssertEqual(policy.supportedAlgorithms.count, 2)
-    XCTAssertTrue(policy.supportedAlgorithms.contains(where: { $0.name == "ES256" }))
-    XCTAssertTrue(policy.supportedAlgorithms.contains(where: { $0.name == "ES384" }))
-    XCTAssertEqual(policy.supportedProofTypes.count, 2)
+  func testAcceptsMissingProofTypesSupported() {
+    let config = makeConfig(proofTypesSupported: nil)
+
+    XCTAssertNoThrow(try ProofTypesPolicy.haipCompliant().validateIssuerMetadata(
+      credentialConfiguration: config
+    ))
   }
 
-  // MARK: - Validation Tests - JWT Without Key Attestation
+  func testAcceptsEmptyProofTypesSupported() {
+    let config = makeConfig(proofTypesSupported: [:])
 
-  func testDeviceBoundPolicy_RejectsJwtWithoutKeyAttestation() throws {
-    let deviceBoundPolicy = DeviceBoundProofPolicy(
-      supportedAlgorithms: [JWSAlgorithm(.ES256)],
-      supportedProofTypes: [.jwtWithKeyAttestation, .attestation]
+    XCTAssertNoThrow(try ProofTypesPolicy.haipCompliant().validateIssuerMetadata(
+      credentialConfiguration: config
+    ))
+  }
+
+  // MARK: - validateIssuerMetadata: accept paths
+
+  func testAcceptsJwtAndAttestationBothWithKeyAttestation() {
+    let config = makeConfig(proofTypesSupported: [
+      "jwt": ProofTypeSupportedMeta(
+        algorithms: ["ES256"],
+        keyAttestationRequirement: .requiredNoConstraints
+      ),
+      "attestation": ProofTypeSupportedMeta(
+        algorithms: ["ES256"],
+        keyAttestationRequirement: .requiredNoConstraints
+      )
+    ])
+
+    XCTAssertNoThrow(try ProofTypesPolicy.haipCompliant().validateIssuerMetadata(
+      credentialConfiguration: config
+    ))
+  }
+
+  // MARK: - validateIssuerMetadata: reject paths (metadata error)
+
+  func testRejectsJwtOnly() {
+    let config = makeConfig(proofTypesSupported: [
+      "jwt": ProofTypeSupportedMeta(
+        algorithms: ["ES256"],
+        keyAttestationRequirement: .requiredNoConstraints
+      )
+    ])
+
+    expectError(
+      .issuerMetadataNoAttestedProofType,
+      try ProofTypesPolicy.haipCompliant().validateIssuerMetadata(credentialConfiguration: config)
     )
-    let policy = ProofTypesPolicy.deviceBound(deviceBoundPolicy)
+  }
 
-    // Credential requires JWT without key attestation
-    let proofTypesSupported: [String: ProofTypeSupportedMeta] = [
+  func testRejectsAttestationOnly() {
+    let config = makeConfig(proofTypesSupported: [
+      "attestation": ProofTypeSupportedMeta(
+        algorithms: ["ES256"],
+        keyAttestationRequirement: .requiredNoConstraints
+      )
+    ])
+
+    expectError(
+      .issuerMetadataNoAttestedProofType,
+      try ProofTypesPolicy.haipCompliant().validateIssuerMetadata(credentialConfiguration: config)
+    )
+  }
+
+  func testRejectsJwtWithoutKeyAttestation() {
+    let config = makeConfig(proofTypesSupported: [
       "jwt": ProofTypeSupportedMeta(
         algorithms: ["ES256"],
         keyAttestationRequirement: .notRequired
+      ),
+      "attestation": ProofTypeSupportedMeta(
+        algorithms: ["ES256"],
+        keyAttestationRequirement: .requiredNoConstraints
       )
-    ]
-    let credentialConfig = createTestCredentialConfiguration(proofTypesSupported: proofTypesSupported)
-    let bindingKey = try createJwtBindingKey()
+    ])
 
-    // Should throw because policy doesn't support JWT without key attestation
-    XCTAssertThrowsError(try policy.validate(
-      credentialConfiguration: credentialConfig,
-      bindingKey: bindingKey
-    )) { error in
-      guard let issuanceError = error as? CredentialIssuanceError else {
-        XCTFail("Expected CredentialIssuanceError")
-        return
-      }
-      if case .proofTypeJwtWithoutKeyAttestationNotAllowedByPolicy = issuanceError {
-        // Expected error
-      } else {
-        XCTFail("Expected proofTypeJwtWithoutKeyAttestationNotAllowedByPolicy error")
-      }
-    }
+    expectError(
+      .issuerMetadataNoAttestedProofType,
+      try ProofTypesPolicy.haipCompliant().validateIssuerMetadata(credentialConfiguration: config)
+    )
   }
 
-  func testAcceptAllPolicy_AcceptsJwtWithoutKeyAttestation() throws {
-    let policy = ProofTypesPolicy.acceptAll
-
-    // Credential requires JWT without key attestation
-    let proofTypesSupported: [String: ProofTypeSupportedMeta] = [
+  func testRejectsAttestationWithoutKeyAttestation() {
+    let config = makeConfig(proofTypesSupported: [
       "jwt": ProofTypeSupportedMeta(
+        algorithms: ["ES256"],
+        keyAttestationRequirement: .requiredNoConstraints
+      ),
+      "attestation": ProofTypeSupportedMeta(
         algorithms: ["ES256"],
         keyAttestationRequirement: .notRequired
       )
-    ]
-    let credentialConfig = createTestCredentialConfiguration(proofTypesSupported: proofTypesSupported)
-    let bindingKey = try createJwtBindingKey()
+    ])
 
-    // Should not throw with acceptAll policy
-    XCTAssertNoThrow(try policy.validate(
-      credentialConfiguration: credentialConfig,
-      bindingKey: bindingKey
-    ))
+    expectError(
+      .issuerMetadataNoAttestedProofType,
+      try ProofTypesPolicy.haipCompliant().validateIssuerMetadata(credentialConfiguration: config)
+    )
   }
 
-  // MARK: - Validation Tests - JWT With Key Attestation
+  func testRejectsUnknownProofTypeOnly() {
+    let config = makeConfig(proofTypesSupported: [
+      "ldp_vc": ProofTypeSupportedMeta(algorithms: ["ES256"])
+    ])
 
-  func testDeviceBoundPolicy_AcceptsJwtWithKeyAttestation() throws {
-    let deviceBoundPolicy = DeviceBoundProofPolicy(
-      supportedAlgorithms: [JWSAlgorithm(.ES256)],
-      supportedProofTypes: [.jwtWithKeyAttestation]
+    expectError(
+      .issuerMetadataNoAttestedProofType,
+      try ProofTypesPolicy.haipCompliant().validateIssuerMetadata(credentialConfiguration: config)
     )
-    let policy = ProofTypesPolicy.deviceBound(deviceBoundPolicy)
+  }
 
-    // Credential requires JWT with key attestation
-    let proofTypesSupported: [String: ProofTypeSupportedMeta] = [
+  // MARK: - validateIssuerMetadata: wallet policy restrictions
+
+  func testRejectsWhenWalletSupportsNeitherAdvertisedType() {
+    let policy = ProofTypesPolicy(
+      supportedAlgorithms: [JWSAlgorithm(.ES256)],
+      supportedProofTypes: []
+    )
+    let config = makeConfig(proofTypesSupported: [
       "jwt": ProofTypeSupportedMeta(
         algorithms: ["ES256"],
-        keyAttestationRequirement: .required(
-          keyStorageConstraints: [.iso18045High],
-          userAuthenticationConstraints: [.iso18045Moderate],
-          preferredKeyStorageStatusPeriod: nil
-        )
-      )
-    ]
-    let credentialConfig = createTestCredentialConfiguration(proofTypesSupported: proofTypesSupported)
-    let bindingKey = try createJwtKeyAttestationBindingKey()
-
-    // Should not throw
-    XCTAssertNoThrow(try policy.validate(
-      credentialConfiguration: credentialConfig,
-      bindingKey: bindingKey
-    ))
-  }
-
-  func testDeviceBoundPolicy_RejectsJwtWithKeyAttestation_WhenNotInSupportedProofTypes() throws {
-    let deviceBoundPolicy = DeviceBoundProofPolicy(
-      supportedAlgorithms: [JWSAlgorithm(.ES256)],
-      supportedProofTypes: [.attestation] // Only attestation, not JWT with key attestation
-    )
-    let policy = ProofTypesPolicy.deviceBound(deviceBoundPolicy)
-
-    // Credential requires JWT with key attestation
-    let proofTypesSupported: [String: ProofTypeSupportedMeta] = [
-      "jwt": ProofTypeSupportedMeta(
-        algorithms: ["ES256"],
-        keyAttestationRequirement: .required(
-          keyStorageConstraints: [.iso18045High],
-          userAuthenticationConstraints: [.iso18045Moderate],
-          preferredKeyStorageStatusPeriod: nil
-        )
-      )
-    ]
-    let credentialConfig = createTestCredentialConfiguration(proofTypesSupported: proofTypesSupported)
-    let bindingKey = try createJwtKeyAttestationBindingKey()
-
-    // Should throw because policy doesn't support JWT with key attestation
-    XCTAssertThrowsError(try policy.validate(
-      credentialConfiguration: credentialConfig,
-      bindingKey: bindingKey
-    )) { error in
-      guard let issuanceError = error as? CredentialIssuanceError else {
-        XCTFail("Expected CredentialIssuanceError")
-        return
-      }
-      if case .proofTypeNotSupportedByWalletPolicy = issuanceError {
-        // Expected error
-      } else {
-        XCTFail("Expected proofTypeNotSupportedByWalletPolicy error")
-      }
-    }
-  }
-
-  func testDeviceBoundPolicy_RejectsJwtWithKeyAttestation_WhenBindingKeyNotAttestationCapable() throws {
-    let deviceBoundPolicy = DeviceBoundProofPolicy(
-      supportedAlgorithms: [JWSAlgorithm(.ES256)],
-      supportedProofTypes: [.jwtWithKeyAttestation]
-    )
-    let policy = ProofTypesPolicy.deviceBound(deviceBoundPolicy)
-
-    // Credential requires JWT with key attestation
-    let proofTypesSupported: [String: ProofTypeSupportedMeta] = [
-      "jwt": ProofTypeSupportedMeta(
-        algorithms: ["ES256"],
-        keyAttestationRequirement: .required(
-          keyStorageConstraints: [.iso18045High],
-          userAuthenticationConstraints: [.iso18045Moderate],
-          preferredKeyStorageStatusPeriod: nil
-        )
-      )
-    ]
-    let credentialConfig = createTestCredentialConfiguration(proofTypesSupported: proofTypesSupported)
-    // Use a plain JWT binding key (not attestation-capable)
-    let bindingKey = try createJwtBindingKey()
-
-    // Should throw because binding key is not attestation-capable
-    XCTAssertThrowsError(try policy.validate(
-      credentialConfiguration: credentialConfig,
-      bindingKey: bindingKey
-    )) { error in
-      guard let issuanceError = error as? CredentialIssuanceError else {
-        XCTFail("Expected CredentialIssuanceError")
-        return
-      }
-      if case .bindingKeyNotAttestationCapable = issuanceError {
-        // Expected error
-      } else {
-        XCTFail("Expected bindingKeyNotAttestationCapable error")
-      }
-    }
-  }
-
-  // MARK: - Validation Tests - Attestation Proof Type
-
-  func testDeviceBoundPolicy_AcceptsAttestationProof() throws {
-    let deviceBoundPolicy = DeviceBoundProofPolicy(
-      supportedAlgorithms: [JWSAlgorithm(.ES256)],
-      supportedProofTypes: [.attestation]
-    )
-    let policy = ProofTypesPolicy.deviceBound(deviceBoundPolicy)
-
-    // Credential requires attestation proof
-    let proofTypesSupported: [String: ProofTypeSupportedMeta] = [
+        keyAttestationRequirement: .requiredNoConstraints
+      ),
       "attestation": ProofTypeSupportedMeta(
         algorithms: ["ES256"],
-        keyAttestationRequirement: nil
+        keyAttestationRequirement: .requiredNoConstraints
       )
-    ]
-    let credentialConfig = createTestCredentialConfiguration(proofTypesSupported: proofTypesSupported)
-    let bindingKey = try createAttestationBindingKey()
+    ])
 
-    // Should not throw
-    XCTAssertNoThrow(try policy.validate(
-      credentialConfiguration: credentialConfig,
-      bindingKey: bindingKey
-    ))
+    expectError(
+      .proofTypeNotSupportedByWalletPolicy,
+      try policy.validateIssuerMetadata(credentialConfiguration: config)
+    )
   }
 
-  func testDeviceBoundPolicy_RejectsAttestationProof_WhenNotInSupportedProofTypes() throws {
-    let deviceBoundPolicy = DeviceBoundProofPolicy(
-      supportedAlgorithms: [JWSAlgorithm(.ES256)],
-      supportedProofTypes: [.jwtWithKeyAttestation] // Only JWT with key attestation
-    )
-    let policy = ProofTypesPolicy.deviceBound(deviceBoundPolicy)
+  func testRejectsAlgorithmMismatch() {
+    let config = makeConfig(proofTypesSupported: [
+      "jwt": ProofTypeSupportedMeta(
+        algorithms: ["RS256"],
+        keyAttestationRequirement: .requiredNoConstraints
+      ),
+      "attestation": ProofTypeSupportedMeta(
+        algorithms: ["RS256"],
+        keyAttestationRequirement: .requiredNoConstraints
+      )
+    ])
 
-    // Credential requires attestation proof
-    let proofTypesSupported: [String: ProofTypeSupportedMeta] = [
+    expectError(
+      .noMatchingAlgorithmForProofType,
+      try ProofTypesPolicy.haipCompliant().validateIssuerMetadata(credentialConfiguration: config)
+    )
+  }
+
+  // MARK: - validate(bindingKey:)
+
+  func testValidateRejectsNonAttestationCapableBindingKey() {
+    let config = makeConfig(proofTypesSupported: [
+      "jwt": ProofTypeSupportedMeta(
+        algorithms: ["ES256"],
+        keyAttestationRequirement: .requiredNoConstraints
+      ),
       "attestation": ProofTypeSupportedMeta(
         algorithms: ["ES256"],
-        keyAttestationRequirement: nil
+        keyAttestationRequirement: .requiredNoConstraints
       )
-    ]
-    let credentialConfig = createTestCredentialConfiguration(proofTypesSupported: proofTypesSupported)
-    let bindingKey = try createAttestationBindingKey()
+    ])
 
-    // Should throw because policy doesn't support attestation proofs
-    XCTAssertThrowsError(try policy.validate(
-      credentialConfiguration: credentialConfig,
-      bindingKey: bindingKey
-    )) { error in
-      guard let issuanceError = error as? CredentialIssuanceError else {
-        XCTFail("Expected CredentialIssuanceError")
-        return
-      }
-      if case .proofTypeNotSupportedByWalletPolicy = issuanceError {
-        // Expected error
-      } else {
-        XCTFail("Expected proofTypeNotSupportedByWalletPolicy error")
-      }
-    }
-  }
-
-  // MARK: - Algorithm Matching Tests
-
-  func testDeviceBoundPolicy_RejectsWhenNoMatchingAlgorithm() throws {
-    let deviceBoundPolicy = DeviceBoundProofPolicy(
-      supportedAlgorithms: [JWSAlgorithm(.ES384)], // Only ES384
-      supportedProofTypes: [.jwtWithKeyAttestation]
-    )
-    let policy = ProofTypesPolicy.deviceBound(deviceBoundPolicy)
-
-    // Credential requires ES256
-    let proofTypesSupported: [String: ProofTypeSupportedMeta] = [
-      "jwt": ProofTypeSupportedMeta(
-        algorithms: ["ES256"], // Different algorithm
-        keyAttestationRequirement: .required(
-          keyStorageConstraints: [.iso18045High],
-          userAuthenticationConstraints: [.iso18045Moderate],
-          preferredKeyStorageStatusPeriod: nil
-        )
+    expectError(
+      .bindingKeyNotAttestationCapable,
+      try ProofTypesPolicy.haipCompliant().validate(
+        credentialConfiguration: config,
+        bindingKey: .did(identity: "did:example:123")
       )
-    ]
-    let credentialConfig = createTestCredentialConfiguration(proofTypesSupported: proofTypesSupported)
-    let bindingKey = try createJwtKeyAttestationBindingKey()
-
-    // Should throw because no matching algorithm
-    XCTAssertThrowsError(try policy.validate(
-      credentialConfiguration: credentialConfig,
-      bindingKey: bindingKey
-    )) { error in
-      guard let issuanceError = error as? CredentialIssuanceError else {
-        XCTFail("Expected CredentialIssuanceError")
-        return
-      }
-      if case .noMatchingAlgorithmForProofType = issuanceError {
-        // Expected error
-      } else {
-        XCTFail("Expected noMatchingAlgorithmForProofType error")
-      }
-    }
+    )
   }
 
-  // MARK: - Flexible Policy Tests
+  // MARK: - Helpers
 
-  func testFlexiblePolicy_AllowsNonDeviceBound() throws {
-    let deviceBoundPolicy = DeviceBoundProofPolicy(
-      supportedAlgorithms: [JWSAlgorithm(.ES256)],
-      supportedProofTypes: [.jwtWithKeyAttestation]
-    )
-    let policy = ProofTypesPolicy.flexible(
-      deviceBound: deviceBoundPolicy,
-      allowNonDeviceBound: true
-    )
-
-    // Credential without proof types (non-device-bound)
-    let credentialConfig = createTestCredentialConfiguration(proofTypesSupported: nil)
-    let bindingKey = try createJwtBindingKey()
-
-    // Should not throw because non-device-bound is allowed
-    XCTAssertNoThrow(try policy.validate(
-      credentialConfiguration: credentialConfig,
-      bindingKey: bindingKey
-    ))
-  }
-
-  func testFlexiblePolicy_RejectsNonDeviceBound_WhenNotAllowed() throws {
-    let deviceBoundPolicy = DeviceBoundProofPolicy(
-      supportedAlgorithms: [JWSAlgorithm(.ES256)],
-      supportedProofTypes: [.jwtWithKeyAttestation]
-    )
-    let policy = ProofTypesPolicy.flexible(
-      deviceBound: deviceBoundPolicy,
-      allowNonDeviceBound: false
-    )
-
-    // Credential without proof types (non-device-bound)
-    let credentialConfig = createTestCredentialConfiguration(proofTypesSupported: nil)
-    let bindingKey = try createJwtBindingKey()
-
-    // Should throw because non-device-bound is not allowed
-    XCTAssertThrowsError(try policy.validate(
-      credentialConfiguration: credentialConfig,
-      bindingKey: bindingKey
-    )) { error in
-      guard let issuanceError = error as? CredentialIssuanceError else {
-        XCTFail("Expected CredentialIssuanceError")
-        return
-      }
-      if case .proofTypesNotSupportedByCredentialConfiguration = issuanceError {
-        // Expected error
-      } else {
-        XCTFail("Expected proofTypesNotSupportedByCredentialConfiguration error")
-      }
-    }
-  }
-
-  // MARK: - Helper Methods
-
-  private func createTestCredentialConfiguration(
+  private func makeConfig(
     proofTypesSupported: [String: ProofTypeSupportedMeta]?
   ) -> CredentialSupported {
-    let credentialDefinition = SdJwtVcFormat.CredentialDefinition(
+    let definition = SdJwtVcFormat.CredentialDefinition(
       type: "VerifiableCredential",
       claims: []
     )
-
     let config = SdJwtVcFormat.CredentialConfiguration(
       scope: nil,
       vct: "test_vct",
@@ -400,62 +225,29 @@ final class ProofTypesPolicyTests: XCTestCase {
       credentialSigningAlgValuesSupported: [],
       proofTypesSupported: proofTypesSupported,
       credentialMetadata: nil,
-      credentialDefinition: credentialDefinition
+      credentialDefinition: definition
     )
     return .sdJwtVc(config)
   }
 
-  private func createJwtBindingKey() throws -> BindingKey {
-    let privateKey = try KeyController.generateECDHPrivateKey()
-    let publicKey = try KeyController.generateECDHPublicKey(from: privateKey)
-    let jwk = try ECPublicKey(
-      publicKey: publicKey,
-      additionalParameters: [
-        "use": "sig",
-        "kid": "test-key-1",
-        "alg": JWSAlgorithm(.ES256).name
-      ]
-    )
-
-    return .jwt(
-      algorithm: JWSAlgorithm(.ES256),
-      jwk: jwk,
-      privateKey: .secKey(privateKey),
-      issuer: nil
-    )
-  }
-
-  private func createJwtKeyAttestationBindingKey() throws -> BindingKey {
-    let privateKey = try KeyController.generateECDHPrivateKey()
-
-    // Mock compact JWS string for testing
-    let mockJWSString = "eyJhbGciOiJFUzI1NiIsInR5cCI6ImtleS1hdHRlc3RhdGlvbitqd3QifQ.eyJ0ZXN0IjoiZGF0YSJ9.mock_signature"
-
-    return .jwtKeyAttestation(
-      algorithm: JWSAlgorithm(.ES256),
-      keyAttestationJWT: { _ in
-        // Mock key attestation JWT using compact serialization
-        try KeyAttestationJWT(
-          jws: JWS(compactSerialization: mockJWSString)
-        )
-      },
-      keyIndex: 0,
-      privateKey: .secKey(privateKey),
-      issuer: nil
-    )
-  }
-
-  private func createAttestationBindingKey() throws -> BindingKey {
-    // Mock compact JWS string for testing
-    let mockJWSString = "eyJhbGciOiJFUzI1NiIsInR5cCI6ImtleS1hdHRlc3RhdGlvbitqd3QifQ.eyJ0ZXN0IjoiZGF0YSJ9.mock_signature"
-
-    return .attestation(
-      keyAttestationJWT: { _ in
-        // Mock key attestation JWT using compact serialization
-        try KeyAttestationJWT(
-          jws: JWS(compactSerialization: mockJWSString)
-        )
+  private func expectError(
+    _ expected: CredentialIssuanceError,
+    _ expression: @autoclosure () throws -> Void,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) {
+    XCTAssertThrowsError(try expression(), file: file, line: line) { error in
+      guard let issuanceError = error as? CredentialIssuanceError else {
+        XCTFail("Expected CredentialIssuanceError, got \(error)", file: file, line: line)
+        return
       }
-    )
+      XCTAssertEqual(
+        "\(issuanceError)",
+        "\(expected)",
+        "Expected \(expected), got \(issuanceError)",
+        file: file,
+        line: line
+      )
+    }
   }
 }

--- a/Tests/Issuance/IssuanceAuthorizationTest.swift
+++ b/Tests/Issuance/IssuanceAuthorizationTest.swift
@@ -351,9 +351,11 @@ class IssuanceAuthorizationTest: XCTestCase {
         "kid": UUID().uuidString
       ])
     
-    let bindingKey: BindingKey = .jwt(
+    let bindingKey: BindingKey = .jwtKeyAttestation(
       algorithm: alg,
-      jwk: publicKeyJWK,
+      keyAttestationJWT: { _ in
+        try .init(jws: .init(compactSerialization: TestsConstants.ketAttestationJWT))
+      },
       privateKey: .secKey(privateKey),
       issuer: "218232426"
     )
@@ -431,9 +433,11 @@ class IssuanceAuthorizationTest: XCTestCase {
         "kid": UUID().uuidString
       ])
     
-    let bindingKey: BindingKey = .jwt(
+    let bindingKey: BindingKey = .jwtKeyAttestation(
       algorithm: alg,
-      jwk: publicKeyJWK,
+      keyAttestationJWT: { _ in
+        try .init(jws: .init(compactSerialization: TestsConstants.ketAttestationJWT))
+      },
       privateKey: privateKeyProxy,
       issuer: "track2_full"
     )
@@ -573,9 +577,11 @@ class IssuanceAuthorizationTest: XCTestCase {
         "kid": UUID().uuidString
     ])
 
-    let bindingKey: BindingKey = .jwt(
+    let bindingKey: BindingKey = .jwtKeyAttestation(
       algorithm: alg,
-      jwk: publicKeyJWK,
+      keyAttestationJWT: { _ in
+        try .init(jws: .init(compactSerialization: TestsConstants.ketAttestationJWT))
+      },
       privateKey: .secKey(privateKey),
       issuer: "218232426"
     )
@@ -683,9 +689,11 @@ class IssuanceAuthorizationTest: XCTestCase {
       XCTAssert(false, "Unexpected grant type")
     }
     
-    let bindingKey: BindingKey = .jwt(
+    let bindingKey: BindingKey = .jwtKeyAttestation(
       algorithm: alg,
-      jwk: jwk,
+      keyAttestationJWT: { _ in
+        try .init(jws: .init(compactSerialization: TestsConstants.ketAttestationJWT))
+      },
       privateKey: .secKey(privateKey),
       issuer: "218232426"
     )

--- a/Tests/Wallet/VCIFlowNoOffer.swift
+++ b/Tests/Wallet/VCIFlowNoOffer.swift
@@ -41,9 +41,11 @@ class VCIFlowNoOffer: XCTestCase {
         "kid": UUID().uuidString
       ])
     
-    let bindingKey: BindingKey = .jwt(
+    let bindingKey: BindingKey = .jwtKeyAttestation(
       algorithm: alg,
-      jwk: publicKeyJWK,
+      keyAttestationJWT: { _ in
+        try .init(jws: .init(compactSerialization: TestsConstants.ketAttestationJWT))
+      },
       privateKey: .secKey(privateKey)
     )
     
@@ -85,9 +87,11 @@ class VCIFlowNoOffer: XCTestCase {
         "kid": UUID().uuidString
       ])
     
-    let bindingKey: BindingKey = .jwt(
+    let bindingKey: BindingKey = .jwtKeyAttestation(
       algorithm: alg,
-      jwk: publicKeyJWK,
+      keyAttestationJWT: { _ in
+        try .init(jws: .init(compactSerialization: TestsConstants.ketAttestationJWT))
+      },
       privateKey: .secKey(privateKey)
     )
     
@@ -130,9 +134,11 @@ class VCIFlowNoOffer: XCTestCase {
         "kid": UUID().uuidString
       ])
     
-    let bindingKey: BindingKey = .jwt(
+    let bindingKey: BindingKey = .jwtKeyAttestation(
       algorithm: alg,
-      jwk: publicKeyJWK,
+      keyAttestationJWT: { _ in
+        try .init(jws: .init(compactSerialization: TestsConstants.ketAttestationJWT))
+      },
       privateKey: .secKey(privateKey)
     )
     
@@ -175,9 +181,11 @@ class VCIFlowNoOffer: XCTestCase {
         "kid": UUID().uuidString
       ])
     
-    let bindingKey: BindingKey = .jwt(
+    let bindingKey: BindingKey = .jwtKeyAttestation(
       algorithm: alg,
-      jwk: publicKeyJWK,
+      keyAttestationJWT: { _ in
+        try .init(jws: .init(compactSerialization: TestsConstants.ketAttestationJWT))
+      },
       privateKey: .secKey(privateKey)
     )
     
@@ -220,9 +228,11 @@ class VCIFlowNoOffer: XCTestCase {
         "kid": UUID().uuidString
       ])
     
-    let bindingKey: BindingKey = .jwt(
+    let bindingKey: BindingKey = .jwtKeyAttestation(
       algorithm: alg,
-      jwk: publicKeyJWK,
+      keyAttestationJWT: { _ in
+        try .init(jws: .init(compactSerialization: TestsConstants.ketAttestationJWT))
+      },
       privateKey: .secKey(privateKey)
     )
     
@@ -263,9 +273,11 @@ class VCIFlowNoOffer: XCTestCase {
         "kid": UUID().uuidString
       ])
     
-    let bindingKey: BindingKey = .jwt(
+    let bindingKey: BindingKey = .jwtKeyAttestation(
       algorithm: alg,
-      jwk: publicKeyJWK,
+      keyAttestationJWT: { _ in
+        try .init(jws: .init(compactSerialization: TestsConstants.ketAttestationJWT))
+      },
       privateKey: .secKey(privateKey)
     )
     
@@ -306,9 +318,11 @@ class VCIFlowNoOffer: XCTestCase {
         "kid": UUID().uuidString
       ])
     
-    let bindingKey: BindingKey = .jwt(
+    let bindingKey: BindingKey = .jwtKeyAttestation(
       algorithm: alg,
-      jwk: publicKeyJWK,
+      keyAttestationJWT: { _ in
+        try .init(jws: .init(compactSerialization: TestsConstants.ketAttestationJWT))
+      },
       privateKey: .secKey(privateKey)
     )
     
@@ -349,9 +363,11 @@ class VCIFlowNoOffer: XCTestCase {
         "kid": UUID().uuidString
       ])
     
-    let bindingKey: BindingKey = .jwt(
+    let bindingKey: BindingKey = .jwtKeyAttestation(
       algorithm: alg,
-      jwk: publicKeyJWK,
+      keyAttestationJWT: { _ in
+        try .init(jws: .init(compactSerialization: TestsConstants.ketAttestationJWT))
+      },
       privateKey: .secKey(privateKey)
     )
     
@@ -393,9 +409,11 @@ class VCIFlowNoOffer: XCTestCase {
         "kid": UUID().uuidString
       ])
     
-    let bindingKey: BindingKey = .jwt(
+    let bindingKey: BindingKey = .jwtKeyAttestation(
       algorithm: alg,
-      jwk: publicKeyJWK,
+      keyAttestationJWT: { _ in
+        try .init(jws: .init(compactSerialization: TestsConstants.ketAttestationJWT))
+      },
       privateKey: .secKey(privateKey)
     )
     
@@ -586,9 +604,11 @@ class VCIFlowNoOffer: XCTestCase {
           "kid": UUID().uuidString
         ])
       
-      let bindingKey: BindingKey = .jwt(
+      let bindingKey: BindingKey = .jwtKeyAttestation(
         algorithm: JWSAlgorithm(.ES256),
-        jwk: publicKeyJWK,
+        keyAttestationJWT: { _ in
+          try .init(jws: .init(compactSerialization: TestsConstants.ketAttestationJWT))
+        },
         privateKey: .secKey(privateKey)
       )
       

--- a/Tests/Wallet/VCIFlowWithOffer.swift
+++ b/Tests/Wallet/VCIFlowWithOffer.swift
@@ -41,9 +41,11 @@ class VCIFlowWithOffer: XCTestCase {
         "kid": UUID().uuidString
       ])
     
-    let bindingKey: BindingKey = .jwt(
+    let bindingKey: BindingKey = .jwtKeyAttestation(
       algorithm: alg,
-      jwk: publicKeyJWK,
+      keyAttestationJWT: { _ in
+        try .init(jws: .init(compactSerialization: TestsConstants.ketAttestationJWT))
+      },
       privateKey: .secKey(privateKey)
     )
     
@@ -85,9 +87,11 @@ class VCIFlowWithOffer: XCTestCase {
         "kid": UUID().uuidString
       ])
     
-    let bindingKey: BindingKey = .jwt(
+    let bindingKey: BindingKey = .jwtKeyAttestation(
       algorithm: alg,
-      jwk: publicKeyJWK,
+      keyAttestationJWT: { _ in
+        try .init(jws: .init(compactSerialization: TestsConstants.ketAttestationJWT))
+      },
       privateKey: .custom(
         TestSigner(
           privateKey: privateKey, jwk: publicKeyJWK
@@ -133,9 +137,11 @@ class VCIFlowWithOffer: XCTestCase {
         "kid": UUID().uuidString
       ])
     
-    let bindingKey: BindingKey = .jwt(
+    let bindingKey: BindingKey = .jwtKeyAttestation(
       algorithm: alg,
-      jwk: publicKeyJWK,
+      keyAttestationJWT: { _ in
+        try .init(jws: .init(compactSerialization: TestsConstants.ketAttestationJWT))
+      },
       privateKey: .secKey(privateKey)
     )
     
@@ -176,9 +182,11 @@ class VCIFlowWithOffer: XCTestCase {
         "kid": UUID().uuidString
       ])
     
-    let bindingKey: BindingKey = .jwt(
+    let bindingKey: BindingKey = .jwtKeyAttestation(
       algorithm: alg,
-      jwk: publicKeyJWK,
+      keyAttestationJWT: { _ in
+        try .init(jws: .init(compactSerialization: TestsConstants.ketAttestationJWT))
+      },
       privateKey: .secKey(privateKey)
     )
     
@@ -219,9 +227,11 @@ class VCIFlowWithOffer: XCTestCase {
         "kid": UUID().uuidString
       ])
     
-    let bindingKey: BindingKey = .jwt(
+    let bindingKey: BindingKey = .jwtKeyAttestation(
       algorithm: alg,
-      jwk: publicKeyJWK,
+      keyAttestationJWT: { _ in
+        try .init(jws: .init(compactSerialization: TestsConstants.ketAttestationJWT))
+      },
       privateKey: .secKey(privateKey)
     )
     
@@ -263,9 +273,11 @@ class VCIFlowWithOffer: XCTestCase {
         "kid": UUID().uuidString
       ])
     
-    let bindingKey: BindingKey = .jwt(
+    let bindingKey: BindingKey = .jwtKeyAttestation(
       algorithm: alg,
-      jwk: publicKeyJWK,
+      keyAttestationJWT: { _ in
+        try .init(jws: .init(compactSerialization: TestsConstants.ketAttestationJWT))
+      },
       privateKey: .secKey(privateKey)
     )
     
@@ -308,9 +320,11 @@ class VCIFlowWithOffer: XCTestCase {
       ])
     
     let privateKeyProxy: SigningKeyProxy = .secKey(privateKey)
-    let bindingKey: BindingKey = .jwt(
+    let bindingKey: BindingKey = .jwtKeyAttestation(
       algorithm: alg,
-      jwk: publicKeyJWK,
+      keyAttestationJWT: { _ in
+        try .init(jws: .init(compactSerialization: TestsConstants.ketAttestationJWT))
+      },
       privateKey: privateKeyProxy
     )
     
@@ -359,9 +373,11 @@ class VCIFlowWithOffer: XCTestCase {
       ])
     
     let privateKeyProxy: SigningKeyProxy = .secKey(privateKey)
-    let bindingKey: BindingKey = .jwt(
+    let bindingKey: BindingKey = .jwtKeyAttestation(
       algorithm: alg,
-      jwk: publicKeyJWK,
+      keyAttestationJWT: { _ in
+        try .init(jws: .init(compactSerialization: TestsConstants.ketAttestationJWT))
+      },
       privateKey: privateKeyProxy
     )
     
@@ -410,9 +426,11 @@ class VCIFlowWithOffer: XCTestCase {
       ])
     
     let privateKeyProxy: SigningKeyProxy = .secKey(privateKey)
-    let bindingKey: BindingKey = .jwt(
+    let bindingKey: BindingKey = .jwtKeyAttestation(
       algorithm: alg,
-      jwk: publicKeyJWK,
+      keyAttestationJWT: { _ in
+        try .init(jws: .init(compactSerialization: TestsConstants.ketAttestationJWT))
+      },
       privateKey: privateKeyProxy
     )
     


### PR DESCRIPTION
# Description of change

Removes support for plain JWT proofs (proof_type `jwt` without `key_attestation` in
  the protected header) and enforces that issuance proofs are device-bound.

- `BindingKey.jwt(algorithm:, jwk:, privateKey:, issuer:)` is removed. Callers must use `.jwtKeyAttestation(...)` or `.attestation(...)`.
- `ProofTypesPolicy` is collapsed from an enum (`.acceptAll` / `.flexible` /`.deviceBound`) into a struct of `supportedAlgorithms` and `supportedProofTypes`. 
- `DeviceBoundProofType` is renamed to `AttestedProofType`.
- `OpenId4VCIConfig.proofTypesPolicy` default is now `.haipCompliant()`.
- `CredentialIssuanceError.proofTypeJwtWithoutKeyAttestationNotAllowedByPolicy` is replaced by `.issuerMetadataNoAttestedProofType`.
- `ProofTypesPolicy.validateIssuerMetadata(credentialConfiguration:)` is added : 

1. empty/missing `proof_types_supported` is accepted (no-proof flow)

2. a non-empty `proof_types_supported` MUST advertise BOTH `jwt` AND `attestation`, and BOTH MUST carry `key_attestations_required`. Otherwise the validator throws `issuerMetadataNoAttestedProofType`.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes