### PR TITLE
fix: Accept issuers advertising only jwt or only attestation proof types

### DIFF
--- a/Sources/Entities/Wallet/ProofTypesPolicy.swift
+++ b/Sources/Entities/Wallet/ProofTypesPolicy.swift
@@ -61,12 +61,13 @@ public extension ProofTypesPolicy {
   /// Rules
   ///   - If `proof_types_supported` is missing or empty, the configuration
   ///     does not require a proof; this method returns successfully.
-  ///   - Otherwise, the configuration MUST advertise BOTH `proof_type: jwt`
-  ///     AND `proof_type: attestation`, and BOTH MUST carry
-  ///     `key_attestations_required`.
-  ///   - At least one of the two advertised attested proof types must be in
-  ///     the wallet's `supportedProofTypes`, with at least one matching
-  ///     algorithm in `supportedAlgorithms`.
+  ///   - Otherwise, the configuration MUST advertise at least one of
+  ///     `proof_type: jwt` or `proof_type: attestation` with
+  ///     `key_attestations_required`. HAIP / TS3 / TS 119 472-3 do not require
+  ///     both to be advertised.
+  ///   - At least one of the advertised attested proof types must be in the
+  ///     wallet's `supportedProofTypes`, with at least one matching algorithm
+  ///     in `supportedAlgorithms`.
   ///
   /// Throws:
   ///   - `CredentialIssuanceError.issuerMetadataNoAttestedProofType` when the
@@ -83,14 +84,22 @@ public extension ProofTypesPolicy {
       return
     }
 
-    guard let attestationMeta = proofTypesSupported["attestation"],
-          Self.requiresKeyAttestation(attestationMeta) else {
+    let attestedCandidates: [(AttestedProofType, ProofTypeSupportedMeta)] = [
+      ("jwt", .jwtWithKeyAttestation),
+      ("attestation", .attestation)
+    ].compactMap { key, type in
+      guard let meta = proofTypesSupported[key],
+            Self.requiresKeyAttestation(meta) else { return nil }
+      return (type, meta)
+    }
+
+    guard !attestedCandidates.isEmpty else {
       throw CredentialIssuanceError.issuerMetadataNoAttestedProofType
     }
 
-    let walletSupported: [(AttestedProofType, ProofTypeSupportedMeta)] = [
-      (.attestation, attestationMeta)
-    ].filter { supportedProofTypes.contains($0.0) }
+    let walletSupported = attestedCandidates.filter {
+      supportedProofTypes.contains($0.0)
+    }
 
     guard !walletSupported.isEmpty else {
       throw CredentialIssuanceError.proofTypeNotSupportedByWalletPolicy

--- a/Tests/Entities/ProofTypesPolicyTests.swift
+++ b/Tests/Entities/ProofTypesPolicyTests.swift
@@ -67,35 +67,50 @@ final class ProofTypesPolicyTests: XCTestCase {
     ))
   }
 
+  func testAcceptsJwtOnlyWithKeyAttestation() {
+    let config = makeConfig(proofTypesSupported: [
+      "jwt": ProofTypeSupportedMeta(
+        algorithms: ["ES256"],
+        keyAttestationRequirement: .requiredNoConstraints
+      )
+    ])
+
+    XCTAssertNoThrow(try ProofTypesPolicy.haipCompliant().validateIssuerMetadata(
+      credentialConfiguration: config
+    ))
+  }
+
+  func testAcceptsAttestationOnlyWithKeyAttestation() {
+    let config = makeConfig(proofTypesSupported: [
+      "attestation": ProofTypeSupportedMeta(
+        algorithms: ["ES256"],
+        keyAttestationRequirement: .requiredNoConstraints
+      )
+    ])
+
+    XCTAssertNoThrow(try ProofTypesPolicy.haipCompliant().validateIssuerMetadata(
+      credentialConfiguration: config
+    ))
+  }
+
+  func testAcceptsJwtWithKeyAttestationEvenIfAttestationLacksIt() {
+    let config = makeConfig(proofTypesSupported: [
+      "jwt": ProofTypeSupportedMeta(
+        algorithms: ["ES256"],
+        keyAttestationRequirement: .requiredNoConstraints
+      ),
+      "attestation": ProofTypeSupportedMeta(
+        algorithms: ["ES256"],
+        keyAttestationRequirement: .notRequired
+      )
+    ])
+
+    XCTAssertNoThrow(try ProofTypesPolicy.haipCompliant().validateIssuerMetadata(
+      credentialConfiguration: config
+    ))
+  }
+
   // MARK: - validateIssuerMetadata: reject paths (metadata error)
-
-  func testRejectsJwtOnly() {
-    let config = makeConfig(proofTypesSupported: [
-      "jwt": ProofTypeSupportedMeta(
-        algorithms: ["ES256"],
-        keyAttestationRequirement: .requiredNoConstraints
-      )
-    ])
-
-    expectError(
-      .issuerMetadataNoAttestedProofType,
-      try ProofTypesPolicy.haipCompliant().validateIssuerMetadata(credentialConfiguration: config)
-    )
-  }
-
-  func testRejectsAttestationOnly() {
-    let config = makeConfig(proofTypesSupported: [
-      "jwt": ProofTypeSupportedMeta(
-        algorithms: ["ES256"],
-        keyAttestationRequirement: .requiredNoConstraints
-      )
-    ])
-
-    expectError(
-      .issuerMetadataNoAttestedProofType,
-      try ProofTypesPolicy.haipCompliant().validateIssuerMetadata(credentialConfiguration: config)
-    )
-  }
 
   func testRejectsJwtWithoutKeyAttestation() {
     let config = makeConfig(proofTypesSupported: [
@@ -113,9 +128,23 @@ final class ProofTypesPolicyTests: XCTestCase {
 
   func testRejectsAttestationWithoutKeyAttestation() {
     let config = makeConfig(proofTypesSupported: [
+      "attestation": ProofTypeSupportedMeta(
+        algorithms: ["ES256"],
+        keyAttestationRequirement: .notRequired
+      )
+    ])
+
+    expectError(
+      .issuerMetadataNoAttestedProofType,
+      try ProofTypesPolicy.haipCompliant().validateIssuerMetadata(credentialConfiguration: config)
+    )
+  }
+
+  func testRejectsBothWithoutKeyAttestation() {
+    let config = makeConfig(proofTypesSupported: [
       "jwt": ProofTypeSupportedMeta(
         algorithms: ["ES256"],
-        keyAttestationRequirement: .requiredNoConstraints
+        keyAttestationRequirement: .notRequired
       ),
       "attestation": ProofTypeSupportedMeta(
         algorithms: ["ES256"],
@@ -152,6 +181,42 @@ final class ProofTypesPolicyTests: XCTestCase {
         algorithms: ["ES256"],
         keyAttestationRequirement: .requiredNoConstraints
       ),
+      "attestation": ProofTypeSupportedMeta(
+        algorithms: ["ES256"],
+        keyAttestationRequirement: .requiredNoConstraints
+      )
+    ])
+
+    expectError(
+      .proofTypeNotSupportedByWalletPolicy,
+      try policy.validateIssuerMetadata(credentialConfiguration: config)
+    )
+  }
+
+  func testRejectsWhenIssuerOnlyJwtButWalletOnlyAttestation() {
+    let policy = ProofTypesPolicy(
+      supportedAlgorithms: [JWSAlgorithm(.ES256)],
+      supportedProofTypes: [.attestation]
+    )
+    let config = makeConfig(proofTypesSupported: [
+      "jwt": ProofTypeSupportedMeta(
+        algorithms: ["ES256"],
+        keyAttestationRequirement: .requiredNoConstraints
+      )
+    ])
+
+    expectError(
+      .proofTypeNotSupportedByWalletPolicy,
+      try policy.validateIssuerMetadata(credentialConfiguration: config)
+    )
+  }
+
+  func testRejectsWhenIssuerOnlyAttestationButWalletOnlyJwt() {
+    let policy = ProofTypesPolicy(
+      supportedAlgorithms: [JWSAlgorithm(.ES256)],
+      supportedProofTypes: [.jwtWithKeyAttestation]
+    )
+    let config = makeConfig(proofTypesSupported: [
       "attestation": ProofTypeSupportedMeta(
         algorithms: ["ES256"],
         keyAttestationRequirement: .requiredNoConstraints


### PR DESCRIPTION
# Description of change

- Fix the rejection of jwt with key attestation
- Accept configurations that advertise either jwt or attestation with key_attestations_required 

- [x] Bug fix (non-breaking change which fixes an issue)

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Closes #299 