### PR TITLE
fix: restore public client support

### DIFF
--- a/Sources/Main/AttestationBasedClient/Client.swift
+++ b/Sources/Main/AttestationBasedClient/Client.swift
@@ -22,7 +22,10 @@ public typealias ClientAttestationProvider = @Sendable (URL) async throws -> (
 )
 
 public enum Client: Sendable {
-  
+
+  /// Represents a Public client
+  case `public`(id: ClientId)
+
   /// Represents an Attested client
   case attested(
     id: ClientId,
@@ -31,47 +34,61 @@ public enum Client: Sendable {
     popJwtSpec: ClientAttestationPoPJWTSpec,
     clientAttestationProvider: ClientAttestationProvider
   )
-  
+
   // Computed property for 'id' (common property for both cases)
   public var id: ClientId {
     switch self {
+    case .public(let id):
+      return id
     case .attested(let id, _, _, _, _):
       return id
     }
   }
-  
-  // Computed property for public key
-  public var jwk: JWK {
+
+  // Computed property for public key, `nil` for a public client
+  public var jwk: JWK? {
     switch self {
+    case .public:
+      return nil
     case .attested(_, _, let jwk, _, _):
       return jwk
     }
   }
-  
-  // Computed property for JWS alg
-  public var alg: JWSAlgorithm {
+
+  // Computed property for JWS alg, `nil` for a public client
+  public var alg: JWSAlgorithm? {
     switch self {
+    case .public:
+      return nil
     case .attested(_, let alg, _, _, _):
       return alg
     }
   }
-  
+
   // Computed property for 'provider'
   public func provider() -> ClientAttestationProvider? {
     switch self {
+    case .public:
+      return nil
     case .attested(_, _, _, _, let provider):
       return provider
     }
   }
-  
+
   // Computed property for 'provider'
   public func spec() -> ClientAttestationPoPJWTSpec? {
     switch self {
+    case .public:
+      return nil
     case .attested(_, _, _, let spec, _):
       return spec
     }
   }
-  
+
+  public init(public id: ClientId) {
+    self = .public(id: id)
+  }
+
   public init(
     id: ClientId,
     alg: JWSAlgorithm,
@@ -87,9 +104,11 @@ public enum Client: Sendable {
       clientAttestationProvider: clientAttestationProvider
     )
   }
-  
+
   internal var attested: (id: ClientId, popJwtSpec: ClientAttestationPoPJWTSpec, clientAttestationProvider: ClientAttestationProvider)? {
     return switch self {
+    case .public:
+      nil
     case .attested(let id, _, _, let popJwtSpec, let clientAttestationProvider):
       (id, popJwtSpec, clientAttestationProvider)
     }

--- a/Sources/Main/Authorisers/AuthorizationServerClient.swift
+++ b/Sources/Main/Authorisers/AuthorizationServerClient.swift
@@ -919,6 +919,8 @@ private extension AuthorizationServerClient {
     challenge: Nonce?
   ) async throws -> (ClientAttestationJWT, ClientAttestationPoPJWT, JWK, SigningKeyProxy)? {
     switch client {
+    case .public:
+      return nil
     case .attested(_, _, let jwk, let spec, let provider):
       guard let clientAttestationPoPBuilder = config.clientAttestationPoPBuilder else {
         return nil

--- a/Tests/AttestationBased/AttestationBasedTests.swift
+++ b/Tests/AttestationBased/AttestationBasedTests.swift
@@ -68,6 +68,38 @@ class AttestationBasedTests: XCTestCase {
     XCTAssertNotNil(client)
   }
 
+  func testPublicClient_carriesNoAttestationMaterial() async throws {
+
+    let client = Client(public: "test-public-client")
+
+    XCTAssertEqual(client.id, "test-public-client")
+    XCTAssertNil(client.jwk)
+    XCTAssertNil(client.alg)
+    XCTAssertNil(client.provider())
+    XCTAssertNil(client.spec())
+    XCTAssertNil(client.attested)
+  }
+
+  func testPublicClient_popBuilderThrowsInvalidClient() async throws {
+
+    let builder = DefaultClientAttestationPoPBuilder()
+
+    do {
+      _ = try await builder.buildAttestationPoPJWT(
+        for: Client(public: "test-public-client"),
+        algorithm: .ES256,
+        clock: Clock(),
+        authServerId: URL(string: "https://as.example.com")!,
+        challenge: nil
+      )
+      XCTFail("Expected ClientAttestationError.invalidClient")
+    } catch let error as ClientAttestationError {
+      guard case .invalidClient = error else {
+        return XCTFail("Expected ClientAttestationError.invalidClient, got \(error)")
+      }
+    }
+  }
+
   func testClientAttestationWithValidAlgorithms_shouldSucceed() async throws {
     // Test that ES256, ES384, ES512 are all accepted
     let privateKey = try KeyController.generateECDHPrivateKey()


### PR DESCRIPTION
# Description of change

`Release/0.36.0` (bdd143c) removed `case public(id: ClientId)` from `Client`, leaving `.attested` as the enum's only case. As a result client attestation is now mandatory: there is no way to configure a client that doesn't support client attestation.

This breaks any wallet whose authorization server does not advertise `attest_jwt_client_auth` in `token_endpoint_auth_methods_supported`, or that is not provisioned with a wallet instance attestation at all. Public clients remain valid in OpenID4VCI; attestation-based client authentication is one supported method rather than the only one, so the library should not force it.

This PR restores the public client alongside the attested one:

- `Client.public(id:)` and `init(public:)` are back.
- `jwk` and `alg` become `Optional`, since a public client has neither.
- `provider()`, `spec()` and `attested` return `nil` for a public client.
- `AuthorizationServerClient.generateClientAttestationIfNeeded` returns `nil` for a public client, so no `OAuth-Client-Attestation` / `OAuth-Client-Attestation-PoP` headers are sent. The PAR, token and pre-authorized-code paths already handled a `nil` attestation, and `makeAttestationHeadersIfNeeded` already returned empty headers when `provider()` is `nil`.
- `DefaultClientAttestationPoPBuilder` needed no change — its `default` branch already throws `ClientAttestationError.invalidClient`, which is what it did for public clients before 0.36.0.
- `Client.ensureSupportedByAuthorizationServer` needed no change — its `default: break` means a public client skips the `attest_jwt_client_auth` check.

Behaviour for attested clients is unchanged.

No new dependencies.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

The behavioural change is additive, but the API change is source-breaking in two ways: `Client.jwk` and `Client.alg` are now `JWK?` / `JWSAlgorithm?`, and the new enum case makes exhaustive `switch` statements over `Client` in downstream code incomplete. Nothing inside `Sources` or `Tests` reads `jwk` or `alg`.

# How Has This Been Tested?

- [x] `swift build` — clean, no new warnings.
- [x] `swift test --filter "AttestationBasedTests|KeyAttestationRequirementTests|ProofTypesPolicyTests"` — 49 tests, 0 failures.
- [x] Two new unit tests in `Tests/AttestationBased/AttestationBasedTests.swift`:
  - `testPublicClient_carriesNoAttestationMaterial` — a public client exposes its `id` and returns `nil` for `jwk`, `alg`, `provider()`, `spec()` and `attested`.
  - `testPublicClient_popBuilderThrowsInvalidClient` — `DefaultClientAttestationPoPBuilder` rejects a public client with `ClientAttestationError.invalidClient`.
- [x] Existing attested-client tests (`testClientAttestationJWT`, `testClientAttestationWithValidAlgorithms_shouldSucceed`, the `testWIA_*` set) still pass unchanged, confirming the attested path is unaffected.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes