### PR TITLE
 Enforce reuse policy base-method rule at options-array level

### DIFF
--- a/Sources/Entities/CredentialReuse/CredentialReusePolicy.swift
+++ b/Sources/Entities/CredentialReuse/CredentialReusePolicy.swift
@@ -39,18 +39,30 @@ extension CredentialReusePolicy: Codable {
 
     id = try container.decode(String.self, forKey: .id)
 
-
     let jsonOptions = try container.decode([ReusePolicyOption].self, forKey: .options)
-    var expandedPolicies: [ReusePolicy] = []
-
-    for jsonOption in jsonOptions {
-      let policies = try ReusePolicy.fromDetails(
-        details: jsonOption.details,
-        batchSize: jsonOption.batchSize,
-        reissueTriggerUnused: jsonOption.reissueTriggerUnused,
-        reissueTriggerLifetimeLeft: jsonOption.reissueTriggerLifetimeLeft
+    
+    let arrayHasBaseMethod = jsonOptions.contains { option in
+      option.details.contains(.onceOnly) || option.details.contains(.limitedTime)
+    }
+    guard arrayHasBaseMethod else {
+      throw CredentialReusePolicyError.invalidPolicyStructure(
+        "options array must contain at least one entry with once_only or limited_time"
       )
-      expandedPolicies.append(contentsOf: policies)
+    }
+
+    var expandedPolicies: [ReusePolicy] = []
+    for jsonOption in jsonOptions {
+      do {
+        let policies = try ReusePolicy.fromDetails(
+          details: jsonOption.details,
+          batchSize: jsonOption.batchSize,
+          reissueTriggerUnused: jsonOption.reissueTriggerUnused,
+          reissueTriggerLifetimeLeft: jsonOption.reissueTriggerLifetimeLeft
+        )
+        expandedPolicies.append(contentsOf: policies)
+      } catch {
+        print("CredentialReusePolicy: skipping invalid option \(jsonOption.details.map { $0.rawValue }): \(error)")
+      }
     }
 
     guard !expandedPolicies.isEmpty else {

--- a/Sources/Entities/CredentialReuse/ReusePolicy.swift
+++ b/Sources/Entities/CredentialReuse/ReusePolicy.swift
@@ -98,15 +98,8 @@ public enum ReusePolicy: Sendable, Equatable {
       throw CredentialReusePolicyError.invalidDetailsCombination(details)
     }
 
-    // Check for base method (once_only OR limited_time)
     let hasOnceOnly = details.contains(.onceOnly)
     let hasLimitedTime = details.contains(.limitedTime)
-
-    guard hasOnceOnly || hasLimitedTime else {
-      throw CredentialReusePolicyError.invalidPolicyStructure(
-        "details must contain either once_only or limited_time"
-      )
-    }
 
     guard !(hasOnceOnly && hasLimitedTime) else {
       throw CredentialReusePolicyError.invalidPolicyStructure(

--- a/Sources/Entities/CredentialSupported/CredentialSupported.swift
+++ b/Sources/Entities/CredentialSupported/CredentialSupported.swift
@@ -207,10 +207,14 @@ public struct ConfigurationCredentialMetadata: Codable, Sendable {
     let claims = try json["claims"].array?.compactMap({ try Claim(json: $0)}) ?? []
     self.claims = claims
     
-    if let policyJson = json["credential_reuse_policy"].dictionaryObject,
-       let policyData = try? JSONSerialization.data(withJSONObject: policyJson),
-       let reusePolicy = try? JSONDecoder().decode(CredentialReusePolicy.self, from: policyData) {
-      self.credentialReusePolicy = reusePolicy
+    if let policyJson = json["credential_reuse_policy"].dictionaryObject {
+      do {
+        let policyData = try JSONSerialization.data(withJSONObject: policyJson)
+        self.credentialReusePolicy = try JSONDecoder().decode(CredentialReusePolicy.self, from: policyData)
+      } catch {
+        print("ConfigurationCredentialMetadata: failed to parse credential_reuse_policy: \(error)")
+        self.credentialReusePolicy = nil
+      }
     } else {
       self.credentialReusePolicy = nil
     }

--- a/Tests/Entities/CredentialReusePolicyParsingTests.swift
+++ b/Tests/Entities/CredentialReusePolicyParsingTests.swift
@@ -247,7 +247,10 @@ class CredentialReusePolicyParsingTests: XCTestCase {
     )
   }
 
-  /// Test parsing without base method (rotating-batch alone)
+  /// Test parsing an options array with no base method anywhere.
+  /// Per ETSI TS 119 472-3 ISS-MDATA-EAA-REUSE-POL-4.2.4.2-03, the base-method
+  /// requirement is enforced at the options-array level: at least one option must
+  /// contain once_only or limited_time.
   func testParsing_RotatingBatchAlone_ThrowsError() {
     let json = """
     {
@@ -265,6 +268,82 @@ class CredentialReusePolicyParsingTests: XCTestCase {
     XCTAssertThrowsError(
       try JSONDecoder().decode(CredentialReusePolicy.self, from: data)
     )
+  }
+
+  /// mDL-shaped policy: one standalone rotating-batch option plus one standalone
+  /// once_only option. The array-level base-method rule is satisfied by once_only,
+  /// so both options should be expanded (issuer's rotating-batch option is treated
+  /// as a valid standalone entry).
+  func testParsing_StandaloneRotatingBatchWithOnceOnlyBaseInArray_Succeeds() throws {
+    let json = """
+    {
+      "id": "arf_annex_ii",
+      "options": [
+        {
+          "details": ["rotating-batch"],
+          "batch_size": 4,
+          "reissue_trigger_lifetime_left": 2159400
+        },
+        {
+          "details": ["once_only"],
+          "batch_size": 8,
+          "reissue_trigger_unused": 3
+        }
+      ]
+    }
+    """
+
+    let data = json.data(using: .utf8)!
+    let policy = try JSONDecoder().decode(CredentialReusePolicy.self, from: data)
+
+    XCTAssertEqual(policy.options.count, 2)
+
+    if case .rotatingBatch(let batchSize, let reissueTriggerLifetimeLeft) = policy.options[0] {
+      XCTAssertEqual(batchSize, 4)
+      XCTAssertEqual(reissueTriggerLifetimeLeft, 2159400)
+    } else {
+      XCTFail("Expected rotatingBatch policy at index 0")
+    }
+
+    if case .onceOnly(let batchSize, let reissueTriggerUnused) = policy.options[1] {
+      XCTAssertEqual(batchSize, 8)
+      XCTAssertEqual(reissueTriggerUnused, 3)
+    } else {
+      XCTFail("Expected onceOnly policy at index 1")
+    }
+  }
+
+  /// An invalid option (missing required field) should be skipped, but the valid
+  /// options in the same array should still be produced.
+  func testParsing_InvalidOptionSkipped_ValidOptionsSurvive() throws {
+    let json = """
+    {
+      "id": "arf_annex_ii",
+      "options": [
+        {
+          "details": ["once_only"],
+          "batch_size": 8,
+          "reissue_trigger_unused": 3
+        },
+        {
+          "details": ["rotating-batch"],
+          "batch_size": 4
+        }
+      ]
+    }
+    """
+
+    let data = json.data(using: .utf8)!
+    let policy = try JSONDecoder().decode(CredentialReusePolicy.self, from: data)
+
+    XCTAssertEqual(policy.options.count, 1)
+
+    if case .onceOnly(let batchSize, let reissueTriggerUnused) = policy.options[0] {
+      XCTAssertEqual(batchSize, 8)
+      XCTAssertEqual(reissueTriggerUnused, 3)
+    } else {
+      XCTFail("Expected surviving onceOnly policy")
+    }
   }
 
   /// Test that policies are in correct order (order matters for selection)

--- a/Tests/Entities/ReusePolicyTests.swift
+++ b/Tests/Entities/ReusePolicyTests.swift
@@ -92,25 +92,34 @@ class ReusePolicyTests: XCTestCase {
     )
   }
 
-  func testFromDetails_FailsWhenRotatingBatchIsUsedWithoutBaseDetail() {
-    XCTAssertThrowsError(
-      try ReusePolicy.fromDetails(
-        details: [.rotatingBatch],
-        batchSize: 10,
-        reissueTriggerUnused: nil,
-        reissueTriggerLifetimeLeft: 100
-      )
+  /// The base-method requirement (once_only or limited_time) is enforced at the
+  /// options-array level in CredentialReusePolicy.init(from:), not per-option in
+  /// fromDetails. A standalone rotating-batch option is accepted here as long as
+  /// its required fields are present.
+  func testFromDetails_StandaloneRotatingBatch_Succeeds() throws {
+    let policies = try ReusePolicy.fromDetails(
+      details: [.rotatingBatch],
+      batchSize: 10,
+      reissueTriggerUnused: nil,
+      reissueTriggerLifetimeLeft: 100
     )
+    XCTAssertEqual(policies.count, 1)
+    XCTAssertEqual(policies[0], .rotatingBatch(batchSize: 10, reissueTriggerLifetimeLeft: 100))
   }
 
-  func testFromDetails_FailsWhenPerRelyingPartyIsUsedWithoutBaseDetail() {
-    XCTAssertThrowsError(
-      try ReusePolicy.fromDetails(
-        details: [.perRelyingParty],
-        batchSize: 10,
-        reissueTriggerUnused: 2,
-        reissueTriggerLifetimeLeft: 100
-      )
+  /// A standalone per-relying-party option is accepted at the fromDetails level;
+  /// the array-level base-method rule is enforced by the decoder.
+  func testFromDetails_StandalonePerRelyingParty_Succeeds() throws {
+    let policies = try ReusePolicy.fromDetails(
+      details: [.perRelyingParty],
+      batchSize: 10,
+      reissueTriggerUnused: 2,
+      reissueTriggerLifetimeLeft: 100
+    )
+    XCTAssertEqual(policies.count, 1)
+    XCTAssertEqual(
+      policies[0],
+      .perRelyingParty(batchSize: 10, reissueTriggerUnused: 2, reissueTriggerLifetimeLeft: 100)
     )
   }
 


### PR DESCRIPTION
# Description of change

This change moves the "base method" enforcement rule for credential reuse policies from the per-option level (`ReusePolicy.fromDetails`) to the options-array level (`CredentialReusePolicy` decoder).


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
