### PR TITLE
fix: Relax ClientAttestationJWT

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,15 +395,21 @@ interactions use the newly provided DPoP Nonce value.
 
 Library supports [OAUTH2 Attestation-Based Client Authentication - Draft 03](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-03.html).
 
-When a `Client.attested(...)` is used, the provided `ClientAttestationJWT` is eagerly validated as a **Wallet Instance Attestation per [TS3 v1.5 §2.3](https://github.com/eu-digital-identity-wallet/eudi-doc-standards-and-technical-specifications/blob/main/docs/technical-specifications/ts3-wallet-unit-attestation.md#23-content)**. The JWT must:
+When a `Client.attested(...)` is used, the provided `ClientAttestationJWT` is treated as a **passthrough** for the compact-serialized JWT returned by the wallet's `ClientAttestationProvider`. The library does not parse or validate its header, signature, or claims — it simply forwards `attestation.value` as the `OAuth-Client-Attestation` HTTP header.
 
-- be signed with `ES256`, `ES384`, or `ES512`
-- carry header `typ` of `oauth-client-attestation+jwt` (when set)
-- contain the required claims: `iss`, `sub`, `exp`, `cnf.jwk` (public key), `wallet_name`, `wallet_version`, `wallet_solution_certification_information`, and `client_status` (with nested `status_list` reference and `exp`)
+```swift
+let attestation = ClientAttestationJWT(compactJwtStringFromProvider)
+```
 
-Parsed values are available via the typed `attestation.claimsSet` (e.g. `attestation.claimsSet.walletName.value`, `attestation.publicKey`). Wallet Provider back-ends MUST issue WIAs that include every required claim, otherwise construction fails with a specific `ClientAttestationError` naming the missing or invalid claim.
+Callers that want to enforce a schema can opt in explicitly:
 
-An example can be found in this test: `testNoOfferSdJWTClientAuthentication()`
+```swift
+// TS3 v1.5 §2.3 Wallet Instance Attestation shape
+let claims = try attestation.decodeAsClientAttestationClaims()
+let clientId = claims.subject.value
+let jwk = claims.confirmation.jwk
+```
+
 
 ### Credential Reuse Policy
 

--- a/Sources/Entities/AccessManagement/IdentityAndAccessManagementMetadata.swift
+++ b/Sources/Entities/AccessManagement/IdentityAndAccessManagementMetadata.swift
@@ -99,4 +99,13 @@ public enum IdentityAndAccessManagementMetadata: Sendable {
     }
   }
 
+  public var clientAttestationSigningAlgValuesSupported: [JWSAlgorithm] {
+    switch self {
+    case .oidc(let metaData):
+      return metaData.clientAttestationSigningAlgValuesSupported?.map { JWSAlgorithm(name: $0) } ?? []
+    case .oauth(let metaData):
+      return metaData.clientAttestationSigningAlgValuesSupported?.map { JWSAlgorithm(name: $0) } ?? []
+    }
+  }
+
 }

--- a/Sources/Issuers/Issuer.swift
+++ b/Sources/Issuers/Issuer.swift
@@ -957,20 +957,33 @@ public extension Issuer {
 }
 
 internal extension Client {
-  
+
   private static let ATTEST_JWT_CLIENT_AUTH = "attest_jwt_client_auth"
-  
+
   func ensureSupportedByAuthorizationServer(_ authorizationServerMetadata: IdentityAndAccessManagementMetadata) throws {
-    
-    let tokenEndpointAuthMethods = authorizationServerMetadata.tokenEndpointAuthMethods
-    
+
     switch self {
-    case .attested:
-      let expectedMethod = Self.ATTEST_JWT_CLIENT_AUTH
-      guard tokenEndpointAuthMethods.contains(expectedMethod) else {
-        throw ValidationError.error(reason: ("\(Self.ATTEST_JWT_CLIENT_AUTH) not supported by authorization server"))
+    case .attested(_, let alg, _, let popJwtSpec, _):
+      let tokenEndpointAuthMethods = authorizationServerMetadata.tokenEndpointAuthMethods
+      guard tokenEndpointAuthMethods.contains(Self.ATTEST_JWT_CLIENT_AUTH) else {
+        throw ValidationError.error(reason: "\(Self.ATTEST_JWT_CLIENT_AUTH) not supported by authorization server")
       }
-      
+
+      let supportedAttestationAlgs = authorizationServerMetadata.clientAttestationSigningAlgValuesSupported
+      guard supportedAttestationAlgs.contains(where: { $0.name == alg.name }) else {
+        throw ValidationError.error(
+          reason: "\(alg.name) Client Attestation JWS Algorithm not supported by Authorization Server"
+        )
+      }
+
+      let supportedPopAlgs = authorizationServerMetadata.clientAttestationPopSigningAlgValuesSupported
+      let popAlgName = popJwtSpec.signingAlgorithm.rawValue
+      guard supportedPopAlgs.contains(where: { $0.name == popAlgName }) else {
+        throw ValidationError.error(
+          reason: "\(popAlgName) Client Attestation POP JWS Algorithm not supported by Authorization Server"
+        )
+      }
+
     default:
       break
     }

--- a/Sources/Main/AttestationBasedClient/ClientAttestation.swift
+++ b/Sources/Main/AttestationBasedClient/ClientAttestation.swift
@@ -20,62 +20,45 @@ import Foundation
 /// A `ClientAttestationJWT` is the Wallet Instance Attestation (WIA) sent by the wallet
 /// to the authorization server when using attestation-based client authentication.
 ///
-/// Construction eagerly validates that the JWT is a valid WIA
-/// header `typ` is `oauth-client-attestation+jwt`, the signing algorithm is one of
-/// ES256/ES384/ES512, and the claim set contains every required claim
-/// (`iss`, `sub`, `exp`, `cnf.jwk`, `wallet_name`, `wallet_version`,
-/// `wallet_solution_certification_information`, `client_status`).
-public struct ClientAttestationJWT: Sendable {
+public struct ClientAttestationJWT: Sendable, Equatable, Hashable {
 
-  public let jws: JWS
-  public let claimsSet: ClientAttestationJWTClaims
+  public let value: String
 
-  public var header: JWSHeader { jws.header }
-  public var clientId: ClientId { claimsSet.subject.value }
-  public var cnf: ConfirmationClaim { claimsSet.confirmation }
-  public var publicKey: JWK { claimsSet.confirmation.jwk }
-
-  /// Backward-compatible accessor. Prefer `publicKey`.
-  @available(*, deprecated, renamed: "publicKey")
-  public var pubKey: JWK? { publicKey }
-
-  private static let allowedAlgorithms: Set<SignatureAlgorithm> = [
-    .ES256, .ES384, .ES512
-  ]
-
-  public init(jws: JWS) throws {
-    guard let algorithm = jws.header.algorithm else {
-      throw ClientAttestationError.notSigned
-    }
-    guard Self.allowedAlgorithms.contains(algorithm) else {
-      throw ClientAttestationError.invalidAlgorithm(
-        allowedAlgorithms: Self.allowedAlgorithms.map { $0.rawValue }
-      )
-    }
-
-    if let typ = jws.header.typ, typ != AttestationBasedClientAuthenticationSpec.attestationJwtType {
-      throw ClientAttestationError.invalidTypHeader(
-        expected: AttestationBasedClientAuthenticationSpec.attestationJwtType,
-        got: typ
-      )
-    }
-
-    let payloadData = jws.payload.data()
-    guard let jsonObject = try JSONSerialization.jsonObject(
-      with: payloadData,
-      options: []
-    ) as? [String: Any] else {
-      throw ClientAttestationError.invalidPayload
-    }
-    let payload = JSON(jsonObject)
-
-    self.claimsSet = try ClientAttestationJWTClaims.parse(payload: payload)
-    self.jws = jws
+  public init(_ value: String) {
+    self.value = value
   }
 
-  /// Convenience initializer accepting the compact-serialized JWT string.
-  public init(jwt: String) throws {
-    let jws = try JWS(compactSerialization: jwt)
-    try self.init(jws: jws)
+  /// Convenience initializer accepting an already-parsed `JWS`.
+  public init(jws: JWS) {
+    self.value = jws.compactSerializedString
+  }
+}
+
+public extension ClientAttestationJWT {
+
+  /// Decodes the JWT payload into the supplied claims type.
+  ///
+  /// Use this to opt in to a specific claims schema — for example
+  /// `decodeClaimsSet(ClientAttestationJWTClaims.self)` to enforce the TS3 WIA shape.
+  func decodeClaimsSet<T: Decodable>(_ type: T.Type) throws -> T {
+    let payload = try decodePayloadData()
+    return try JSONDecoder().decode(T.self, from: payload)
+  }
+
+  /// Decodes the JWT payload as a generic JSON structure.
+  func decodeClaimsSet() throws -> JSON {
+    let payload = try decodePayloadData()
+    let jsonObject = try JSONSerialization.jsonObject(with: payload, options: [])
+    return JSON(jsonObject)
+  }
+
+  /// Decodes the JWT payload into `ClientAttestationJWTClaims`, enforcing the TS3 WIA schema.
+  func decodeAsClientAttestationClaims() throws -> ClientAttestationJWTClaims {
+    try ClientAttestationJWTClaims.parse(payload: try decodeClaimsSet())
+  }
+
+  private func decodePayloadData() throws -> Data {
+    let jws = try JWS(compactSerialization: value)
+    return jws.payload.data()
   }
 }

--- a/Sources/Main/AttestationBasedClient/ClientAttestationPoPBuilder.swift
+++ b/Sources/Main/AttestationBasedClient/ClientAttestationPoPBuilder.swift
@@ -58,18 +58,18 @@ public struct DefaultClientAttestationPoPBuilder: ClientAttestationPoPBuilder {
     challenge: String?
   ) async throws -> ClientAttestationPoPJWT {
     switch client {
-    case .attested(_, _, let jwk, let popJwtSpec, let clientAttestationProvider):
-      let (attestationJWT, signingKey) = try await clientAttestationProvider(authServerId)
-      
+    case .attested(let clientId, _, let jwk, let popJwtSpec, let clientAttestationProvider):
+      let (_, signingKey) = try await clientAttestationProvider(authServerId)
+
       let now = Date().timeIntervalSince1970
       let exp = Date().addingTimeInterval(popJwtSpec.duration).timeIntervalSince1970
       let payload: [String: Any?] = [
-        JWTClaimNames.issuer: attestationJWT.clientId,
+        JWTClaimNames.issuer: clientId,
         JWTClaimNames.jwtId: String.randomBase64URLString(length: 20),
         JWTClaimNames.expirationTime: exp,
         JWTClaimNames.issuedAt: now,
         JWTClaimNames.audience: authServerId.absoluteString,
-        JWTClaimNames.cnf: try attestationJWT.cnf.jwk.toDictionary(),
+        JWTClaimNames.cnf: try jwk.toDictionary(),
         JWTClaimNames.challenge: challenge
       ]
       

--- a/Sources/Main/Authorisers/AuthorizationServerClient.swift
+++ b/Sources/Main/Authorisers/AuthorizationServerClient.swift
@@ -908,7 +908,7 @@ private extension AuthorizationServerClient {
     }
     
     return [
-      Constants.OAUTH_CLIENT_ATTESTATION: clientAttestation.0.jws.compactSerializedString,
+      Constants.OAUTH_CLIENT_ATTESTATION: clientAttestation.0.value,
       Constants.OAUTH_CLIENT_ATTESTATION_POP: clientAttestation.1.jws.compactSerializedString
     ]
   }
@@ -979,7 +979,7 @@ private extension AuthorizationServerClient {
     )
 
     return ([
-      Constants.OAUTH_CLIENT_ATTESTATION: attestationJWT.jws.compactSerializedString,
+      Constants.OAUTH_CLIENT_ATTESTATION: attestationJWT.value,
       Constants.OAUTH_CLIENT_ATTESTATION_POP: popJWT.jws.compactSerializedString
     ], signingKey)
   }

--- a/Tests/AttestationBased/AttestationBasedTests.swift
+++ b/Tests/AttestationBased/AttestationBasedTests.swift
@@ -25,15 +25,16 @@ class AttestationBasedTests: XCTestCase {
   func testClientAttestation() async throws {
 
     let jwt = try makeWIAJWT()
-    let clientAttestation = try ClientAttestationJWT(
-      jws: JWS(compactSerialization: jwt)
-    )
+    let clientAttestation = ClientAttestationJWT(jwt)
 
-    XCTAssertEqual(clientAttestation.clientId, "test-client")
-    XCTAssertEqual(clientAttestation.claimsSet.walletName.value, "Test Wallet Solution")
-    XCTAssertEqual(clientAttestation.claimsSet.walletVersion.value, "1.0.0")
-    XCTAssertEqual(clientAttestation.claimsSet.clientStatus.status.statusList.index, 0)
-    XCTAssertNotNil(clientAttestation.publicKey)
+    XCTAssertEqual(clientAttestation.value, jwt)
+
+    let claims = try clientAttestation.decodeAsClientAttestationClaims()
+    XCTAssertEqual(claims.subject.value, "test-client")
+    XCTAssertEqual(claims.walletName.value, "Test Wallet Solution")
+    XCTAssertEqual(claims.walletVersion.value, "1.0.0")
+    XCTAssertEqual(claims.clientStatus.status.statusList.index, 0)
+    XCTAssertNotNil(claims.confirmation.jwk)
   }
   
   func testClientAttestationPopJwt() async throws {
@@ -129,103 +130,34 @@ class AttestationBasedTests: XCTestCase {
     XCTAssertNotNil(clientES512, "ES512 should be accepted")
   }
 
-  func testClientAttestationWithInvalidAlgorithm_shouldFail() async throws {
-    // Test that RS256 (RSA) is rejected
-    // Create a JWT with RS256 algorithm in the header
+  func testClientAttestation_constructionIsRelaxed() async throws {
+    // Callers that need TS3 validation must opt in via `decodeAsClientAttestationClaims()`.
     let now = Date().timeIntervalSince1970
     let exp = Date().addingTimeInterval(300).timeIntervalSince1970
 
     let headerDict: [String: Any] = [
       "alg": "RS256",
-      "typ": "oauth-client-attestation+jwt"
+      "typ": "wrong+jwt"
     ]
 
     let payloadDict: [String: Any] = [
       "iss": "test-client",
-      "aud": "test-client",
       "sub": "test-client",
       "iat": now,
-      "exp": exp,
-      "cnf": [
-        "jwk": [
-          "kty": "RSA",
-          "n": "test",
-          "e": "AQAB"
-        ]
-      ]
+      "exp": exp
     ]
 
     let headerData = try JSONSerialization.data(withJSONObject: headerDict)
     let payloadData = try JSONSerialization.data(withJSONObject: payloadDict)
 
-    let headerB64 = base64URLEncode(headerData)
-    let payloadB64 = base64URLEncode(payloadData)
-    let signature = "fake-signature"
+    let compactJWT = "\(base64URLEncode(headerData)).\(base64URLEncode(payloadData)).fake-signature"
 
-    let compactJWT = "\(headerB64).\(payloadB64).\(signature)"
-    let jws = try JWS(compactSerialization: compactJWT)
+    // Construction succeeds — no parsing, no algorithm, no typ, no claims validation.
+    let attestation = ClientAttestationJWT(compactJWT)
+    XCTAssertEqual(attestation.value, compactJWT)
 
-    // Should throw invalidAlgorithm error
-    XCTAssertThrowsError(try ClientAttestationJWT(jws: jws)) { error in
-      guard let attestationError = error as? ClientAttestationError,
-            case .invalidAlgorithm(let allowed) = attestationError else {
-        XCTFail("Expected ClientAttestationError.invalidAlgorithm, got \(error)")
-        return
-      }
-
-      // Verify the error includes all allowed algorithms
-      XCTAssertEqual(allowed.sorted(), ["ES256", "ES384", "ES512"])
-
-      // Verify error message is descriptive
-      let errorMessage = attestationError.errorDescription ?? ""
-      XCTAssertTrue(errorMessage.contains("ES256"))
-      XCTAssertTrue(errorMessage.contains("ES384"))
-      XCTAssertTrue(errorMessage.contains("ES512"))
-    }
-  }
-
-  func testClientAttestationWithHMACAlgorithm_shouldFail() async throws {
-    // Test that HS256 (HMAC) is rejected
-    let now = Date().timeIntervalSince1970
-    let exp = Date().addingTimeInterval(300).timeIntervalSince1970
-
-    let headerDict: [String: Any] = [
-      "alg": "HS256",
-      "typ": "oauth-client-attestation+jwt"
-    ]
-
-    let payloadDict: [String: Any] = [
-      "iss": "test-client",
-      "aud": "test-client",
-      "sub": "test-client",
-      "iat": now,
-      "exp": exp,
-      "cnf": [
-        "jwk": [
-          "kty": "oct",
-          "k": "test"
-        ]
-      ]
-    ]
-
-    let headerData = try JSONSerialization.data(withJSONObject: headerDict)
-    let payloadData = try JSONSerialization.data(withJSONObject: payloadDict)
-
-    let headerB64 = base64URLEncode(headerData)
-    let payloadB64 = base64URLEncode(payloadData)
-    let signature = "fake-signature"
-
-    let compactJWT = "\(headerB64).\(payloadB64).\(signature)"
-    let jws = try JWS(compactSerialization: compactJWT)
-
-    // Should throw invalidAlgorithm error
-    XCTAssertThrowsError(try ClientAttestationJWT(jws: jws)) { error in
-      guard let attestationError = error as? ClientAttestationError,
-            case .invalidAlgorithm = attestationError else {
-        XCTFail("Expected ClientAttestationError.invalidAlgorithm, got \(error)")
-        return
-      }
-    }
+    // Opt-in validation still surfaces TS3 issues.
+    XCTAssertThrowsError(try attestation.decodeAsClientAttestationClaims())
   }
 
   // Helper function for base64 URL encoding
@@ -237,13 +169,17 @@ class AttestationBasedTests: XCTestCase {
     return base64String
   }
 
-  // MARK: - TS3 WIA validation tests
+  // MARK: - TS3 WIA opt-in validation tests
+
+  private func attestation(_ jwt: String) -> ClientAttestationJWT {
+    ClientAttestationJWT(jwt)
+  }
 
   func testWIA_missingWalletName_shouldFail() throws {
     let jwt = try makeWIAJWT { payload in
       payload.removeValue(forKey: "wallet_name")
     }
-    XCTAssertThrowsError(try ClientAttestationJWT(jws: JWS(compactSerialization: jwt))) { error in
+    XCTAssertThrowsError(try attestation(jwt).decodeAsClientAttestationClaims()) { error in
       guard case ClientAttestationError.missingWalletName = error else {
         XCTFail("Expected missingWalletName, got \(error)"); return
       }
@@ -254,7 +190,7 @@ class AttestationBasedTests: XCTestCase {
     let jwt = try makeWIAJWT { payload in
       payload.removeValue(forKey: "wallet_version")
     }
-    XCTAssertThrowsError(try ClientAttestationJWT(jws: JWS(compactSerialization: jwt))) { error in
+    XCTAssertThrowsError(try attestation(jwt).decodeAsClientAttestationClaims()) { error in
       guard case ClientAttestationError.missingWalletVersion = error else {
         XCTFail("Expected missingWalletVersion, got \(error)"); return
       }
@@ -265,7 +201,7 @@ class AttestationBasedTests: XCTestCase {
     let jwt = try makeWIAJWT { payload in
       payload.removeValue(forKey: "wallet_solution_certification_information")
     }
-    XCTAssertThrowsError(try ClientAttestationJWT(jws: JWS(compactSerialization: jwt))) { error in
+    XCTAssertThrowsError(try attestation(jwt).decodeAsClientAttestationClaims()) { error in
       guard case ClientAttestationError.missingWalletSolutionCertificationInformation = error else {
         XCTFail("Expected missingWalletSolutionCertificationInformation, got \(error)"); return
       }
@@ -276,7 +212,7 @@ class AttestationBasedTests: XCTestCase {
     let jwt = try makeWIAJWT { payload in
       payload.removeValue(forKey: "client_status")
     }
-    XCTAssertThrowsError(try ClientAttestationJWT(jws: JWS(compactSerialization: jwt))) { error in
+    XCTAssertThrowsError(try attestation(jwt).decodeAsClientAttestationClaims()) { error in
       guard case ClientAttestationError.missingClientStatus = error else {
         XCTFail("Expected missingClientStatus, got \(error)"); return
       }
@@ -289,7 +225,7 @@ class AttestationBasedTests: XCTestCase {
       cs.removeValue(forKey: "exp")
       payload["client_status"] = cs
     }
-    XCTAssertThrowsError(try ClientAttestationJWT(jws: JWS(compactSerialization: jwt))) { error in
+    XCTAssertThrowsError(try attestation(jwt).decodeAsClientAttestationClaims()) { error in
       guard case ClientAttestationError.invalidClientStatus = error else {
         XCTFail("Expected invalidClientStatus, got \(error)"); return
       }
@@ -302,7 +238,7 @@ class AttestationBasedTests: XCTestCase {
       cs["status"] = [String: Any]()
       payload["client_status"] = cs
     }
-    XCTAssertThrowsError(try ClientAttestationJWT(jws: JWS(compactSerialization: jwt))) { error in
+    XCTAssertThrowsError(try attestation(jwt).decodeAsClientAttestationClaims()) { error in
       guard case ClientAttestationError.invalidStatusListReference = error else {
         XCTFail("Expected invalidStatusListReference, got \(error)"); return
       }
@@ -313,20 +249,9 @@ class AttestationBasedTests: XCTestCase {
     let jwt = try makeWIAJWT { payload in
       payload["wallet_name"] = "   "
     }
-    XCTAssertThrowsError(try ClientAttestationJWT(jws: JWS(compactSerialization: jwt))) { error in
+    XCTAssertThrowsError(try attestation(jwt).decodeAsClientAttestationClaims()) { error in
       guard case ClientAttestationError.blankClaim(let name) = error, name == "wallet_name" else {
         XCTFail("Expected blankClaim(wallet_name), got \(error)"); return
-      }
-    }
-  }
-
-  func testWIA_wrongTypHeader_shouldFail() throws {
-    let jwt = try makeWIAJWT(typHeader: "wrong+jwt")
-    XCTAssertThrowsError(try ClientAttestationJWT(jws: JWS(compactSerialization: jwt))) { error in
-      guard case ClientAttestationError.invalidTypHeader(let expected, let got) = error,
-            expected == "oauth-client-attestation+jwt",
-            got == "wrong+jwt" else {
-        XCTFail("Expected invalidTypHeader, got \(error)"); return
       }
     }
   }
@@ -335,7 +260,7 @@ class AttestationBasedTests: XCTestCase {
     let jwt = try makeWIAJWT { payload in
       payload.removeValue(forKey: "iss")
     }
-    XCTAssertThrowsError(try ClientAttestationJWT(jws: JWS(compactSerialization: jwt))) { error in
+    XCTAssertThrowsError(try attestation(jwt).decodeAsClientAttestationClaims()) { error in
       guard case ClientAttestationError.missingIssuerClaim = error else {
         XCTFail("Expected missingIssuerClaim, got \(error)"); return
       }
@@ -346,7 +271,7 @@ class AttestationBasedTests: XCTestCase {
     let jwt = try makeWIAJWT { payload in
       payload.removeValue(forKey: "sub")
     }
-    XCTAssertThrowsError(try ClientAttestationJWT(jws: JWS(compactSerialization: jwt))) { error in
+    XCTAssertThrowsError(try attestation(jwt).decodeAsClientAttestationClaims()) { error in
       guard case ClientAttestationError.missingSubject = error else {
         XCTFail("Expected missingSubject, got \(error)"); return
       }
@@ -363,11 +288,132 @@ class AttestationBasedTests: XCTestCase {
       cs["status"] = status
       payload["client_status"] = cs
     }
-    XCTAssertThrowsError(try ClientAttestationJWT(jws: JWS(compactSerialization: jwt))) { error in
+    XCTAssertThrowsError(try attestation(jwt).decodeAsClientAttestationClaims()) { error in
       guard case ClientAttestationError.invalidStatusListReference = error else {
         XCTFail("Expected invalidStatusListReference, got \(error)"); return
       }
     }
+  }
+
+  // MARK: - AS algorithm cross-check (ensureSupportedByAuthorizationServer)
+
+  private func makeAttestedClient(
+    attestationAlg: JWSAlgorithm.AlgorithmType = .ES256,
+    popAlg: SignatureAlgorithm = .ES256
+  ) throws -> Client {
+    let privateKey = try KeyController.generateECDHPrivateKey()
+    let jwk = try ECPublicKey(publicKey: try KeyController.generateECDHPublicKey(from: privateKey))
+    return try .attested(
+      id: "test-client",
+      alg: .init(attestationAlg),
+      jwk: jwk,
+      popJwtSpec: .init(signingAlgorithm: popAlg, duration: 300, typ: "oauth-client-attestation-pop+jwt"),
+      clientAttestationProvider: { _ in
+        fatalError("provider must not be invoked from ensureSupportedByAuthorizationServer")
+      }
+    )
+  }
+
+  private func makeAuthorizationServerMetadata(
+    tokenEndpointAuthMethods: [String]? = ["attest_jwt_client_auth"],
+    attestationAlgs: [String]? = ["ES256"],
+    popAlgs: [String]? = ["ES256"]
+  ) -> IdentityAndAccessManagementMetadata {
+    .oauth(AuthorizationServerMetadata(
+      tokenEndpointAuthMethodsSupported: tokenEndpointAuthMethods,
+      clientAttestationSigningAlgValuesSupported: attestationAlgs,
+      clientAttestationPopSigningAlgValuesSupported: popAlgs
+    ))
+  }
+
+  func testEnsureSupportedByAS_acceptsMatchingAlgorithms() throws {
+    let client = try makeAttestedClient(attestationAlg: .ES256, popAlg: .ES256)
+    let metadata = makeAuthorizationServerMetadata(
+      attestationAlgs: ["ES256", "ES384"],
+      popAlgs: ["ES256"]
+    )
+    XCTAssertNoThrow(try client.ensureSupportedByAuthorizationServer(metadata))
+  }
+
+  func testEnsureSupportedByAS_rejectsUnsupportedAttestationAlg() throws {
+    let client = try makeAttestedClient(attestationAlg: .ES512, popAlg: .ES256)
+    let metadata = makeAuthorizationServerMetadata(
+      attestationAlgs: ["ES256"],
+      popAlgs: ["ES256"]
+    )
+    XCTAssertThrowsError(try client.ensureSupportedByAuthorizationServer(metadata)) { error in
+      guard case ValidationError.error(let reason) = error else {
+        XCTFail("Expected ValidationError.error, got \(error)"); return
+      }
+      XCTAssertTrue(reason.contains("ES512"))
+      XCTAssertTrue(reason.contains("Client Attestation JWS Algorithm"))
+    }
+  }
+
+  func testEnsureSupportedByAS_rejectsUnsupportedPopAlg() throws {
+    let client = try makeAttestedClient(attestationAlg: .ES256, popAlg: .ES384)
+    let metadata = makeAuthorizationServerMetadata(
+      attestationAlgs: ["ES256"],
+      popAlgs: ["ES256"]
+    )
+    XCTAssertThrowsError(try client.ensureSupportedByAuthorizationServer(metadata)) { error in
+      guard case ValidationError.error(let reason) = error else {
+        XCTFail("Expected ValidationError.error, got \(error)"); return
+      }
+      XCTAssertTrue(reason.contains("ES384"))
+      XCTAssertTrue(reason.contains("POP JWS Algorithm"))
+    }
+  }
+
+  func testEnsureSupportedByAS_rejectsWhenAttestationAlgsMissing() throws {
+    let client = try makeAttestedClient()
+    let metadata = makeAuthorizationServerMetadata(
+      attestationAlgs: nil,
+      popAlgs: ["ES256"]
+    )
+    XCTAssertThrowsError(try client.ensureSupportedByAuthorizationServer(metadata)) { error in
+      guard case ValidationError.error(let reason) = error else {
+        XCTFail("Expected ValidationError.error, got \(error)"); return
+      }
+      XCTAssertTrue(reason.contains("Client Attestation JWS Algorithm"))
+    }
+  }
+
+  func testEnsureSupportedByAS_rejectsWhenPopAlgsMissing() throws {
+    let client = try makeAttestedClient()
+    let metadata = makeAuthorizationServerMetadata(
+      attestationAlgs: ["ES256"],
+      popAlgs: nil
+    )
+    XCTAssertThrowsError(try client.ensureSupportedByAuthorizationServer(metadata)) { error in
+      guard case ValidationError.error(let reason) = error else {
+        XCTFail("Expected ValidationError.error, got \(error)"); return
+      }
+      XCTAssertTrue(reason.contains("POP JWS Algorithm"))
+    }
+  }
+
+  func testEnsureSupportedByAS_rejectsWhenAuthMethodMissing() throws {
+    let client = try makeAttestedClient()
+    let metadata = makeAuthorizationServerMetadata(
+      tokenEndpointAuthMethods: ["client_secret_basic"]
+    )
+    XCTAssertThrowsError(try client.ensureSupportedByAuthorizationServer(metadata)) { error in
+      guard case ValidationError.error(let reason) = error else {
+        XCTFail("Expected ValidationError.error, got \(error)"); return
+      }
+      XCTAssertTrue(reason.contains("attest_jwt_client_auth"))
+    }
+  }
+
+  func testEnsureSupportedByAS_publicClientIsUnchecked() throws {
+    let client = Client(public: "public-client")
+    let metadata = makeAuthorizationServerMetadata(
+      tokenEndpointAuthMethods: [],
+      attestationAlgs: nil,
+      popAlgs: nil
+    )
+    XCTAssertNoThrow(try client.ensureSupportedByAuthorizationServer(metadata))
   }
 
   // MARK: - WIA builder

--- a/Tests/Helpers/SelfSignedClientAttestation.swift
+++ b/Tests/Helpers/SelfSignedClientAttestation.swift
@@ -40,10 +40,7 @@ internal func jwkProviderSignedClient(
     ]
   )
 
-  // Pre-validate the WIA here so TS3 parsing failures surface as throws.
-  let attestationJWT = try ClientAttestationJWT(
-    jws: JWS(compactSerialization: attestation.walletInstanceAttestation)
-  )
+  let attestationJWT = ClientAttestationJWT(attestation.walletInstanceAttestation)
 
   @Sendable func getSignerFrom(authServer: URL) -> SigningKeyProxy {
     .secKey(privateKey)
@@ -89,9 +86,8 @@ internal func jwkSetProviderSignedClient(
     ]
   )
 
-  // Pre-validate the WIA here so TS3 parsing failures surface as throws,
-  let attestationJWT = try ClientAttestationJWT(
-    jws: JWS(compactSerialization: attestation.walletUnitAttestation)
+  let attestationJWT = ClientAttestationJWT(
+    jws: try JWS(compactSerialization: attestation.walletUnitAttestation)
   )
 
   @Sendable func getSignerFrom(authServer: URL) -> SigningKeyProxy {
@@ -156,8 +152,8 @@ internal func attestedClient(
       let proxy = getSignerFrom(authServer: authServer)
       let walletInstanceAttestation = try await client.issueWalletInstanceAttestation(payload: ["jwk": jwk.toDictionary()])
       return (
-        try! .init(
-          jws: .init(compactSerialization: walletInstanceAttestation.walletInstanceAttestation)
+        .init(
+          jws: try .init(compactSerialization: walletInstanceAttestation.walletInstanceAttestation)
         ),
         proxy
       )


### PR DESCRIPTION
# Description of change

Relaxes `ClientAttestationJWT` from a strictly-validated struct into a
lightweight passthrough over the compact-serialized JWT string produced
by the wallet's `ClientAttestationProvider`. 


After this change:

- `ClientAttestationJWT` stores a `value: String` — byte-identical to
  what the provider returned. No parsing, no re-normalization.
- Construction never throws. Callers that want TS3 validation opt in via
  `attestation.decodeAsClientAttestationClaims()` or supply their own
  `Decodable` schema via `attestation.decodeClaimsSet(MySchema.self)`.
- The default PoP JWT builder now reads `iss` and `cnf` from the
  advertised `Client.attested(id:jwk:…)` fields instead of parsing them
  out of the attestation.
- `Client.ensureSupportedByAuthorizationServer` (internal) additionally
  cross-checks the wallet's advertised attestation and PoP signing
  algorithms against the AS's `client_attestation_signing_alg_values_supported`
  and `client_attestation_pop_signing_alg_values_supported` metadata.
- `IdentityAndAccessManagementMetadata` gains a new
  `clientAttestationSigningAlgValuesSupported` accessor to expose the
  first of those two fields (the PoP accessor was already present).


## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Breaking changes on the public API

Compile-time removals on `ClientAttestationJWT`:
- Removed `jws: JWS` (replaced by `value: String`).
- Removed `claimsSet`, `header`, `clientId`, `cnf`, `publicKey`,
  `pubKey`.
- Removed `init(jwt: String) throws`. Use `init(_ value: String)` or
  the retained `init(jws: JWS)` convenience.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
