### PR TITLE
Support WRP Registration Certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,10 +145,15 @@ The OpenID4VCI specification defines two flows of issuance:
 
 The ```Issuer``` is the component that facilitates the authorization and submission of a credential issuance request.
 It consists of two components:
-- **IssuanceAuthorizer**: A component responsible for all interactions with an authorization server to authorize a request for credential issuance.
+- **AuthorizeIssuance**: A component responsible for all interactions with an authorization server to authorize a request for credential issuance.
 - **IssuanceRequester**: A component responsible for all interactions with a credential issuer for submitting credential issuance requests.
 
 #### Initialize an Issuer
+
+Two construction paths are supported:
+
+**Direct initialisation** — for wallets that do not enable WRP Registration
+Certificate (WRPRC) enforcement:
 
 ```swift
 import OpenID4VCI
@@ -164,6 +169,28 @@ let issuer = try Issuer(
     config: config
 )
 ```
+
+**`Issuer.make(...)` factory** — required when
+`config.registrationCertificatePolicy` is set. Runs WRPRC policy enforcement
+against the resolved offer and returns an `IssuerResolutionResult` pairing
+the constructed `Issuer` with any `.warning`-severity policy violations:
+
+```swift
+import OpenID4VCI
+
+let result = try await Issuer.make(
+    credentialOffer: offer,
+    config: config,
+    session: session
+)
+let issuer = result.issuer
+let warnings = result.warnings  // [PolicyViolation]
+```
+
+Setting `registrationCertificatePolicy` while `issuerMetadataPolicy` is
+`.preferSigned` or `.ignoreSigned` trips a `preconditionFailure` at
+`OpenId4VCIConfig` construction — WRPRC enforcement requires a
+cryptographically bound issuer metadata signer.
 
 #### Authorize request via Authorization Code Flow
 
@@ -286,11 +313,14 @@ public struct OpenId4VCIConfig: Sendable {
   public let client: Client
   public let authFlowRedirectionURI: URL
   public let authorizeIssuanceConfig: AuthorizeIssuanceConfig
-  public let requirePAR: Bool
-  public let dPoPConstructor: DPoPConstructorType?
+  public let requirePAR: ParUsage
   public let clientAttestationPoPBuilder: ClientAttestationPoPBuilder?
   public let issuerMetadataPolicy: IssuerMetadataPolicy
+  public let supportedCompressionAlgorithms: [CompressionAlgorithm]?
+  public let requireDpop: Bool
+  public let supportedCredentialReusePolicies: SupportedCredentialReusePolicies
   public let proofTypesPolicy: ProofTypesPolicy
+  public let registrationCertificatePolicy: RegistrationCertificatePolicy?
 }
 ```
 
@@ -300,11 +330,16 @@ public struct OpenId4VCIConfig: Sendable {
 
 - `authFlowRedirectionURI`: It is the `redirect_uri` parameter that will be included in a PAR or simple authorization request.
 - `authorizeIssuanceConfig`: An enum that allows you to favour scopes or authorization details, favour scopes is the default.
-- `requirePAR`: Force the usage of PAR if the authorization server supports it. Fail if true and not supported by server
-- `dPoPConstructor`: If dpop is supported this option constructs what is required.
+- `requirePAR`: A `ParUsage` enum that controls whether Pushed Authorization Requests are required (`.required(authorizationCodeDPoPBinding:)`) or never used (`.never`).
 - `clientAttestationPoPBuilder`: If the authorization supports client attestations, this object constructs what is required.
-- `issuerMetadataPolicy`: Trust between the Wallet and the Signer of the signed metadata advertised by the Credential Issuer is established using this configuration option.
+- `issuerMetadataPolicy`: Trust between the Wallet and the Signer of the signed metadata advertised by the Credential Issuer is established using this configuration option. `.requireSigned` and `.preferSigned` both take an `IssuerTrust.byCertificateChain(certificateChainTrust:)` (JWK-based pinning was removed in favour of chain-of-trust rooted in the EU List of Trusted Lists).
+- `supportedCompressionAlgorithms`: Optional list of `CompressionAlgorithm`s the wallet advertises support for when negotiating signed metadata / request compression. `nil` means the wallet does not advertise compression support.
+- `requireDpop`: If `true`, the wallet requires the authorization server to support DPoP. If DPoP is not supported by the server the issuance flow is halted.
+- `supportedCredentialReusePolicies`: The set of credential reuse policies the wallet is willing to honour. Defaults to `.notSupported`.
 - `proofTypesPolicy`: Policy defining which proof types the wallet supports. See [Proof Types Policy Configuration](#proof-types-policy-configuration) for details.
+- `registrationCertificatePolicy`: Optional. When set, activates WRP Registration Certificate (WRPRC) enforcement in `Issuer.make(...)`. Carries an `IssuerTrust` for the WRPRC signing chain and an `Authorize` closure that receives the WRPAC, decoded WRPRC payload, and offered credential configurations, and returns an `Authorization` — either `.granted(warnings:)` or `.notGranted(error:)`. Requires `issuerMetadataPolicy = .requireSigned(...)` (checked at construction). Defaults to `nil` (no WRPRC enforcement).
+
+The DPoP constructor itself is passed as a parameter to `Issuer(...)` / `Issuer.make(...)`, not stored on `OpenId4VCIConfig`.
 
 ### Proof Types Policy Configuration
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ let issuer = try Issuer(
 **`Issuer.make(...)` factory** — required when
 `config.registrationCertificatePolicy` is set. Runs WRPRC policy enforcement
 against the resolved offer and returns an `IssuerResolutionResult` pairing
-the constructed `Issuer` with any `.warning`-severity policy violations:
+the constructed `Issuer` with any warnings produced by the policy:
 
 ```swift
 import OpenID4VCI
@@ -184,13 +184,55 @@ let result = try await Issuer.make(
     session: session
 )
 let issuer = result.issuer
-let warnings = result.warnings  // [PolicyViolation]
+let warnings = result.warnings  // [String: [PolicyViolation]]
+```
+
+The library treats the WRPRC as an opaque `String` and delegates every trust
+and signature decision to the caller-supplied policy. Library responsibilities
+are limited to:
+
+1. Enforcing WRPRC presence — exactly one `registration_cert`-format entry in
+   `issuer_info` when a policy is configured (per CIR 2024/2082).
+2. Ensuring the WRPAC is available on the resolved metadata.
+3. Applying the caller's policy and acting on its result.
+
+The policy receives:
+
+- **WRPAC** — the WRP Access Certificate (base64 DER, single X.509 leaf) that
+  signed the issuer metadata.
+- **WRPRC** — the raw registration certificate value as delivered in
+  `issuer_info` (a `String`, typically a JWT). Parse it yourself if you need
+  to inspect the leaf/chain and perform your own trust checks.
+- **offeredConfigurations** — the credential configurations referenced by the
+  resolved `CredentialOffer`.
+
+...and returns an `Authorization`:
+
+- `.granted(warnings: [String: [PolicyViolation]] = [:])` — resolution succeeds.
+  Warnings are keyed by a caller-defined bucket; convention is to key by
+  `CredentialConfigurationIdentifier.value` so a wallet UI can render warnings
+  next to each credential option, and use `"global"` for request-wide warnings.
+- `.notGranted(error: PolicyViolation)` — resolution fails with
+  `WRPRCError.policyNotMet(error)`.
+
+```swift
+let policy = RegistrationCertificatePolicy { wrpac, wrprc, offered in
+    // Parse/verify the raw WRPRC yourself if your policy needs it.
+    if /* reject */ {
+        return .notGranted(error: PolicyViolation("reason for rejection"))
+    }
+    var warnings: [String: [PolicyViolation]] = [:]
+    for id in offered.keys {
+        // ...evaluate per credential; append to warnings[id.value]...
+    }
+    return .granted(warnings: warnings)
+}
 ```
 
 Setting `registrationCertificatePolicy` while `issuerMetadataPolicy` is
 `.preferSigned` or `.ignoreSigned` trips a `preconditionFailure` at
 `OpenId4VCIConfig` construction — WRPRC enforcement requires a
-cryptographically bound issuer metadata signer.
+cryptographically bound issuer metadata signer to supply the WRPAC.
 
 #### Authorize request via Authorization Code Flow
 
@@ -337,7 +379,7 @@ public struct OpenId4VCIConfig: Sendable {
 - `requireDpop`: If `true`, the wallet requires the authorization server to support DPoP. If DPoP is not supported by the server the issuance flow is halted.
 - `supportedCredentialReusePolicies`: The set of credential reuse policies the wallet is willing to honour. Defaults to `.notSupported`.
 - `proofTypesPolicy`: Policy defining which proof types the wallet supports. See [Proof Types Policy Configuration](#proof-types-policy-configuration) for details.
-- `registrationCertificatePolicy`: Optional. When set, activates WRP Registration Certificate (WRPRC) enforcement in `Issuer.make(...)`. Carries an `IssuerTrust` for the WRPRC signing chain and an `Authorize` closure that receives the WRPAC, decoded WRPRC payload, and offered credential configurations, and returns an `Authorization` — either `.granted(warnings:)` or `.notGranted(error:)`. Requires `issuerMetadataPolicy = .requireSigned(...)` (checked at construction). Defaults to `nil` (no WRPRC enforcement).
+- `registrationCertificatePolicy`: Optional. When set, activates WRP Registration Certificate (WRPRC) enforcement in `Issuer.make(...)`. Carries an `Authorize` closure that receives the WRPAC (`String`), the raw opaque WRPRC value (`String`) as delivered in `issuer_info`, and the offered credential configurations, and returns an `Authorization` — either `.granted(warnings: [String: [PolicyViolation]])` or `.notGranted(error: PolicyViolation)`. The library performs no chain-of-trust or signature validation on the WRPRC — those decisions live in the caller's closure. Requires `issuerMetadataPolicy = .requireSigned(...)` (checked at construction). Defaults to `nil` (no WRPRC enforcement).
 
 The DPoP constructor itself is passed as a parameter to `Issuer(...)` / `Issuer.make(...)`, not stored on `OpenId4VCIConfig`.
 

--- a/Sources/Entities/CredentialIssuer/CredentialIssuerMetadata.swift
+++ b/Sources/Entities/CredentialIssuer/CredentialIssuerMetadata.swift
@@ -31,7 +31,10 @@ public struct CredentialIssuerMetadata: Decodable, Equatable, Sendable {
   public let display: [Display]
   public let batchCredentialIssuance: BatchCredentialIssuance?
   public let preferredClientStatusPeriod: Int?
-  
+  public let issuerInfo: IssuerInfo?
+  /// The WRPAC (base64 DER) that signed this issuer metadata.
+  public let wrpac: String?
+
   public enum CodingKeys: String, CodingKey {
     case credentialIssuerIdentifier = "credential_issuer"
     case authorizationServers = "authorization_servers"
@@ -49,6 +52,7 @@ public struct CredentialIssuerMetadata: Decodable, Equatable, Sendable {
     case credentialIdentifiersSupported = "credential_identifiers_supported"
     case batchCredentialIssuance = "batch_credential_issuance"
     case preferredClientStatusPeriod = "preferred_client_status_period"
+    case issuerInfo = "issuer_info"
   }
   
   public init(
@@ -64,7 +68,9 @@ public struct CredentialIssuerMetadata: Decodable, Equatable, Sendable {
     display: [Display]?,
     credentialIdentifiersSupported: Bool? = nil,
     batchCredentialIssuance: BatchCredentialIssuance? = nil,
-    preferredClientStatusPeriod: Int? = nil
+    preferredClientStatusPeriod: Int? = nil,
+    issuerInfo: IssuerInfo? = nil,
+    wrpac: String? = nil
   ) {
     self.credentialIssuerIdentifier = credentialIssuerIdentifier
     self.authorizationServers = authorizationServers
@@ -83,6 +89,8 @@ public struct CredentialIssuerMetadata: Decodable, Equatable, Sendable {
     self.credentialIdentifiersSupported = credentialIdentifiersSupported
     self.batchCredentialIssuance = batchCredentialIssuance
     self.preferredClientStatusPeriod = preferredClientStatusPeriod
+    self.issuerInfo = issuerInfo
+    self.wrpac = wrpac
   }
   
   public init(
@@ -205,9 +213,43 @@ public struct CredentialIssuerMetadata: Decodable, Equatable, Sendable {
       Int.self,
       forKey: .preferredClientStatusPeriod
     )
+
+    issuerInfo = try? container.decodeIfPresent(
+      IssuerInfo.self,
+      forKey: .issuerInfo
+    )
+
+    // `wrpac` is a runtime artifact of signature verification —
+    // never present in metadata JSON. Populated by `MetadataProcessor`.
+    wrpac = nil
   }
-  
+
   public static func == (lhs: CredentialIssuerMetadata, rhs: CredentialIssuerMetadata) -> Bool {
     lhs.credentialIssuerIdentifier == rhs.credentialIssuerIdentifier
+  }
+
+  /// Returns a copy with `wrpac` set to the given leaf certificate.
+  ///
+  /// Used by `MetadataProcessor` to attach the WRP Access Certificate
+  /// (base64 DER, the leaf of the signed-metadata JWS `x5c` header) after
+  /// successful signature verification. Intended for use inside the library.
+  internal func withWrpac(_ wrpac: String?) -> CredentialIssuerMetadata {
+    CredentialIssuerMetadata(
+      credentialIssuerIdentifier: self.credentialIssuerIdentifier,
+      authorizationServers: self.authorizationServers ?? [],
+      credentialEndpoint: self.credentialEndpoint,
+      deferredCredentialEndpoint: self.deferredCredentialEndpoint,
+      nonceEndpoint: self.nonceEndpoint,
+      notificationEndpoint: self.notificationEndpoint,
+      credentialRequestEncryption: self.credentialRequestEncryption ?? .notSupported,
+      credentialResponseEncryption: self.credentialResponseEncryption,
+      credentialConfigurationsSupported: self.credentialsSupported,
+      display: self.display,
+      credentialIdentifiersSupported: self.credentialIdentifiersSupported,
+      batchCredentialIssuance: self.batchCredentialIssuance,
+      preferredClientStatusPeriod: self.preferredClientStatusPeriod,
+      issuerInfo: self.issuerInfo,
+      wrpac: wrpac
+    )
   }
 }

--- a/Sources/Entities/Types/IssuerMetadataPolicy.swift
+++ b/Sources/Entities/Types/IssuerMetadataPolicy.swift
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import Foundation
-@preconcurrency import JOSESwift
 
 /// A protocol for verifying the trustworthiness of a certificate chain.
 public protocol CertificateChainTrust: Sendable {
@@ -28,12 +27,7 @@ public protocol CertificateChainTrust: Sendable {
 
 /// Defines how the issuer's trust is determined.
 public enum IssuerTrust: Sendable {
-  
-  /// Trust is established using a public key contained in a JSON Web Key (JWK).
-  ///
-  /// - Parameter jwk: The JSON Web Key representing the public key.
-  case byPublicKey(jwk: JWK)
-  
+
   /// Trust is established using a certificate chain validation process.
   ///
   /// - Parameter certificateChainTrust: A `CertificateChainTrust` instance that verifies the certificate chain.

--- a/Sources/Entities/Wallet/Config.swift
+++ b/Sources/Entities/Wallet/Config.swift
@@ -88,7 +88,11 @@ public struct OpenId4VCIConfig: Sendable {
   ///
   /// Default is `.haipCompliant()`.
   public let proofTypesPolicy: ProofTypesPolicy
-  
+
+  /// Optional policy that, when set, activates WRP Registration Certificate (WRPRC)
+  /// enforcement during `Issuer.make(...)`. When `nil`, WRPRC is not validated.
+  public let registrationCertificatePolicy: RegistrationCertificatePolicy?
+
   /// Initializes an `OpenId4VCIConfig` instance with the given parameters.
   /// - Parameters:
   ///   - client: The client used for OpenID4VCI operations.
@@ -100,6 +104,7 @@ public struct OpenId4VCIConfig: Sendable {
   ///   - requireDpop: If dpop is supported then use it, otherwise always don't
   ///   - proofTypesPolicy: Policy defining which proof types the wallet supports (default: `.haipCompliant()`).
   ///   - supportedCredentialReusePolicies: Wallet's supported credential reuse policies (default: `.notSupported`).
+  ///   - registrationCertificatePolicy: Optional policy that, when set, activates WRPRC enforcement in `Issuer.make(...)` (default: `nil`).
   public init(
     client: Client,
     authFlowRedirectionURI: URL,
@@ -110,7 +115,8 @@ public struct OpenId4VCIConfig: Sendable {
     supportedCompressionAlgorithms: [CompressionAlgorithm]? = nil,
     proofTypesPolicy: ProofTypesPolicy = .haipCompliant(),
     requireDpop: Bool = true,
-    supportedCredentialReusePolicies: SupportedCredentialReusePolicies = .notSupported
+    supportedCredentialReusePolicies: SupportedCredentialReusePolicies = .notSupported,
+    registrationCertificatePolicy: RegistrationCertificatePolicy? = nil
   ) {
     self.client = client
     self.authFlowRedirectionURI = authFlowRedirectionURI
@@ -122,5 +128,23 @@ public struct OpenId4VCIConfig: Sendable {
     self.requireDpop = requireDpop
     self.supportedCredentialReusePolicies = supportedCredentialReusePolicies
     self.proofTypesPolicy = proofTypesPolicy
+    self.registrationCertificatePolicy = registrationCertificatePolicy
+
+    // When a WRPRC policy is configured, the issuer metadata must be signed —
+    // otherwise there is no cryptographic binding of the `issuer_info` (and
+    // therefore the WRPRC) to the issuer's identity, and no WRP Access
+    // Certificate to hand to the policy validator.
+    if registrationCertificatePolicy != nil {
+      switch issuerMetadataPolicy {
+      case .requireSigned:
+        break
+      case .preferSigned, .ignoreSigned:
+        preconditionFailure(
+          "OpenId4VCIConfig: registrationCertificatePolicy requires " +
+          "issuerMetadataPolicy = .requireSigned(...). " +
+          "Received: \(issuerMetadataPolicy)"
+        )
+      }
+    }
   }
 }

--- a/Sources/Issuers/Issuer.swift
+++ b/Sources/Issuers/Issuer.swift
@@ -327,6 +327,41 @@ public actor Issuer: IssuerType {
     }
   }
   
+  /// Builds an `Issuer` for the given resolved `CredentialOffer` and, when
+  /// `config.registrationCertificatePolicy` is set, enforces the WRP Registration
+  /// Certificate policy first via `IssuanceAuthorizer`.
+  ///
+  /// - Returns: An `IssuerResolutionResult` pairing the constructed `Issuer`
+  ///   with any `.warning`-severity `PolicyViolation`s produced by the policy
+  ///   validator.
+  /// - Throws: `WRPRCError` when the WRPRC is missing / multiple / malformed /
+  ///   untrusted, or when the policy validator produced any `.error` violations.
+  public static func make(
+    credentialOffer: CredentialOffer,
+    config: OpenId4VCIConfig,
+    dpopConstructor: DPoPConstructorType? = nil,
+    session: Networking
+  ) async throws -> IssuerResolutionResult {
+
+    let warnings: [PolicyViolation]
+    if let policy = config.registrationCertificatePolicy {
+      let authorizer = IssuanceAuthorizer(policy: policy)
+      warnings = try await authorizer.authorize(credentialOffer: credentialOffer)
+    } else {
+      warnings = []
+    }
+
+    let issuer = try Issuer(
+      authorizationServerMetadata: credentialOffer.authorizationServerMetadata,
+      issuerMetadata: credentialOffer.credentialIssuerMetadata,
+      config: config,
+      dpopConstructor: dpopConstructor,
+      session: session
+    )
+
+    return IssuerResolutionResult(issuer: issuer, warnings: warnings)
+  }
+
   public func setDeferredResponseEncryptionSpec(_ deferredResponseEncryptionSpec: IssuanceResponseEncryptionSpec?) async {
     self.deferredResponseEncryptionSpec = deferredResponseEncryptionSpec
   }

--- a/Sources/Issuers/Issuer.swift
+++ b/Sources/Issuers/Issuer.swift
@@ -332,10 +332,10 @@ public actor Issuer: IssuerType {
   /// Certificate policy first via `IssuanceAuthorizer`.
   ///
   /// - Returns: An `IssuerResolutionResult` pairing the constructed `Issuer`
-  ///   with any `.warning`-severity `PolicyViolation`s produced by the policy
-  ///   validator.
-  /// - Throws: `WRPRCError` when the WRPRC is missing / multiple / malformed /
-  ///   untrusted, or when the policy validator produced any `.error` violations.
+  ///   with any warnings produced by the policy validator (empty dict means a
+  ///   clean pass).
+  /// - Throws: `WRPRCError` when the WRPRC is missing / multiple / WRPAC missing,
+  ///   or when the policy validator returned `.notGranted`.
   public static func make(
     credentialOffer: CredentialOffer,
     config: OpenId4VCIConfig,
@@ -343,12 +343,12 @@ public actor Issuer: IssuerType {
     session: Networking
   ) async throws -> IssuerResolutionResult {
 
-    let warnings: [PolicyViolation]
+    let warnings: [String: [PolicyViolation]]
     if let policy = config.registrationCertificatePolicy {
       let authorizer = IssuanceAuthorizer(policy: policy)
       warnings = try await authorizer.authorize(credentialOffer: credentialOffer)
     } else {
-      warnings = []
+      warnings = [:]
     }
 
     let issuer = try Issuer(

--- a/Sources/Main/Metadata/MetadataProcessor.swift
+++ b/Sources/Main/Metadata/MetadataProcessor.swift
@@ -16,12 +16,6 @@
 import Foundation
 @preconcurrency import JOSESwift
 
-private enum SignedMetadataValidation {
-  /// Default clock skew (seconds) used for validating `iat` and `exp`.
-  /// Override by changing this value (library integrators can fork/configure).
-  static let clockSkew: TimeInterval = 300
-}
-
 public protocol MetadataProcessing: Sendable {
   func processMetadata(
     rawResponse: RawFetchResponse,
@@ -140,13 +134,41 @@ private extension MetadataProcessor {
     let jws = try JWS(compactSerialization: metadata)
     
     try validateJOSEHeader(jws.header)
-    
-    // Verify signature + claims in one centralized place
-    let verifiedJWS = try await issuerTrust.verify(jws: jws)
-    
+
+    // Signature + chain verification is shared with the WRPRC path via JWSVerification.swift.
+    // Translate the shared helper's errors back into CredentialIssuerMetadataError to preserve
+    // existing metadata-error contracts.
+    let verifiedJWS: JWS
+    do {
+      verifiedJWS = try await issuerTrust.verify(jws: jws)
+    } catch let error as JWSVerificationError {
+      switch error {
+      case .chainNotTrusted:
+        throw CredentialIssuerMetadataError.invalidSignedMetadata(
+          "Failed to verify chain (.byCertificateChain)"
+        )
+      case .invalidCertificateChain(let reason),
+           .verifierCreationFailed(let reason),
+           .signatureInvalid(let reason),
+           .unsupportedAlgorithm(let reason):
+        throw CredentialIssuerMetadataError.invalidSignedMetadata(reason)
+      }
+    }
+
+    // Metadata-specific: assert iss/sub/iat presence on the verified JWS
+    _ = try verifiedJWS.validateSignedMetadataClaims()
+
     let payloadData = verifiedJWS.payload.data()
     let metadata = try JSONDecoder().decode(CredentialIssuerMetadata.self, from: payloadData)
     try validateJWTClaims(jws: verifiedJWS, expectedSubject: issuerId.url.absoluteString)
+
+    // Capture the verified WRPAC (base64 DER — the LEAF of the JWS `x5c`
+    // header) and attach it to the metadata so it can be used later by WRPRC
+    // policy enforcement. The chain has already been trust-validated at this
+    // point; only the leaf carries the WRP's identity.
+    if let leaf = verifiedJWS.header.x5c?.first {
+      return metadata.withWrpac(leaf)
+    }
     return metadata
   }
   
@@ -177,7 +199,7 @@ private extension MetadataProcessor {
     }
     
     let currentTime = Date().timeIntervalSince1970
-    let skew = SignedMetadataValidation.clockSkew
+    let skew = SignedJWTValidation.clockSkew
 
     // iat must not be in the future beyond skew
     if iat > currentTime + skew {
@@ -194,65 +216,6 @@ private extension MetadataProcessor {
       if iat > exp + skew {
         throw CredentialIssuerMetadataError.invalidSignedMetadata("JWT 'iat' is after 'exp'")
       }
-    }
-  }
-}
-
-private extension IssuerTrust {
-  
-  @discardableResult
-  func verify(
-    jws: JWS
-  ) async throws -> JWS {
-    switch self {
-    // NOTE: Only RS256 (RSA) and ES256 (EC P-256) are supported for signed metadata verification.
-    case .byPublicKey(let jwk):
-      let algorithm = try supportedSignatureAlgorithm(for: jwk)
-      
-      guard
-        let key = try JWKSecKeyConverter(jwk: jwk).secKey(),
-        let verifier: Verifier = .init(
-          signatureAlgorithm: algorithm,
-          key: key
-        ) else {
-        throw CredentialIssuerMetadataError.invalidSignedMetadata(
-          "Failed to create verifier"
-        )
-      }
-      return try jws.validate(using: verifier)
-      
-    case .byCertificateChain(let certificateChainTrust):
-      let chain = jws.header.x5c ?? []
-      guard await certificateChainTrust.isValid(chain: chain) else {
-        throw CredentialIssuerMetadataError.invalidSignedMetadata(
-          "Failed to verify chain (.byCertificateChain)"
-        )
-      }
-      
-      let utilities: SecCertificateHelper = .init()
-      guard
-        let first = chain.first,
-        let key = utilities.publicKey(fromPem: first),
-        let algorithm: SignatureAlgorithm = switch key.keyAlgorithm() {
-        case "RSA": .RS256
-        case "EC": .ES256
-        default: nil
-        },
-      let verifier: Verifier = .init(
-        signatureAlgorithm: algorithm,
-        key: key
-      )
-      else {
-        throw CredentialIssuerMetadataError.invalidSignedMetadata(
-          "Failed to create verifier (.byCertificateChain)"
-        )
-      }
-      
-      let verifiedJWS = try jws
-        .validate(using: verifier)
-        .validateSignedMetadataClaims()
-      
-      return verifiedJWS
     }
   }
 }
@@ -290,28 +253,3 @@ private extension JWS {
   }
 }
 
-private extension IssuerTrust {
-  func supportedSignatureAlgorithm(for jwk: JWK) throws -> SignatureAlgorithm {
-    // If the JWK declares an alg, enforce it.
-    if let alg = jwk.parameters["alg"]?.uppercased() {
-      switch alg {
-      case "RS256": return .RS256
-      case "ES256": return .ES256
-      default:
-        throw CredentialIssuerMetadataError.invalidSignedMetadata(
-          "Unsupported JWK alg '\(alg)'. Only RS256 and ES256 are supported."
-        )
-      }
-    }
-
-    // If no alg is declared, fall back to key type, but still only allow RS256/ES256.
-    switch jwk.keyType {
-    case .RSA: return .RS256
-    case .EC:  return .ES256
-    default:
-      throw CredentialIssuerMetadataError.invalidSignedMetadata(
-        "Unsupported key type: \(jwk.keyType). Only RSA (RS256) and EC P-256 (ES256) are supported."
-      )
-    }
-  }
-}

--- a/Sources/RegistrationCertificate/Authorization.swift
+++ b/Sources/RegistrationCertificate/Authorization.swift
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Foundation
+
+/// Outcome of a WRPRC policy evaluation performed by the consumer-supplied
+/// `RegistrationCertificatePolicy.authorize` closure.
+///
+/// - `.granted` — the policy is satisfied. `warnings` may be empty (clean pass)
+///   or contain non-blocking violations the caller should be told about.
+/// - `.notGranted` — the policy is not satisfied. Carries a single blocking
+///   `PolicyViolation` describing why. The library propagates this via
+///   `WRPRCError.policyNotMet(...)` and refuses to construct an `Issuer`.
+public enum Authorization: Sendable, Equatable {
+  case granted(warnings: [PolicyViolation])
+  case notGranted(error: PolicyViolation)
+}

--- a/Sources/RegistrationCertificate/Authorization.swift
+++ b/Sources/RegistrationCertificate/Authorization.swift
@@ -18,12 +18,12 @@ import Foundation
 /// Outcome of a WRPRC policy evaluation performed by the consumer-supplied
 /// `RegistrationCertificatePolicy.authorize` closure.
 ///
-/// - `.granted` — the policy is satisfied. `warnings` may be empty (clean pass)
-///   or contain non-blocking violations the caller should be told about.
+/// - `.granted` — the policy is satisfied. `warnings` is a map keyed by a
+///   caller-defined bucket.
 /// - `.notGranted` — the policy is not satisfied. Carries a single blocking
 ///   `PolicyViolation` describing why. The library propagates this via
 ///   `WRPRCError.policyNotMet(...)` and refuses to construct an `Issuer`.
 public enum Authorization: Sendable, Equatable {
-  case granted(warnings: [PolicyViolation])
+  case granted(warnings: [String: [PolicyViolation]] = [:])
   case notGranted(error: PolicyViolation)
 }

--- a/Sources/RegistrationCertificate/IssuanceAuthorizer.swift
+++ b/Sources/RegistrationCertificate/IssuanceAuthorizer.swift
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Foundation
+import Security
+@preconcurrency import JOSESwift
+@preconcurrency import SwiftyJSON
+
+/// Extracts and validates the WRP Registration Certificate (WRPRC) that accompanies
+/// a resolved `CredentialOffer` and applies the configured
+/// `RegistrationCertificatePolicy` to authorize the issuance transaction.
+public actor IssuanceAuthorizer {
+
+  private let policy: RegistrationCertificatePolicy
+
+  public init(policy: RegistrationCertificatePolicy) {
+    self.policy = policy
+  }
+
+  /// Authorizes the resolved `credentialOffer` against the configured WRPRC policy.
+  ///
+  /// - Returns: The `.warning` violations produced by the policy validator, if any.
+  ///   Empty means the policy applied cleanly.
+  /// - Throws: `WRPRCError` if the WRPRC is missing/multiple/malformed/untrusted,
+  ///   or if the policy validator produced any `.error` violations.
+  public func authorize(credentialOffer: CredentialOffer) async throws -> [PolicyViolation] {
+
+    let issuerMetadata = credentialOffer.credentialIssuerMetadata
+    
+    guard let issuerInfo = issuerMetadata.issuerInfo, !issuerInfo.attestations.isEmpty else {
+      throw WRPRCError.missingIssuerInfo
+    }
+
+    let wrprcAttestations = issuerInfo.attestations.filter {
+      $0.format == ETSI119472Part3.REGISTRATION_CERT
+    }
+
+    // Cardinality: exactly one REGISTRATION_CERT attestation.
+    guard !wrprcAttestations.isEmpty else {
+      throw WRPRCError.missingRequiredRegistrationCertificate
+    }
+    guard wrprcAttestations.count == 1 else {
+      throw WRPRCError.multipleRegistrationCertificates
+    }
+
+    let wrprcAttestation = wrprcAttestations[0]
+
+    // Parse the compact-serialized JWT.
+    let jws: JWS
+    do {
+      jws = try JWS(compactSerialization: wrprcAttestation.data)
+    } catch {
+      throw WRPRCError.malformedRegistrationCertificate(
+        cause: "Invalid WRPRC JWT: \(error.localizedDescription)"
+      )
+    }
+
+    // Enforce JOSE header `typ` per ETSI 119475.
+    guard jws.header.typ == ETSI119475.REG_CERT_HEADER_TYPE else {
+      throw WRPRCError.malformedRegistrationCertificate(
+        cause: "Unexpected JWT typ '\(jws.header.typ ?? "")'. Expected '\(ETSI119475.REG_CERT_HEADER_TYPE)'."
+      )
+    }
+
+    // x5c chain must be present and every entry must parse
+    let chain = jws.header.x5c ?? []
+    guard !chain.isEmpty else {
+      throw WRPRCError.malformedRegistrationCertificate(cause: "Missing x5c header on WRPRC JWT")
+    }
+    try assertAllCertificatesParse(chain: chain)
+
+    
+    try assertLeafKeyIsAsymmetric(chain: chain)
+
+    // Signature + chain trust via the shared verifier. Translate helper errors
+    //    into WRPRC-domain errors.
+    let verifiedJWS: JWS
+    do {
+      verifiedJWS = try await policy.issuerTrust.verify(jws: jws)
+    } catch let error as JWSVerificationError {
+      switch error {
+      case .chainNotTrusted:
+        throw WRPRCError.registrationCertificateNotTrusted
+      case .invalidCertificateChain(let reason),
+           .verifierCreationFailed(let reason),
+           .signatureInvalid(let reason),
+           .unsupportedAlgorithm(let reason):
+        throw WRPRCError.malformedRegistrationCertificate(cause: reason)
+      }
+    }
+
+    // Validate time claims (both iat and exp OPTIONAL; no string-sub check).
+    let payloadJSON = try decodePayload(verifiedJWS)
+    try validateTimeClaims(payloadJSON)
+
+    // Compute offered credential configurations for this credential offer.
+    let offeredConfigurations = issuerMetadata.credentialsSupported
+      .filter { credentialOffer.credentialConfigurationIdentifiers.contains($0.key) }
+
+    guard let wrpac = issuerMetadata.wrpac else {
+      throw WRPRCError.missingWrpac
+    }
+
+    // Invoke the consumer-supplied policy validator.
+    let authorization = await policy.authorize(wrpac, payloadJSON, offeredConfigurations)
+
+    // Route the outcome.
+    switch authorization {
+    case .granted(let warnings):
+      return warnings
+    case .notGranted(let error):
+      throw WRPRCError.policyNotMet(error)
+    }
+  }
+
+  // MARK: - Helpers
+  private func assertLeafKeyIsAsymmetric(chain: [String]) throws {
+    guard
+      let leaf = chain.first,
+      let key = SecCertificateHelper().publicKey(fromPem: leaf)
+    else {
+      throw WRPRCError.malformedRegistrationCertificate(
+        cause: "Could not extract public key from WRPRC leaf certificate"
+      )
+    }
+
+    switch key.keyAlgorithm() {
+    case "RSA", "EC":
+      return
+    default:
+      throw WRPRCError.malformedRegistrationCertificate(
+        cause: "WRPRC signing key must be asymmetric (RSA or EC)"
+      )
+    }
+  }
+
+  /// Every base64 entry in the x5c chain must produce a valid `SecCertificate`.
+  private func assertAllCertificatesParse(chain: [String]) throws {
+    for pem in chain {
+      let cleaned = pem
+        .replacingOccurrences(of: "-----BEGIN CERTIFICATE-----", with: "")
+        .replacingOccurrences(of: "-----END CERTIFICATE-----", with: "")
+        .replacingOccurrences(of: "\n", with: "")
+      guard let data = Data(base64Encoded: cleaned),
+            SecCertificateCreateWithData(nil, data as CFData) != nil
+      else {
+        throw WRPRCError.malformedRegistrationCertificate(
+          cause: "x5c contains an unparseable certificate entry"
+        )
+      }
+    }
+  }
+
+  private func decodePayload(_ jws: JWS) throws -> JSON {
+    do {
+      return try JSON(data: jws.payload.data())
+    } catch {
+      throw WRPRCError.malformedRegistrationCertificate(
+        cause: "WRPRC payload is not valid JSON"
+      )
+    }
+  }
+
+  private func validateTimeClaims(_ payload: JSON) throws {
+    let now = Date().timeIntervalSince1970
+    let skew = SignedJWTValidation.clockSkew
+
+    let iat = payload["iat"].double
+    let exp = payload["exp"].double
+
+    // If iat is present, it must not be in the future beyond skew.
+    if let iat, iat > now + skew {
+      throw WRPRCError.malformedRegistrationCertificate(cause: "WRPRC 'iat' is in the future")
+    }
+
+    // If exp is present, it must not have expired beyond skew.
+    if let exp {
+      if exp < now - skew {
+        throw WRPRCError.malformedRegistrationCertificate(cause: "WRPRC has expired")
+      }
+      // Cross-check only when both iat and exp are present.
+      if let iat, iat > exp + skew {
+        throw WRPRCError.malformedRegistrationCertificate(cause: "WRPRC 'iat' is after 'exp'")
+      }
+    }
+  }
+}

--- a/Sources/RegistrationCertificate/IssuanceAuthorizer.swift
+++ b/Sources/RegistrationCertificate/IssuanceAuthorizer.swift
@@ -14,13 +14,10 @@
  * limitations under the License.
  */
 import Foundation
-import Security
-@preconcurrency import JOSESwift
-@preconcurrency import SwiftyJSON
 
-/// Extracts and validates the WRP Registration Certificate (WRPRC) that accompanies
-/// a resolved `CredentialOffer` and applies the configured
-/// `RegistrationCertificatePolicy` to authorize the issuance transaction.
+/// Extracts the WRP Registration Certificate (WRPRC) that accompanies a resolved
+/// `CredentialOffer` and applies the configured `RegistrationCertificatePolicy`
+/// to authorize the issuance transaction.
 public actor IssuanceAuthorizer {
 
   private let policy: RegistrationCertificatePolicy
@@ -31,11 +28,11 @@ public actor IssuanceAuthorizer {
 
   /// Authorizes the resolved `credentialOffer` against the configured WRPRC policy.
   ///
-  /// - Returns: The `.warning` violations produced by the policy validator, if any.
+  /// - Returns: The warnings produced by the policy validator.
   ///   Empty means the policy applied cleanly.
-  /// - Throws: `WRPRCError` if the WRPRC is missing/multiple/malformed/untrusted,
-  ///   or if the policy validator produced any `.error` violations.
-  public func authorize(credentialOffer: CredentialOffer) async throws -> [PolicyViolation] {
+  /// - Throws: `WRPRCError` if the WRPRC is missing / multiple / WRPAC missing,
+  ///   or if the policy returned `.notGranted`.
+  public func authorize(credentialOffer: CredentialOffer) async throws -> [String: [PolicyViolation]] {
 
     let issuerMetadata = credentialOffer.credentialIssuerMetadata
     
@@ -55,55 +52,7 @@ public actor IssuanceAuthorizer {
       throw WRPRCError.multipleRegistrationCertificates
     }
 
-    let wrprcAttestation = wrprcAttestations[0]
-
-    // Parse the compact-serialized JWT.
-    let jws: JWS
-    do {
-      jws = try JWS(compactSerialization: wrprcAttestation.data)
-    } catch {
-      throw WRPRCError.malformedRegistrationCertificate(
-        cause: "Invalid WRPRC JWT: \(error.localizedDescription)"
-      )
-    }
-
-    // Enforce JOSE header `typ` per ETSI 119475.
-    guard jws.header.typ == ETSI119475.REG_CERT_HEADER_TYPE else {
-      throw WRPRCError.malformedRegistrationCertificate(
-        cause: "Unexpected JWT typ '\(jws.header.typ ?? "")'. Expected '\(ETSI119475.REG_CERT_HEADER_TYPE)'."
-      )
-    }
-
-    // x5c chain must be present and every entry must parse
-    let chain = jws.header.x5c ?? []
-    guard !chain.isEmpty else {
-      throw WRPRCError.malformedRegistrationCertificate(cause: "Missing x5c header on WRPRC JWT")
-    }
-    try assertAllCertificatesParse(chain: chain)
-
-    
-    try assertLeafKeyIsAsymmetric(chain: chain)
-
-    // Signature + chain trust via the shared verifier. Translate helper errors
-    //    into WRPRC-domain errors.
-    let verifiedJWS: JWS
-    do {
-      verifiedJWS = try await policy.issuerTrust.verify(jws: jws)
-    } catch let error as JWSVerificationError {
-      switch error {
-      case .chainNotTrusted:
-        throw WRPRCError.registrationCertificateNotTrusted
-      case .invalidCertificateChain(let reason),
-           .verifierCreationFailed(let reason),
-           .signatureInvalid(let reason),
-           .unsupportedAlgorithm(let reason):
-        throw WRPRCError.malformedRegistrationCertificate(cause: reason)
-      }
-    }
-
-    // Validate time claims (both iat and exp OPTIONAL; no string-sub check).
-    let payloadJSON = try decodePayload(verifiedJWS)
-    try validateTimeClaims(payloadJSON)
+    let wrprc = wrprcAttestations[0].data
 
     // Compute offered credential configurations for this credential offer.
     let offeredConfigurations = issuerMetadata.credentialsSupported
@@ -114,86 +63,13 @@ public actor IssuanceAuthorizer {
     }
 
     // Invoke the consumer-supplied policy validator.
-    let authorization = await policy.authorize(wrpac, payloadJSON, offeredConfigurations)
+    let authorization = await policy.authorize(wrpac, wrprc, offeredConfigurations)
 
-    // Route the outcome.
     switch authorization {
     case .granted(let warnings):
       return warnings
     case .notGranted(let error):
       throw WRPRCError.policyNotMet(error)
-    }
-  }
-
-  // MARK: - Helpers
-  private func assertLeafKeyIsAsymmetric(chain: [String]) throws {
-    guard
-      let leaf = chain.first,
-      let key = SecCertificateHelper().publicKey(fromPem: leaf)
-    else {
-      throw WRPRCError.malformedRegistrationCertificate(
-        cause: "Could not extract public key from WRPRC leaf certificate"
-      )
-    }
-
-    switch key.keyAlgorithm() {
-    case "RSA", "EC":
-      return
-    default:
-      throw WRPRCError.malformedRegistrationCertificate(
-        cause: "WRPRC signing key must be asymmetric (RSA or EC)"
-      )
-    }
-  }
-
-  /// Every base64 entry in the x5c chain must produce a valid `SecCertificate`.
-  private func assertAllCertificatesParse(chain: [String]) throws {
-    for pem in chain {
-      let cleaned = pem
-        .replacingOccurrences(of: "-----BEGIN CERTIFICATE-----", with: "")
-        .replacingOccurrences(of: "-----END CERTIFICATE-----", with: "")
-        .replacingOccurrences(of: "\n", with: "")
-      guard let data = Data(base64Encoded: cleaned),
-            SecCertificateCreateWithData(nil, data as CFData) != nil
-      else {
-        throw WRPRCError.malformedRegistrationCertificate(
-          cause: "x5c contains an unparseable certificate entry"
-        )
-      }
-    }
-  }
-
-  private func decodePayload(_ jws: JWS) throws -> JSON {
-    do {
-      return try JSON(data: jws.payload.data())
-    } catch {
-      throw WRPRCError.malformedRegistrationCertificate(
-        cause: "WRPRC payload is not valid JSON"
-      )
-    }
-  }
-
-  private func validateTimeClaims(_ payload: JSON) throws {
-    let now = Date().timeIntervalSince1970
-    let skew = SignedJWTValidation.clockSkew
-
-    let iat = payload["iat"].double
-    let exp = payload["exp"].double
-
-    // If iat is present, it must not be in the future beyond skew.
-    if let iat, iat > now + skew {
-      throw WRPRCError.malformedRegistrationCertificate(cause: "WRPRC 'iat' is in the future")
-    }
-
-    // If exp is present, it must not have expired beyond skew.
-    if let exp {
-      if exp < now - skew {
-        throw WRPRCError.malformedRegistrationCertificate(cause: "WRPRC has expired")
-      }
-      // Cross-check only when both iat and exp are present.
-      if let iat, iat > exp + skew {
-        throw WRPRCError.malformedRegistrationCertificate(cause: "WRPRC 'iat' is after 'exp'")
-      }
     }
   }
 }

--- a/Sources/RegistrationCertificate/IssuerInfo.swift
+++ b/Sources/RegistrationCertificate/IssuerInfo.swift
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Foundation
+
+
+public struct IssuerInfo: Sendable, Equatable, Decodable {
+
+  public let attestations: [IssuerInfoAttestation]
+
+  public init(attestations: [IssuerInfoAttestation]) {
+    self.attestations = attestations
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+
+    if let array = try? container.decode([IssuerInfoAttestation].self) {
+      self.attestations = array
+      return
+    }
+
+    if let single = try? container.decode(IssuerInfoAttestation.self) {
+      self.attestations = [single]
+      return
+    }
+
+    if let jwtString = try? container.decode(String.self), !jwtString.isEmpty {
+      // Tolerant: bare JWT string is treated as a WRPRC attestation.
+      self.attestations = [
+        IssuerInfoAttestation(
+          format: ETSI119472Part3.REGISTRATION_CERT,
+          data: jwtString
+        )
+      ]
+      return
+    }
+
+    throw DecodingError.dataCorruptedError(
+      in: container,
+      debugDescription: "issuer_info must be an attestation object, an array of attestation objects, or a bare JWT string"
+    )
+  }
+}
+
+/// A single entry inside `issuer_info` — declares its `format` and carries the
+/// attestation `data` (for WRPRC, a compact-serialized signed JWT).
+public struct IssuerInfoAttestation: Sendable, Equatable, Decodable {
+
+  public let format: String
+  public let data: String
+
+  public init(format: String, data: String) {
+    self.format = format
+    self.data = data
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case format
+    case data
+  }
+}

--- a/Sources/RegistrationCertificate/IssuerResolutionResult.swift
+++ b/Sources/RegistrationCertificate/IssuerResolutionResult.swift
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Foundation
+
+/// Result of `Issuer.make(credentialOffer:config:...)`.
+///
+/// Pairs the constructed `Issuer` with any warning-severity WRPRC policy
+/// violations produced by the configured `RegistrationCertificatePolicy`.
+public struct IssuerResolutionResult: Sendable {
+  public let issuer: Issuer
+  public let warnings: [PolicyViolation]
+
+  public init(issuer: Issuer, warnings: [PolicyViolation]) {
+    self.issuer = issuer
+    self.warnings = warnings
+  }
+}

--- a/Sources/RegistrationCertificate/IssuerResolutionResult.swift
+++ b/Sources/RegistrationCertificate/IssuerResolutionResult.swift
@@ -17,13 +17,13 @@ import Foundation
 
 /// Result of `Issuer.make(credentialOffer:config:...)`.
 ///
-/// Pairs the constructed `Issuer` with any warning-severity WRPRC policy
-/// violations produced by the configured `RegistrationCertificatePolicy`.
+/// Pairs the constructed `Issuer` with any warnings produced by the configured
+/// `RegistrationCertificatePolicy`.
 public struct IssuerResolutionResult: Sendable {
   public let issuer: Issuer
-  public let warnings: [PolicyViolation]
+  public let warnings: [String: [PolicyViolation]]
 
-  public init(issuer: Issuer, warnings: [PolicyViolation]) {
+  public init(issuer: Issuer, warnings: [String: [PolicyViolation]]) {
     self.issuer = issuer
     self.warnings = warnings
   }

--- a/Sources/RegistrationCertificate/JWSVerification.swift
+++ b/Sources/RegistrationCertificate/JWSVerification.swift
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Foundation
+@preconcurrency import JOSESwift
+
+/// Errors raised by the shared `IssuerTrust.verify(jws:)` helper.
+internal enum JWSVerificationError: Error, Sendable {
+  /// The `CertificateChainTrust` rejected the certificate chain.
+  case chainNotTrusted
+  /// The `x5c` header was empty or its leaf certificate could not be parsed.
+  case invalidCertificateChain(String)
+  /// A JWS `Verifier` could not be constructed for the resolved key.
+  case verifierCreationFailed(String)
+  /// The JWS signature failed cryptographic verification.
+  case signatureInvalid(String)
+  /// The signing key uses an algorithm not supported by this helper.
+  case unsupportedAlgorithm(String)
+}
+
+/// Clock skew (seconds) used across the library for validating `iat` / `exp` on
+/// signed JWTs. Kept in a single place so metadata (WRPAC) and WRPRC use the
+/// same tolerance.
+internal enum SignedJWTValidation {
+  static let clockSkew: TimeInterval = 300
+}
+
+internal extension IssuerTrust {
+
+  /// Verifies the certificate chain trust and JWS signature. Only RS256 and
+  /// ES256 are supported.
+  @discardableResult
+  func verify(jws: JWS) async throws -> JWS {
+    guard case .byCertificateChain(let certificateChainTrust) = self else {
+      throw JWSVerificationError.unsupportedAlgorithm(
+        "IssuerTrust variant not supported for JWS verification"
+      )
+    }
+
+    let chain = jws.header.x5c ?? []
+    guard !chain.isEmpty else {
+      throw JWSVerificationError.invalidCertificateChain("x5c header is missing or empty")
+    }
+    guard await certificateChainTrust.isValid(chain: chain) else {
+      throw JWSVerificationError.chainNotTrusted
+    }
+
+    let utilities: SecCertificateHelper = .init()
+    guard
+      let first = chain.first,
+      let key = utilities.publicKey(fromPem: first)
+    else {
+      throw JWSVerificationError.invalidCertificateChain("Failed to extract public key from leaf certificate")
+    }
+
+    let algorithm: SignatureAlgorithm? = switch key.keyAlgorithm() {
+    case "RSA": .RS256
+    case "EC": .ES256
+    default: nil
+    }
+
+    guard
+      let algorithm,
+      let verifier: Verifier = .init(signatureAlgorithm: algorithm, key: key)
+    else {
+      throw JWSVerificationError.verifierCreationFailed("Failed to create verifier from leaf certificate")
+    }
+
+    do {
+      return try jws.validate(using: verifier)
+    } catch {
+      throw JWSVerificationError.signatureInvalid(error.localizedDescription)
+    }
+  }
+}

--- a/Sources/RegistrationCertificate/PolicyViolation.swift
+++ b/Sources/RegistrationCertificate/PolicyViolation.swift
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Foundation
+
+/// A single WRP Registration Certificate policy violation produced by the
+/// consumer-supplied `RegistrationCertificatePolicy.authorize` closure.
+///
+/// The **outcome** (grant vs deny) is expressed by `Authorization`, not by this
+/// type. `Authorization.granted(warnings: [PolicyViolation])` carries any
+/// non-blocking violations; `Authorization.notGranted(error: PolicyViolation)`
+/// carries a single blocking violation.
+public struct PolicyViolation: Sendable, Equatable {
+  public let value: String
+
+  public init(_ value: String) {
+    precondition(!value.isEmpty, "PolicyViolation.value must not be empty")
+    self.value = value
+  }
+}

--- a/Sources/RegistrationCertificate/RegistrationCertificatePolicy.swift
+++ b/Sources/RegistrationCertificate/RegistrationCertificatePolicy.swift
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Foundation
+@preconcurrency import SwiftyJSON
+
+/// Configuration that drives WRP Registration Certificate (WRPRC) enforcement during
+/// issuance authorization.
+public struct RegistrationCertificatePolicy: Sendable {
+
+  /// Signature of the consumer-supplied WRPRC policy validation function.
+  ///
+  /// - Parameters:
+  ///   - wrpac: The WRP Access Certificate (base64 DER — a single X.509 leaf
+  ///     certificate) that signed the issuer metadata.
+  ///   - wrprc: The decoded WRPRC JWT payload as `SwiftyJSON.JSON`.
+  ///   - offeredConfigurations: The credential configurations referenced by the
+  ///     resolved `CredentialOffer`.
+  /// - Returns: An `Authorization` — either `.granted(warnings:)` (empty for a
+  ///   clean pass) or `.notGranted(error:)`. `.notGranted` causes the authorizer
+  ///   to throw `WRPRCError.policyNotMet(...)`.
+  public typealias Authorize = @Sendable (
+    _ wrpac: String,
+    _ wrprc: JSON,
+    _ offeredConfigurations: [CredentialConfigurationIdentifier: CredentialSupported]
+  ) async -> Authorization
+
+  public let issuerTrust: IssuerTrust
+  public let authorize: Authorize
+
+  public init(issuerTrust: IssuerTrust, authorize: @escaping Authorize) {
+    self.issuerTrust = issuerTrust
+    self.authorize = authorize
+  }
+
+  /// A policy that only enforces chain-of-trust on the WRPRC — the domain
+  /// validation function is a no-op returning `.granted(warnings: [])`.
+  /// Useful for consumers that need WRPRC presence + trust guarantees but
+  /// haven't yet implemented their own policy.
+  public static func trustOnly(issuerTrust: IssuerTrust) -> RegistrationCertificatePolicy {
+    RegistrationCertificatePolicy(
+      issuerTrust: issuerTrust,
+      authorize: { _, _, _ in .granted(warnings: []) }
+    )
+  }
+}

--- a/Sources/RegistrationCertificate/RegistrationCertificatePolicy.swift
+++ b/Sources/RegistrationCertificate/RegistrationCertificatePolicy.swift
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 import Foundation
-@preconcurrency import SwiftyJSON
 
 /// Configuration that drives WRP Registration Certificate (WRPRC) enforcement during
 /// issuance authorization.
+///
 public struct RegistrationCertificatePolicy: Sendable {
 
   /// Signature of the consumer-supplied WRPRC policy validation function.
@@ -25,34 +25,22 @@ public struct RegistrationCertificatePolicy: Sendable {
   /// - Parameters:
   ///   - wrpac: The WRP Access Certificate (base64 DER — a single X.509 leaf
   ///     certificate) that signed the issuer metadata.
-  ///   - wrprc: The decoded WRPRC JWT payload as `SwiftyJSON.JSON`.
+  ///   - wrprc: The raw WRPRC value as delivered in `issuer_info`, opaque to the
+  ///     library (typically a compact-serialized JWT).
   ///   - offeredConfigurations: The credential configurations referenced by the
   ///     resolved `CredentialOffer`.
-  /// - Returns: An `Authorization` — either `.granted(warnings:)` (empty for a
-  ///   clean pass) or `.notGranted(error:)`. `.notGranted` causes the authorizer
-  ///   to throw `WRPRCError.policyNotMet(...)`.
+  /// - Returns: An `Authorization` — either `.granted(warnings:)` or 
+  ///   `.notGranted(error:)`. `.notGranted` causes the authorizer to throw
+  ///   `WRPRCError.policyNotMet(...)`.
   public typealias Authorize = @Sendable (
     _ wrpac: String,
-    _ wrprc: JSON,
+    _ wrprc: String,
     _ offeredConfigurations: [CredentialConfigurationIdentifier: CredentialSupported]
   ) async -> Authorization
 
-  public let issuerTrust: IssuerTrust
   public let authorize: Authorize
 
-  public init(issuerTrust: IssuerTrust, authorize: @escaping Authorize) {
-    self.issuerTrust = issuerTrust
+  public init(authorize: @escaping Authorize) {
     self.authorize = authorize
-  }
-
-  /// A policy that only enforces chain-of-trust on the WRPRC — the domain
-  /// validation function is a no-op returning `.granted(warnings: [])`.
-  /// Useful for consumers that need WRPRC presence + trust guarantees but
-  /// haven't yet implemented their own policy.
-  public static func trustOnly(issuerTrust: IssuerTrust) -> RegistrationCertificatePolicy {
-    RegistrationCertificatePolicy(
-      issuerTrust: issuerTrust,
-      authorize: { _, _, _ in .granted(warnings: []) }
-    )
   }
 }

--- a/Sources/RegistrationCertificate/Specs.swift
+++ b/Sources/RegistrationCertificate/Specs.swift
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Foundation
+
+
+public enum ETSI119472Part3 {
+  /// The `issuer_info` member on the Credential Issuer Metadata.
+  public static let ISSUER_INFO = "issuer_info"
+
+  /// The `format` member on each `issuer_info` attestation entry.
+  public static let FORMAT = "format"
+
+  /// The `data` member on each `issuer_info` attestation entry.
+  public static let DATA = "data"
+
+  /// Format identifier for a WRP Registration Certificate attestation carried inside `issuer_info`.
+  public static let REGISTRATION_CERT = "registration_cert"
+}
+
+/// Constants from ETSI TS 119 475 v1.1.1 (WRP Registration Certificate).
+public enum ETSI119475 {
+  /// JWS header `typ` value for a WRP Registration Certificate.
+  public static let REG_CERT_HEADER_TYPE = "rc-wrp+jwt"
+}

--- a/Sources/RegistrationCertificate/Specs.swift
+++ b/Sources/RegistrationCertificate/Specs.swift
@@ -29,9 +29,3 @@ public enum ETSI119472Part3 {
   /// Format identifier for a WRP Registration Certificate attestation carried inside `issuer_info`.
   public static let REGISTRATION_CERT = "registration_cert"
 }
-
-/// Constants from ETSI TS 119 475 v1.1.1 (WRP Registration Certificate).
-public enum ETSI119475 {
-  /// JWS header `typ` value for a WRP Registration Certificate.
-  public static let REG_CERT_HEADER_TYPE = "rc-wrp+jwt"
-}

--- a/Sources/RegistrationCertificate/WRPRCError.swift
+++ b/Sources/RegistrationCertificate/WRPRCError.swift
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Foundation
+
+/// Errors raised while extracting, verifying, or enforcing the WRP Registration Certificate
+/// (ETSI TS 119 475 v1.1.1) during issuance authorization.
+public enum WRPRCError: LocalizedError, Sendable {
+
+  /// The issuer metadata does not carry an `issuer_info` container, or the
+  /// container is empty. Distinct from `.missingRequiredRegistrationCertificate`
+  /// where `issuer_info` exists but has no `registration_cert`-format entry.
+  case missingIssuerInfo
+
+  /// No WRP Registration Certificate was found in issuer metadata `issuer_info`
+  /// (the container exists but has no `registration_cert`-format entry).
+  case missingRequiredRegistrationCertificate
+
+  /// More than one WRP Registration Certificate was found in `issuer_info`.
+  case multipleRegistrationCertificates
+
+  /// The WRP Registration Certificate is not well-formed. `cause` describes the specific failure.
+  case malformedRegistrationCertificate(cause: String)
+
+  /// The WRP Registration Certificate's signing certificate chain was rejected by the configured trust.
+  case registrationCertificateNotTrusted
+
+  /// The metadata carries a WRPRC but no WRPAC was captured during metadata
+  /// resolution — a configuration invariant should prevent this, but the check
+  /// exists in the authorizer for defence in depth.
+  case missingWrpac
+
+  /// Policy evaluation returned `.notGranted(error:)`.
+  case policyNotMet(PolicyViolation)
+
+  public var errorDescription: String? {
+    switch self {
+    case .missingIssuerInfo:
+      return "Issuer metadata does not carry an `issuer_info` container, or the container is empty"
+    case .missingRequiredRegistrationCertificate:
+      return "No WRP Registration Certificate found in issuer metadata issuer_info"
+    case .multipleRegistrationCertificates:
+      return "More than one WRP Registration Certificate found in issuer_info; exactly one is required"
+    case .malformedRegistrationCertificate(let cause):
+      return "Malformed WRP Registration Certificate: \(cause)"
+    case .registrationCertificateNotTrusted:
+      return "WRP Registration Certificate signing chain is not trusted"
+    case .missingWrpac:
+      return "WRPAC is not available on the issuer metadata; " +
+             "ensure OpenId4VCIConfig.issuerMetadataPolicy is .requireSigned(.byCertificateChain(...))."
+    case .policyNotMet(let violation):
+      return "WRPRC policy not met: \(violation.value)"
+    }
+  }
+}

--- a/Sources/RegistrationCertificate/WRPRCError.swift
+++ b/Sources/RegistrationCertificate/WRPRCError.swift
@@ -15,7 +15,7 @@
  */
 import Foundation
 
-/// Errors raised while extracting, verifying, or enforcing the WRP Registration Certificate
+/// Errors raised while extracting or enforcing the WRP Registration Certificate
 /// (ETSI TS 119 475 v1.1.1) during issuance authorization.
 public enum WRPRCError: LocalizedError, Sendable {
 
@@ -30,12 +30,6 @@ public enum WRPRCError: LocalizedError, Sendable {
 
   /// More than one WRP Registration Certificate was found in `issuer_info`.
   case multipleRegistrationCertificates
-
-  /// The WRP Registration Certificate is not well-formed. `cause` describes the specific failure.
-  case malformedRegistrationCertificate(cause: String)
-
-  /// The WRP Registration Certificate's signing certificate chain was rejected by the configured trust.
-  case registrationCertificateNotTrusted
 
   /// The metadata carries a WRPRC but no WRPAC was captured during metadata
   /// resolution — a configuration invariant should prevent this, but the check
@@ -53,10 +47,6 @@ public enum WRPRCError: LocalizedError, Sendable {
       return "No WRP Registration Certificate found in issuer metadata issuer_info"
     case .multipleRegistrationCertificates:
       return "More than one WRP Registration Certificate found in issuer_info; exactly one is required"
-    case .malformedRegistrationCertificate(let cause):
-      return "Malformed WRP Registration Certificate: \(cause)"
-    case .registrationCertificateNotTrusted:
-      return "WRP Registration Certificate signing chain is not trusted"
     case .missingWrpac:
       return "WRPAC is not available on the issuer metadata; " +
              "ensure OpenId4VCIConfig.issuerMetadataPolicy is .requireSigned(.byCertificateChain(...))."

--- a/Tests/RegistrationCertificate/IssuanceAuthorizerTests.swift
+++ b/Tests/RegistrationCertificate/IssuanceAuthorizerTests.swift
@@ -1,0 +1,234 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import XCTest
+@preconcurrency import JOSESwift
+import SwiftyJSON
+@testable import OpenID4VCI
+
+final class IssuanceAuthorizerTests: XCTestCase {
+
+  // MARK: - Missing / multiple / malformed WRPRC
+
+  func testNilIssuerInfoThrowsMissingIssuerInfo() async throws {
+    let offer = try makeCredentialOffer(issuerInfo: nil)
+    let policy = trustAcceptAllPolicy()
+    let authorizer = IssuanceAuthorizer(policy: policy)
+
+    await assertThrows(WRPRCError.missingIssuerInfo) {
+      _ = try await authorizer.authorize(credentialOffer: offer)
+    }
+  }
+
+  func testEmptyIssuerInfoThrowsMissingIssuerInfo() async throws {
+    let offer = try makeCredentialOffer(issuerInfo: IssuerInfo(attestations: []))
+    let policy = trustAcceptAllPolicy()
+    let authorizer = IssuanceAuthorizer(policy: policy)
+
+    await assertThrows(WRPRCError.missingIssuerInfo) {
+      _ = try await authorizer.authorize(credentialOffer: offer)
+    }
+  }
+
+  func testNoWRPRCFormatAttestationsThrowsMissingRequired() async throws {
+    let offer = try makeCredentialOffer(issuerInfo: IssuerInfo(attestations: [
+      IssuerInfoAttestation(format: "other_format", data: "x")
+    ]))
+    let authorizer = IssuanceAuthorizer(policy: trustAcceptAllPolicy())
+
+    await assertThrows(WRPRCError.missingRequiredRegistrationCertificate) {
+      _ = try await authorizer.authorize(credentialOffer: offer)
+    }
+  }
+
+  func testMultipleWRPRCAttestationsThrowsMultiple() async throws {
+    let offer = try makeCredentialOffer(issuerInfo: IssuerInfo(attestations: [
+      IssuerInfoAttestation(format: ETSI119472Part3.REGISTRATION_CERT, data: "one"),
+      IssuerInfoAttestation(format: ETSI119472Part3.REGISTRATION_CERT, data: "two")
+    ]))
+    let authorizer = IssuanceAuthorizer(policy: trustAcceptAllPolicy())
+
+    await assertThrows(WRPRCError.multipleRegistrationCertificates) {
+      _ = try await authorizer.authorize(credentialOffer: offer)
+    }
+  }
+
+  func testMalformedJWTThrowsMalformed() async throws {
+    let offer = try makeCredentialOffer(issuerInfo: IssuerInfo(attestations: [
+      IssuerInfoAttestation(format: ETSI119472Part3.REGISTRATION_CERT, data: "not.a.jwt")
+    ]))
+    let authorizer = IssuanceAuthorizer(policy: trustAcceptAllPolicy())
+
+    do {
+      _ = try await authorizer.authorize(credentialOffer: offer)
+      XCTFail("Expected throw")
+    } catch let error as WRPRCError {
+      guard case .malformedRegistrationCertificate = error else {
+        return XCTFail("Expected .malformedRegistrationCertificate, got \(error)")
+      }
+    }
+  }
+
+  func testWrongTypHeaderThrowsMalformed() async throws {
+    let (jwt, _) = try mintTestJWT(typHeader: "some-other-typ")
+    let offer = try makeCredentialOffer(issuerInfo: IssuerInfo(attestations: [
+      IssuerInfoAttestation(format: ETSI119472Part3.REGISTRATION_CERT, data: jwt)
+    ]))
+    let authorizer = IssuanceAuthorizer(policy: trustAcceptAllPolicy())
+
+    do {
+      _ = try await authorizer.authorize(credentialOffer: offer)
+      XCTFail("Expected throw")
+    } catch let error as WRPRCError {
+      guard case .malformedRegistrationCertificate = error else {
+        return XCTFail("Expected .malformedRegistrationCertificate, got \(error)")
+      }
+    }
+  }
+
+  // MARK: - Missing x5c is treated as malformed (WRPRC always requires the WRPAC chain)
+
+  func testMissingX5CThrowsMalformed() async throws {
+    let (jwt, _) = try mintTestJWT(
+      typHeader: ETSI119475.REG_CERT_HEADER_TYPE,
+      payload: ["iat": Date().timeIntervalSince1970]
+    )
+    let offer = try makeCredentialOffer(issuerInfo: IssuerInfo(attestations: [
+      IssuerInfoAttestation(format: ETSI119472Part3.REGISTRATION_CERT, data: jwt)
+    ]))
+    let authorizer = IssuanceAuthorizer(policy: trustAcceptAllPolicy())
+
+    do {
+      _ = try await authorizer.authorize(credentialOffer: offer)
+      XCTFail("Expected throw")
+    } catch let error as WRPRCError {
+      guard case .malformedRegistrationCertificate = error else {
+        return XCTFail("Expected .malformedRegistrationCertificate, got \(error)")
+      }
+    }
+  }
+
+  // NOTE: Full happy-path tests (valid signature + policy warnings/errors + time-claim
+  // validation) require a real x5c chain — the JWS must carry a base64-DER certificate
+  // whose public key matches the signing key. Adding a self-signed cert generation
+  // helper is a follow-up; the structural-failure tests above already cover the
+  // per-branch authorizer logic up to and including x5c validation.
+
+  // MARK: - Fixture helpers
+
+  private func makeCredentialOffer(issuerInfo: IssuerInfo?) throws -> CredentialOffer {
+    let issuerId = try CredentialIssuerId("https://issuer.example.com")
+    let configId = try CredentialConfigurationIdentifier(value: "test-cfg")
+    let metadata = CredentialIssuerMetadata(
+      credentialIssuerIdentifier: issuerId,
+      authorizationServers: [URL(string: "https://issuer.example.com")!],
+      credentialEndpoint: try CredentialIssuerEndpoint(string: "https://issuer.example.com/credential"),
+      deferredCredentialEndpoint: nil,
+      nonceEndpoint: nil,
+      notificationEndpoint: nil,
+      credentialConfigurationsSupported: [:],
+      display: nil,
+      issuerInfo: issuerInfo
+    )
+    let asMetadataJSON = """
+    {
+      "issuer": "https://issuer.example.com",
+      "authorization_endpoint": "https://issuer.example.com/authorize",
+      "token_endpoint": "https://issuer.example.com/token"
+    }
+    """
+    let asMetadata = try JSONDecoder().decode(
+      AuthorizationServerMetadata.self,
+      from: Data(asMetadataJSON.utf8)
+    )
+    return try CredentialOffer(
+      credentialIssuerIdentifier: issuerId,
+      credentialIssuerMetadata: metadata,
+      credentialConfigurationIdentifiers: [configId],
+      grants: nil,
+      authorizationServerMetadata: .oauth(asMetadata)
+    )
+  }
+
+  /// Trust that accepts any chain — used to isolate authorizer failure paths from crypto.
+  /// The authorizer will still reject before reaching trust when structural checks fail.
+  private func trustAcceptAllPolicy() -> RegistrationCertificatePolicy {
+    let acceptAll = AcceptAllChainTrust()
+    return RegistrationCertificatePolicy(
+      issuerTrust: .byCertificateChain(certificateChainTrust: acceptAll),
+      authorize: { _, _, _ in .granted(warnings: []) }
+    )
+  }
+
+  /// Mints a self-signed ES256 JWT with a configurable `typ` and payload.
+  /// Returns the compact-serialized JWT and the corresponding public JWK.
+  private func mintTestJWT(
+    typHeader: String,
+    payload: [String: Any] = ["iat": Date().timeIntervalSince1970]
+  ) throws -> (jwt: String, publicJWK: JWK) {
+    let privateKey = try KeyController.generateECDHPrivateKey()
+    let publicSecKey = try KeyController.generateECDHPublicKey(from: privateKey)
+    let publicJWK = try ECPublicKey(
+      publicKey: publicSecKey,
+      additionalParameters: ["alg": "ES256", "use": "sig"]
+    )
+
+    let header = try JWSHeader(parameters: [
+      "alg": SignatureAlgorithm.ES256.rawValue,
+      "typ": typHeader
+    ])
+    let payloadData = try JSONSerialization.data(withJSONObject: payload, options: [])
+    guard let signer = Signer(signatureAlgorithm: .ES256, key: privateKey) else {
+      throw XCTError("Unable to build signer")
+    }
+    let jws = try JWS(header: header, payload: Payload(payloadData), signer: signer)
+    return (jws.compactSerializedString, publicJWK)
+  }
+
+  private func assertThrows(
+    _ expected: WRPRCError,
+    _ block: () async throws -> Void
+  ) async {
+    do {
+      try await block()
+      XCTFail("Expected \(expected) to be thrown")
+    } catch let error as WRPRCError {
+      switch (error, expected) {
+      case (.missingIssuerInfo, .missingIssuerInfo),
+           (.missingRequiredRegistrationCertificate, .missingRequiredRegistrationCertificate),
+           (.multipleRegistrationCertificates, .multipleRegistrationCertificates),
+           (.registrationCertificateNotTrusted, .registrationCertificateNotTrusted):
+        return
+      case (.malformedRegistrationCertificate, .malformedRegistrationCertificate),
+           (.policyNotMet, .policyNotMet):
+        return
+      default:
+        XCTFail("Expected \(expected), got \(error)")
+      }
+    } catch {
+      XCTFail("Expected WRPRCError, got \(error)")
+    }
+  }
+}
+
+/// Trust stub that accepts any chain. `@unchecked Sendable` — stateless and safe.
+private final class AcceptAllChainTrust: CertificateChainTrust, @unchecked Sendable {
+  func isValid(chain: [String]) async -> Bool { true }
+}
+
+private struct XCTError: Error {
+  let message: String
+  init(_ message: String) { self.message = message }
+}

--- a/Tests/RegistrationCertificate/IssuanceAuthorizerTests.swift
+++ b/Tests/RegistrationCertificate/IssuanceAuthorizerTests.swift
@@ -14,18 +14,15 @@
  * limitations under the License.
  */
 import XCTest
-@preconcurrency import JOSESwift
-import SwiftyJSON
 @testable import OpenID4VCI
 
 final class IssuanceAuthorizerTests: XCTestCase {
 
-  // MARK: - Missing / multiple / malformed WRPRC
+  // MARK: - Missing / multiple WRPRC
 
   func testNilIssuerInfoThrowsMissingIssuerInfo() async throws {
     let offer = try makeCredentialOffer(issuerInfo: nil)
-    let policy = trustAcceptAllPolicy()
-    let authorizer = IssuanceAuthorizer(policy: policy)
+    let authorizer = IssuanceAuthorizer(policy: acceptAllPolicy())
 
     await assertThrows(WRPRCError.missingIssuerInfo) {
       _ = try await authorizer.authorize(credentialOffer: offer)
@@ -34,8 +31,7 @@ final class IssuanceAuthorizerTests: XCTestCase {
 
   func testEmptyIssuerInfoThrowsMissingIssuerInfo() async throws {
     let offer = try makeCredentialOffer(issuerInfo: IssuerInfo(attestations: []))
-    let policy = trustAcceptAllPolicy()
-    let authorizer = IssuanceAuthorizer(policy: policy)
+    let authorizer = IssuanceAuthorizer(policy: acceptAllPolicy())
 
     await assertThrows(WRPRCError.missingIssuerInfo) {
       _ = try await authorizer.authorize(credentialOffer: offer)
@@ -46,7 +42,7 @@ final class IssuanceAuthorizerTests: XCTestCase {
     let offer = try makeCredentialOffer(issuerInfo: IssuerInfo(attestations: [
       IssuerInfoAttestation(format: "other_format", data: "x")
     ]))
-    let authorizer = IssuanceAuthorizer(policy: trustAcceptAllPolicy())
+    let authorizer = IssuanceAuthorizer(policy: acceptAllPolicy())
 
     await assertThrows(WRPRCError.missingRequiredRegistrationCertificate) {
       _ = try await authorizer.authorize(credentialOffer: offer)
@@ -58,77 +54,99 @@ final class IssuanceAuthorizerTests: XCTestCase {
       IssuerInfoAttestation(format: ETSI119472Part3.REGISTRATION_CERT, data: "one"),
       IssuerInfoAttestation(format: ETSI119472Part3.REGISTRATION_CERT, data: "two")
     ]))
-    let authorizer = IssuanceAuthorizer(policy: trustAcceptAllPolicy())
+    let authorizer = IssuanceAuthorizer(policy: acceptAllPolicy())
 
     await assertThrows(WRPRCError.multipleRegistrationCertificates) {
       _ = try await authorizer.authorize(credentialOffer: offer)
     }
   }
 
-  func testMalformedJWTThrowsMalformed() async throws {
-    let offer = try makeCredentialOffer(issuerInfo: IssuerInfo(attestations: [
-      IssuerInfoAttestation(format: ETSI119472Part3.REGISTRATION_CERT, data: "not.a.jwt")
-    ]))
-    let authorizer = IssuanceAuthorizer(policy: trustAcceptAllPolicy())
+  // MARK: - Missing WRPAC
 
-    do {
-      _ = try await authorizer.authorize(credentialOffer: offer)
-      XCTFail("Expected throw")
-    } catch let error as WRPRCError {
-      guard case .malformedRegistrationCertificate = error else {
-        return XCTFail("Expected .malformedRegistrationCertificate, got \(error)")
-      }
-    }
-  }
-
-  func testWrongTypHeaderThrowsMalformed() async throws {
-    let (jwt, _) = try mintTestJWT(typHeader: "some-other-typ")
-    let offer = try makeCredentialOffer(issuerInfo: IssuerInfo(attestations: [
-      IssuerInfoAttestation(format: ETSI119472Part3.REGISTRATION_CERT, data: jwt)
-    ]))
-    let authorizer = IssuanceAuthorizer(policy: trustAcceptAllPolicy())
-
-    do {
-      _ = try await authorizer.authorize(credentialOffer: offer)
-      XCTFail("Expected throw")
-    } catch let error as WRPRCError {
-      guard case .malformedRegistrationCertificate = error else {
-        return XCTFail("Expected .malformedRegistrationCertificate, got \(error)")
-      }
-    }
-  }
-
-  // MARK: - Missing x5c is treated as malformed (WRPRC always requires the WRPAC chain)
-
-  func testMissingX5CThrowsMalformed() async throws {
-    let (jwt, _) = try mintTestJWT(
-      typHeader: ETSI119475.REG_CERT_HEADER_TYPE,
-      payload: ["iat": Date().timeIntervalSince1970]
+  func testMissingWrpacThrowsMissingWrpac() async throws {
+    let offer = try makeCredentialOffer(
+      issuerInfo: IssuerInfo(attestations: [
+        IssuerInfoAttestation(format: ETSI119472Part3.REGISTRATION_CERT, data: "opaque-wrprc")
+      ]),
+      wrpac: nil
     )
-    let offer = try makeCredentialOffer(issuerInfo: IssuerInfo(attestations: [
-      IssuerInfoAttestation(format: ETSI119472Part3.REGISTRATION_CERT, data: jwt)
-    ]))
-    let authorizer = IssuanceAuthorizer(policy: trustAcceptAllPolicy())
+    let authorizer = IssuanceAuthorizer(policy: acceptAllPolicy())
+
+    await assertThrows(WRPRCError.missingWrpac) {
+      _ = try await authorizer.authorize(credentialOffer: offer)
+    }
+  }
+
+  // MARK: - Policy routing
+
+  func testGrantedReturnsWarningsAsProvided() async throws {
+    let offer = try makeCredentialOffer(
+      issuerInfo: IssuerInfo(attestations: [
+        IssuerInfoAttestation(format: ETSI119472Part3.REGISTRATION_CERT, data: "opaque-wrprc")
+      ]),
+      wrpac: "opaque-wrpac"
+    )
+    let expected: [String: [PolicyViolation]] = [
+      "test-cfg": [PolicyViolation("w1")],
+      "global": [PolicyViolation("w2")]
+    ]
+    let policy = RegistrationCertificatePolicy { _, _, _ in
+      .granted(warnings: expected)
+    }
+    let authorizer = IssuanceAuthorizer(policy: policy)
+
+    let warnings = try await authorizer.authorize(credentialOffer: offer)
+    XCTAssertEqual(warnings, expected)
+  }
+
+  func testPolicyReceivesRawWrpacAndWrprc() async throws {
+    let offer = try makeCredentialOffer(
+      issuerInfo: IssuerInfo(attestations: [
+        IssuerInfoAttestation(format: ETSI119472Part3.REGISTRATION_CERT, data: "opaque-wrprc")
+      ]),
+      wrpac: "opaque-wrpac"
+    )
+    let received = ReceivedInputs()
+    let policy = RegistrationCertificatePolicy { wrpac, wrprc, offered in
+      await received.set(wrpac: wrpac, wrprc: wrprc, offered: Array(offered.keys))
+      return .granted(warnings: [:])
+    }
+
+    _ = try await IssuanceAuthorizer(policy: policy).authorize(credentialOffer: offer)
+
+    let snapshot = await received.snapshot()
+    XCTAssertEqual(snapshot.wrpac, "opaque-wrpac")
+    XCTAssertEqual(snapshot.wrprc, "opaque-wrprc")
+  }
+
+  func testNotGrantedThrowsPolicyNotMet() async throws {
+    let offer = try makeCredentialOffer(
+      issuerInfo: IssuerInfo(attestations: [
+        IssuerInfoAttestation(format: ETSI119472Part3.REGISTRATION_CERT, data: "opaque-wrprc")
+      ]),
+      wrpac: "opaque-wrpac"
+    )
+    let policy = RegistrationCertificatePolicy { _, _, _ in
+      .notGranted(error: PolicyViolation("boom"))
+    }
+    let authorizer = IssuanceAuthorizer(policy: policy)
 
     do {
       _ = try await authorizer.authorize(credentialOffer: offer)
       XCTFail("Expected throw")
-    } catch let error as WRPRCError {
-      guard case .malformedRegistrationCertificate = error else {
-        return XCTFail("Expected .malformedRegistrationCertificate, got \(error)")
-      }
+    } catch let WRPRCError.policyNotMet(violation) {
+      XCTAssertEqual(violation, PolicyViolation("boom"))
+    } catch {
+      XCTFail("Expected WRPRCError.policyNotMet, got \(error)")
     }
   }
-
-  // NOTE: Full happy-path tests (valid signature + policy warnings/errors + time-claim
-  // validation) require a real x5c chain — the JWS must carry a base64-DER certificate
-  // whose public key matches the signing key. Adding a self-signed cert generation
-  // helper is a follow-up; the structural-failure tests above already cover the
-  // per-branch authorizer logic up to and including x5c validation.
 
   // MARK: - Fixture helpers
 
-  private func makeCredentialOffer(issuerInfo: IssuerInfo?) throws -> CredentialOffer {
+  private func makeCredentialOffer(
+    issuerInfo: IssuerInfo?,
+    wrpac: String? = "opaque-wrpac"
+  ) throws -> CredentialOffer {
     let issuerId = try CredentialIssuerId("https://issuer.example.com")
     let configId = try CredentialConfigurationIdentifier(value: "test-cfg")
     let metadata = CredentialIssuerMetadata(
@@ -140,7 +158,8 @@ final class IssuanceAuthorizerTests: XCTestCase {
       notificationEndpoint: nil,
       credentialConfigurationsSupported: [:],
       display: nil,
-      issuerInfo: issuerInfo
+      issuerInfo: issuerInfo,
+      wrpac: wrpac
     )
     let asMetadataJSON = """
     {
@@ -162,39 +181,8 @@ final class IssuanceAuthorizerTests: XCTestCase {
     )
   }
 
-  /// Trust that accepts any chain — used to isolate authorizer failure paths from crypto.
-  /// The authorizer will still reject before reaching trust when structural checks fail.
-  private func trustAcceptAllPolicy() -> RegistrationCertificatePolicy {
-    let acceptAll = AcceptAllChainTrust()
-    return RegistrationCertificatePolicy(
-      issuerTrust: .byCertificateChain(certificateChainTrust: acceptAll),
-      authorize: { _, _, _ in .granted(warnings: []) }
-    )
-  }
-
-  /// Mints a self-signed ES256 JWT with a configurable `typ` and payload.
-  /// Returns the compact-serialized JWT and the corresponding public JWK.
-  private func mintTestJWT(
-    typHeader: String,
-    payload: [String: Any] = ["iat": Date().timeIntervalSince1970]
-  ) throws -> (jwt: String, publicJWK: JWK) {
-    let privateKey = try KeyController.generateECDHPrivateKey()
-    let publicSecKey = try KeyController.generateECDHPublicKey(from: privateKey)
-    let publicJWK = try ECPublicKey(
-      publicKey: publicSecKey,
-      additionalParameters: ["alg": "ES256", "use": "sig"]
-    )
-
-    let header = try JWSHeader(parameters: [
-      "alg": SignatureAlgorithm.ES256.rawValue,
-      "typ": typHeader
-    ])
-    let payloadData = try JSONSerialization.data(withJSONObject: payload, options: [])
-    guard let signer = Signer(signatureAlgorithm: .ES256, key: privateKey) else {
-      throw XCTError("Unable to build signer")
-    }
-    let jws = try JWS(header: header, payload: Payload(payloadData), signer: signer)
-    return (jws.compactSerializedString, publicJWK)
+  private func acceptAllPolicy() -> RegistrationCertificatePolicy {
+    RegistrationCertificatePolicy(authorize: { _, _, _ in .granted(warnings: [:]) })
   }
 
   private func assertThrows(
@@ -209,9 +197,7 @@ final class IssuanceAuthorizerTests: XCTestCase {
       case (.missingIssuerInfo, .missingIssuerInfo),
            (.missingRequiredRegistrationCertificate, .missingRequiredRegistrationCertificate),
            (.multipleRegistrationCertificates, .multipleRegistrationCertificates),
-           (.registrationCertificateNotTrusted, .registrationCertificateNotTrusted):
-        return
-      case (.malformedRegistrationCertificate, .malformedRegistrationCertificate),
+           (.missingWrpac, .missingWrpac),
            (.policyNotMet, .policyNotMet):
         return
       default:
@@ -223,12 +209,18 @@ final class IssuanceAuthorizerTests: XCTestCase {
   }
 }
 
-/// Trust stub that accepts any chain. `@unchecked Sendable` — stateless and safe.
-private final class AcceptAllChainTrust: CertificateChainTrust, @unchecked Sendable {
-  func isValid(chain: [String]) async -> Bool { true }
-}
+private actor ReceivedInputs {
+  private(set) var wrpac: String = ""
+  private(set) var wrprc: String = ""
+  private(set) var offered: [CredentialConfigurationIdentifier] = []
 
-private struct XCTError: Error {
-  let message: String
-  init(_ message: String) { self.message = message }
+  func set(wrpac: String, wrprc: String, offered: [CredentialConfigurationIdentifier]) {
+    self.wrpac = wrpac
+    self.wrprc = wrprc
+    self.offered = offered
+  }
+
+  func snapshot() -> (wrpac: String, wrprc: String, offered: [CredentialConfigurationIdentifier]) {
+    (wrpac, wrprc, offered)
+  }
 }

--- a/Tests/RegistrationCertificate/IssuerInfoDecodingTests.swift
+++ b/Tests/RegistrationCertificate/IssuerInfoDecodingTests.swift
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import XCTest
+@testable import OpenID4VCI
+
+final class IssuerInfoDecodingTests: XCTestCase {
+
+  private func decode(_ jsonString: String) throws -> IssuerInfo {
+    let data = Data(jsonString.utf8)
+    return try JSONDecoder().decode(IssuerInfo.self, from: data)
+  }
+
+  // MARK: - Array of attestations (normal case)
+
+  func testDecodesArrayOfAttestations() throws {
+    let json = """
+    [
+      {"format": "registration_cert", "data": "eyJhbGciOiJFUzI1NiJ9.eyJmb28iOiJiYXIifQ.sig"},
+      {"format": "other_format", "data": "someOtherPayload"}
+    ]
+    """
+
+    let info = try decode(json)
+
+    XCTAssertEqual(info.attestations.count, 2)
+    XCTAssertEqual(info.attestations[0].format, "registration_cert")
+    XCTAssertEqual(info.attestations[0].data, "eyJhbGciOiJFUzI1NiJ9.eyJmb28iOiJiYXIifQ.sig")
+    XCTAssertEqual(info.attestations[1].format, "other_format")
+  }
+
+  // MARK: - Single attestation object (tolerant)
+
+  func testDecodesSingleAttestationObject() throws {
+    let json = """
+    {"format": "registration_cert", "data": "jwt.string.here"}
+    """
+
+    let info = try decode(json)
+
+    XCTAssertEqual(info.attestations.count, 1)
+    XCTAssertEqual(info.attestations[0].format, "registration_cert")
+    XCTAssertEqual(info.attestations[0].data, "jwt.string.here")
+  }
+
+  // MARK: - Bare JWT string (tolerant)
+
+  func testDecodesBareJWTStringAsWRPRC() throws {
+    let json = """
+    "eyJhbGciOiJFUzI1NiJ9.eyJmb28iOiJiYXIifQ.sig"
+    """
+
+    let info = try decode(json)
+
+    XCTAssertEqual(info.attestations.count, 1)
+    XCTAssertEqual(info.attestations[0].format, ETSI119472Part3.REGISTRATION_CERT)
+    XCTAssertEqual(info.attestations[0].data, "eyJhbGciOiJFUzI1NiJ9.eyJmb28iOiJiYXIifQ.sig")
+  }
+
+  func testDecodingEmptyStringFails() {
+    let json = "\"\""
+    XCTAssertThrowsError(try decode(json))
+  }
+
+  // MARK: - Failure modes
+
+  func testDecodingNumberFails() {
+    let json = "42"
+    XCTAssertThrowsError(try decode(json))
+  }
+
+  func testDecodingBoolFails() {
+    let json = "true"
+    XCTAssertThrowsError(try decode(json))
+  }
+
+  func testDecodingNullFails() {
+    let json = "null"
+    XCTAssertThrowsError(try decode(json))
+  }
+
+  // MARK: - Empty array is allowed at decode time
+
+  func testDecodesEmptyArray() throws {
+    let json = "[]"
+    let info = try decode(json)
+    XCTAssertTrue(info.attestations.isEmpty)
+  }
+
+  // MARK: - Optional inside enclosing metadata
+
+  func testIssuerInfoIsOptionalInMetadata() throws {
+    // Metadata without issuer_info should decode with issuerInfo == nil.
+    let json = """
+    {
+      "credential_issuer": "https://issuer.example.com",
+      "authorization_servers": ["https://as.example.com"],
+      "credential_endpoint": "https://issuer.example.com/credential"
+    }
+    """
+
+    let metadata = try JSONDecoder().decode(CredentialIssuerMetadata.self, from: Data(json.utf8))
+    XCTAssertNil(metadata.issuerInfo)
+  }
+
+  func testIssuerInfoIsPopulatedFromMetadataWhenPresent() throws {
+    let json = """
+    {
+      "credential_issuer": "https://issuer.example.com",
+      "authorization_servers": ["https://as.example.com"],
+      "credential_endpoint": "https://issuer.example.com/credential",
+      "issuer_info": [
+        {"format": "registration_cert", "data": "eyJhbGciOiJFUzI1NiJ9.eyJpYXQiOjE2ODMwMDAwMDB9.sig"}
+      ]
+    }
+    """
+
+    let metadata = try JSONDecoder().decode(CredentialIssuerMetadata.self, from: Data(json.utf8))
+    XCTAssertNotNil(metadata.issuerInfo)
+    XCTAssertEqual(metadata.issuerInfo?.attestations.count, 1)
+    XCTAssertEqual(metadata.issuerInfo?.attestations.first?.format, "registration_cert")
+  }
+}

--- a/Tests/RegistrationCertificate/OpenId4VCIConfigInvariantTests.swift
+++ b/Tests/RegistrationCertificate/OpenId4VCIConfigInvariantTests.swift
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import XCTest
+@preconcurrency import JOSESwift
+@testable import OpenID4VCI
+
+/// Sanity checks for the invariant that couples `registrationCertificatePolicy`
+/// to `issuerMetadataPolicy = .requireSigned(.byCertificateChain(...))`.
+///
+/// Negative cases (`.preferSigned`, `.ignoreSigned`, `.requireSigned(.byPublicKey)`)
+/// trip a `preconditionFailure` — that terminates the process and isn't cleanly
+/// testable in XCTest without extra harnesses. They're documented in
+/// `OpenId4VCIConfig.init` and enforced by the same code path exercised by the
+/// positive tests here.
+final class OpenId4VCIConfigInvariantTests: XCTestCase {
+
+  private let redirectURI = URL(string: "urn:ietf:wg:oauth:2.0:oob")!
+
+  func testPolicyOmittedIsAlwaysValid() {
+    // No WRPRC policy configured — every issuerMetadataPolicy value is fine.
+    _ = OpenId4VCIConfig(
+      client: attestionClient,
+      authFlowRedirectionURI: redirectURI,
+      issuerMetadataPolicy: .ignoreSigned,
+      registrationCertificatePolicy: nil
+    )
+    _ = OpenId4VCIConfig(
+      client: attestionClient,
+      authFlowRedirectionURI: redirectURI,
+      issuerMetadataPolicy: .preferSigned(issuerTrust: .byCertificateChain(certificateChainTrust: AcceptAllTrust())),
+      registrationCertificatePolicy: nil
+    )
+  }
+
+  func testPolicyWithRequireSignedAndCertificateChainIsValid() {
+    // WRPRC policy configured AND metadata must be signed via cert chain —
+    // the only combination that yields a WRPAC.
+    _ = OpenId4VCIConfig(
+      client: attestionClient,
+      authFlowRedirectionURI: redirectURI,
+      issuerMetadataPolicy: .requireSigned(issuerTrust: .byCertificateChain(certificateChainTrust: AcceptAllTrust())),
+      registrationCertificatePolicy: RegistrationCertificatePolicy(
+        issuerTrust: .byCertificateChain(certificateChainTrust: AcceptAllTrust()),
+        authorize: { _, _, _ in .granted(warnings: []) }
+      )
+    )
+  }
+}
+
+private final class AcceptAllTrust: CertificateChainTrust, @unchecked Sendable {
+  func isValid(chain: [String]) async -> Bool { true }
+}

--- a/Tests/RegistrationCertificate/OpenId4VCIConfigInvariantTests.swift
+++ b/Tests/RegistrationCertificate/OpenId4VCIConfigInvariantTests.swift
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import XCTest
-@preconcurrency import JOSESwift
 @testable import OpenID4VCI
 
 /// Sanity checks for the invariant that couples `registrationCertificatePolicy`
@@ -53,8 +52,7 @@ final class OpenId4VCIConfigInvariantTests: XCTestCase {
       authFlowRedirectionURI: redirectURI,
       issuerMetadataPolicy: .requireSigned(issuerTrust: .byCertificateChain(certificateChainTrust: AcceptAllTrust())),
       registrationCertificatePolicy: RegistrationCertificatePolicy(
-        issuerTrust: .byCertificateChain(certificateChainTrust: AcceptAllTrust()),
-        authorize: { _, _, _ in .granted(warnings: []) }
+        authorize: { _, _, _ in .granted(warnings: [:]) }
       )
     )
   }

--- a/Tests/RegistrationCertificate/PolicyViolationTests.swift
+++ b/Tests/RegistrationCertificate/PolicyViolationTests.swift
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import XCTest
+@testable import OpenID4VCI
+
+final class PolicyViolationTests: XCTestCase {
+
+  // MARK: - PolicyViolation
+
+  func testEquatable() {
+    XCTAssertEqual(PolicyViolation("x"), PolicyViolation("x"))
+    XCTAssertNotEqual(PolicyViolation("x"), PolicyViolation("y"))
+  }
+
+  func testPreservesValue() {
+    XCTAssertEqual(PolicyViolation("boom").value, "boom")
+  }
+
+  // MARK: - Authorization
+
+  func testGrantedWithNoWarningsIsCleanPass() {
+    let outcome: Authorization = .granted(warnings: [])
+    guard case .granted(let warnings) = outcome else {
+      return XCTFail("Expected .granted")
+    }
+    XCTAssertTrue(warnings.isEmpty)
+  }
+
+  func testGrantedWithWarnings() {
+    let outcome: Authorization = .granted(warnings: [
+      PolicyViolation("w1"),
+      PolicyViolation("w2")
+    ])
+    guard case .granted(let warnings) = outcome else {
+      return XCTFail("Expected .granted")
+    }
+    XCTAssertEqual(warnings, [PolicyViolation("w1"), PolicyViolation("w2")])
+  }
+
+  func testNotGrantedCarriesSingleError() {
+    let outcome: Authorization = .notGranted(error: PolicyViolation("boom"))
+    guard case .notGranted(let error) = outcome else {
+      return XCTFail("Expected .notGranted")
+    }
+    XCTAssertEqual(error, PolicyViolation("boom"))
+  }
+
+  func testEquatableAuthorization() {
+    XCTAssertEqual(
+      Authorization.granted(warnings: [PolicyViolation("w")]),
+      Authorization.granted(warnings: [PolicyViolation("w")])
+    )
+    XCTAssertNotEqual(
+      Authorization.granted(warnings: [PolicyViolation("w")]),
+      Authorization.notGranted(error: PolicyViolation("w"))
+    )
+  }
+}

--- a/Tests/RegistrationCertificate/PolicyViolationTests.swift
+++ b/Tests/RegistrationCertificate/PolicyViolationTests.swift
@@ -32,7 +32,7 @@ final class PolicyViolationTests: XCTestCase {
   // MARK: - Authorization
 
   func testGrantedWithNoWarningsIsCleanPass() {
-    let outcome: Authorization = .granted(warnings: [])
+    let outcome: Authorization = .granted()
     guard case .granted(let warnings) = outcome else {
       return XCTFail("Expected .granted")
     }
@@ -40,14 +40,15 @@ final class PolicyViolationTests: XCTestCase {
   }
 
   func testGrantedWithWarnings() {
-    let outcome: Authorization = .granted(warnings: [
-      PolicyViolation("w1"),
-      PolicyViolation("w2")
-    ])
-    guard case .granted(let warnings) = outcome else {
+    let warnings: [String: [PolicyViolation]] = [
+      "cfg-1": [PolicyViolation("w1")],
+      "global": [PolicyViolation("w2")]
+    ]
+    let outcome: Authorization = .granted(warnings: warnings)
+    guard case .granted(let received) = outcome else {
       return XCTFail("Expected .granted")
     }
-    XCTAssertEqual(warnings, [PolicyViolation("w1"), PolicyViolation("w2")])
+    XCTAssertEqual(received, warnings)
   }
 
   func testNotGrantedCarriesSingleError() {
@@ -59,12 +60,13 @@ final class PolicyViolationTests: XCTestCase {
   }
 
   func testEquatableAuthorization() {
+    let warnings: [String: [PolicyViolation]] = ["k": [PolicyViolation("w")]]
     XCTAssertEqual(
-      Authorization.granted(warnings: [PolicyViolation("w")]),
-      Authorization.granted(warnings: [PolicyViolation("w")])
+      Authorization.granted(warnings: warnings),
+      Authorization.granted(warnings: warnings)
     )
     XCTAssertNotEqual(
-      Authorization.granted(warnings: [PolicyViolation("w")]),
+      Authorization.granted(warnings: warnings),
       Authorization.notGranted(error: PolicyViolation("w"))
     )
   }

--- a/Tests/Resolver/CredentialOfferResolverTests.swift
+++ b/Tests/Resolver/CredentialOfferResolverTests.swift
@@ -45,26 +45,11 @@ class CredentialOfferResolverTests: XCTestCase {
     let credentialIssuerMetadataResolver = CredentialIssuerMetadataResolver(
       fetcher: fetcher)
     
-    let jwkJSON = """
-        {
-          "kty": "EC",
-          "d": "hmQqQjKufUDXOBaVs-alU0sl1j9_WR1U9ia3J680s2E",
-          "crv": "P-256",
-          "x": "ilzt0a_ukEX-nl0S05S2RAlbQFL2DSOpTjT3xf52JBY",
-          "y": "q-fNv_d0nlZf_S_3S-KmrktIsylB0cybRiL6rZMLZHI"
-        }
-        """
-        
-        guard let jsonData = jwkJSON.data(using: .utf8) else {
-          XCTAssert(false, "Failed to convert JWK JSON string to Data")
-          return
-        }
-    
     // When
     let result = try await credentialIssuerMetadataResolver.resolve(
       source: .credentialIssuer(CredentialIssuerId("https://credential-issuer.example.com")),
-      policy: .requireSigned(issuerTrust: .byPublicKey(jwk: ECPublicKey(data: jsonData))
-    ))
+      policy: .requireSigned(issuerTrust: .byCertificateChain(certificateChainTrust: TestTrust()))
+    )
     
     switch result {
     case .success(let result):


### PR DESCRIPTION
# Description of change

Adds WRP Registration Certificate (WRPRC) enforcement support to the library. The library treats the WRPRC as an opaque `String` and delegates every trust, signature, JOSE-header, x5c, and freshness decision to the caller-supplied policy. 

Included in this change:

- `RegistrationCertificatePolicy` carrying only an `Authorize` closure .the closure receives `wrpac: String`, `wrprc: String` , and the offered credential configurations, and returns an `Authorization`.
- `Authorization` enum with `.granted(warnings: [String: [PolicyViolation]] = [:])` and `.notGranted(error: PolicyViolation)` 
- `IssuanceAuthorizer` (Swift `actor`) that extracts the WRPRC, enforces presence and cardinality, verifies WRPAC availability, invokes the policy, and routes the outcome.
- `Issuer.make(...)` static factory returning `IssuerResolutionResult`. Existing `Issuer.init(...)` initializers are unchanged for consumers that do not opt in.
- `OpenId4VCIConfig.registrationCertificatePolicy` optional attribute. When set, the config enforces `issuerMetadataPolicy = .requireSigned(.byCertificateChain(...))` at construction to guarantee a WRPAC is captured.
- `WRPRCError` covering only the failure modes the library owns: `.missingIssuerInfo`, `.missingRequiredRegistrationCertificate`, `.multipleRegistrationCertificates`, `.missingWrpac`, `.policyNotMet(PolicyViolation)`.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Closes #303 
