### PR TITLE
fix: use injected clock and emit integer NumericDates in attestation

### DIFF
--- a/Sources/Main/AttestationBasedClient/ClientAttestationPoPBuilder.swift
+++ b/Sources/Main/AttestationBasedClient/ClientAttestationPoPBuilder.swift
@@ -61,8 +61,9 @@ public struct DefaultClientAttestationPoPBuilder: ClientAttestationPoPBuilder {
     case .attested(let clientId, _, let jwk, let popJwtSpec, let clientAttestationProvider):
       let (_, signingKey) = try await clientAttestationProvider(authServerId)
 
-      let now = Date().timeIntervalSince1970
-      let exp = Date().addingTimeInterval(popJwtSpec.duration).timeIntervalSince1970
+      let issuedAt = clock.now()
+      let now = Int(issuedAt.timeIntervalSince1970)
+      let exp = Int(issuedAt.addingTimeInterval(popJwtSpec.duration).timeIntervalSince1970)
       let payload: [String: Any?] = [
         JWTClaimNames.issuer: clientId,
         JWTClaimNames.jwtId: String.randomBase64URLString(length: 20),

--- a/Tests/AttestationBased/AttestationBasedTests.swift
+++ b/Tests/AttestationBased/AttestationBasedTests.swift
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Foundation
+@preconcurrency import Foundation
 import XCTest
-import JOSESwift
+@preconcurrency import JOSESwift
 import SwiftyJSON
 
 @testable import OpenID4VCI
@@ -99,6 +99,52 @@ class AttestationBasedTests: XCTestCase {
         return XCTFail("Expected ClientAttestationError.invalidClient, got \(error)")
       }
     }
+  }
+
+  func testPopBuilder_usesInjectedClock_andEmitsIntegerNumericDates() async throws {
+    struct FixedClock: ClockType {
+      let instant: Date
+      func now() -> Date { instant }
+    }
+
+    let fixedInstant = Date(timeIntervalSince1970: 1_700_000_000)
+    let fixedEpoch = 1_700_000_000
+    let duration: TimeInterval = 300
+
+    let privateKey = try KeyController.generateECDHPrivateKey()
+    let jwk = try ECPublicKey(publicKey: try KeyController.generateECDHPublicKey(from: privateKey))
+
+    @Sendable func signer() -> SigningKeyProxy {
+      .secKey(privateKey)
+    }
+
+    let client: Client = try .attested(
+      id: "test-client",
+      alg: .init(.ES256),
+      jwk: jwk,
+      popJwtSpec: .init(signingAlgorithm: .ES256, duration: duration, typ: "oauth-client-attestation-pop+jwt"),
+      clientAttestationProvider: { _ in
+        (ClientAttestationJWT(""), signer())
+      }
+    )
+
+    let pop = try await DefaultClientAttestationPoPBuilder().buildAttestationPoPJWT(
+      for: client,
+      algorithm: .ES256,
+      clock: FixedClock(instant: fixedInstant),
+      authServerId: URL(string: "https://as.example.com")!,
+      challenge: nil
+    )
+
+    let payload = JSON(pop.jws.payload.data())
+    XCTAssertEqual(payload["iat"].int, fixedEpoch, "iat must equal the injected clock's epoch second")
+    XCTAssertEqual(payload["exp"].int, fixedEpoch + Int(duration), "exp must equal iat + popJwtSpec.duration")
+
+    // Guard against fractional-seconds regression by inspecting the serialised bytes:
+    // if the number carried a decimal, the substring "<epoch>." would appear.
+    let raw = String(data: pop.jws.payload.data(), encoding: .utf8) ?? ""
+    XCTAssertFalse(raw.contains("\(fixedEpoch)."), "iat must not be serialised with fractional seconds")
+    XCTAssertFalse(raw.contains("\(fixedEpoch + Int(duration))."), "exp must not be serialised with fractional seconds")
   }
 
   func testClientAttestationWithValidAlgorithms_shouldSucceed() async throws {


### PR DESCRIPTION
# Description of change

Fixes two bugs in `DefaultClientAttestationPoPBuilder.buildAttestationPoPJWT`

1. **The injected `clock: ClockType` was ignored.** The builder called
   `Date()` directly for both `iat` and `exp`, so any clock-skew handling
   or test-time injection had no effect, and the two separate `Date()`
   calls left a millisecond-level race between the two claims.
2. **`iat` and `exp` were serialised as `Double` fractional seconds** —
   e.g. `"iat": 1753800000.483` — because `TimeInterval.timeIntervalSince1970`
   is a `Double`. RFC 7519 §2 defines `NumericDate` as "the number of
   seconds ... ignoring leap seconds", and RFC 8725 §3.11 recommends
   integer seconds; many strict authorization-server validators reject
   fractional values.

The fix takes a single `clock.now()` snapshot and casts both epoch
values to `Int` before adding them to the payload, so `iat` and `exp`
are (a) both derived from the same instant and (b) emitted as integer
NumericDates.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Closes #304 
