### PR TITLE
grants: both with different authorization_servers can leak pre-authorized code to the wrong token endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ let offer: CredentialOffer = ...
 let config: OpenId4VCIConfig = ...
 
 let issuer = try Issuer(
-    authorizationServerMetadata: offer.authorizationServerMetadata,
+    grantsMetadata: offer.grantsMetadata,
     issuerMetadata: offer.credentialIssuerMetadata,
     config: config
 )

--- a/Sources/Entities/CredentialOffer/CredentialOffer.swift
+++ b/Sources/Entities/CredentialOffer/CredentialOffer.swift
@@ -21,8 +21,53 @@ public struct CredentialOffer: Sendable {
   public let credentialIssuerMetadata: CredentialIssuerMetadata
   public let credentialConfigurationIdentifiers: [CredentialConfigurationIdentifier]
   public let grants: Grants?
-  public let authorizationServerMetadata: IdentityAndAccessManagementMetadata
-  
+
+  //// Authorization server metadata for the authorization code flow.
+  public let authorizationCodeServerMetadata: IdentityAndAccessManagementMetadata?
+
+  //// Authorization server metadata for the pre-authorization code flow.
+  //// When different from authorizationCodeServerMetadata, the pre-auth flow
+  //// will use this server's token endpoint.
+  public let preAuthorizationCodeServerMetadata: IdentityAndAccessManagementMetadata?
+
+  //// Primary authorization server metadata, guaranteed to be non-nil.
+  //// This is set during initialization to whichever metadata is available,
+  //// preferring the authorization code server.
+  private let primaryAuthorizationServerMetadata: IdentityAndAccessManagementMetadata
+
+  //// Returns the authorization server metadata, preferring the authorization code server.
+  //// This property maintains backward compatibility with code that expects a single metadata.
+  public var authorizationServerMetadata: IdentityAndAccessManagementMetadata {
+    primaryAuthorizationServerMetadata
+  }
+
+  public init(
+    credentialIssuerIdentifier: CredentialIssuerId,
+    credentialIssuerMetadata: CredentialIssuerMetadata,
+    credentialConfigurationIdentifiers: [CredentialConfigurationIdentifier],
+    grants: Grants? = nil,
+    authorizationCodeServerMetadata: IdentityAndAccessManagementMetadata?,
+    preAuthorizationCodeServerMetadata: IdentityAndAccessManagementMetadata?
+  ) throws {
+    self.credentialIssuerIdentifier = credentialIssuerIdentifier
+    self.credentialIssuerMetadata = credentialIssuerMetadata
+    self.credentialConfigurationIdentifiers = credentialConfigurationIdentifiers
+    self.grants = grants
+    self.authorizationCodeServerMetadata = authorizationCodeServerMetadata
+    self.preAuthorizationCodeServerMetadata = preAuthorizationCodeServerMetadata
+
+    // At least one authorization server metadata must be provided
+    guard let primary = authorizationCodeServerMetadata ?? preAuthorizationCodeServerMetadata else {
+      throw ValidationError.error(reason: "At least one authorization server metadata must be provided")
+    }
+    self.primaryAuthorizationServerMetadata = primary
+
+    if credentialConfigurationIdentifiers.isEmpty {
+      throw CredentialOfferRequestError.emptyCredentialsError
+    }
+  }
+
+  /// Convenience initializer for backward compatibility when a single authorization server is used.
   public init(
     credentialIssuerIdentifier: CredentialIssuerId,
     credentialIssuerMetadata: CredentialIssuerMetadata,
@@ -30,14 +75,13 @@ public struct CredentialOffer: Sendable {
     grants: Grants? = nil,
     authorizationServerMetadata: IdentityAndAccessManagementMetadata
   ) throws {
-    self.credentialIssuerIdentifier = credentialIssuerIdentifier
-    self.credentialIssuerMetadata = credentialIssuerMetadata
-    self.credentialConfigurationIdentifiers = credentialConfigurationIdentifiers
-    self.grants = grants
-    self.authorizationServerMetadata = authorizationServerMetadata
-    
-    if credentialConfigurationIdentifiers.isEmpty {
-      throw CredentialOfferRequestError.emptyCredentialsError
-    }
+    try self.init(
+      credentialIssuerIdentifier: credentialIssuerIdentifier,
+      credentialIssuerMetadata: credentialIssuerMetadata,
+      credentialConfigurationIdentifiers: credentialConfigurationIdentifiers,
+      grants: grants,
+      authorizationCodeServerMetadata: authorizationServerMetadata,
+      preAuthorizationCodeServerMetadata: authorizationServerMetadata
+    )
   }
 }

--- a/Sources/Entities/CredentialOffer/CredentialOffer.swift
+++ b/Sources/Entities/CredentialOffer/CredentialOffer.swift
@@ -16,29 +16,59 @@
 import Foundation
 import SwiftyJSON
 
+/// Holds per-grant authorization server metadata.
+/// Each grant type (authorization code, pre-authorization code) can specify
+/// a different authorization server, and this struct captures the resolved
+/// metadata for each.
+public struct GrantsMetadata: Sendable {
+
+  /// Metadata for the authorization code flow.
+  public let authorizationCode: IdentityAndAccessManagementMetadata?
+
+  /// Metadata for the pre-authorization code flow.
+  /// When different from `authorizationCode`, the pre-auth flow
+  /// will use this server's token endpoint.
+  public let preAuthorizationCode: IdentityAndAccessManagementMetadata?
+
+  /// Primary metadata, guaranteed to be non-nil.
+  /// Prefers authorization code metadata, falls back to pre-authorization code.
+  public let primary: IdentityAndAccessManagementMetadata
+
+  /// Creates metadata for both grant types.
+  /// At least one metadata must be provided.
+  public init(
+    authorizationCode: IdentityAndAccessManagementMetadata?,
+    preAuthorizationCode: IdentityAndAccessManagementMetadata?
+  ) throws {
+    guard let primary = authorizationCode ?? preAuthorizationCode else {
+      throw ValidationError.error(reason: "At least one authorization server metadata must be provided")
+    }
+    self.authorizationCode = authorizationCode
+    self.preAuthorizationCode = preAuthorizationCode
+    self.primary = primary
+  }
+
+  /// Convenience initializer when both grants use the same authorization server.
+  public init(shared: IdentityAndAccessManagementMetadata) {
+    self.authorizationCode = shared
+    self.preAuthorizationCode = shared
+    self.primary = shared
+  }
+}
+
 public struct CredentialOffer: Sendable {
   public let credentialIssuerIdentifier: CredentialIssuerId
   public let credentialIssuerMetadata: CredentialIssuerMetadata
   public let credentialConfigurationIdentifiers: [CredentialConfigurationIdentifier]
   public let grants: Grants?
 
-  //// Authorization server metadata for the authorization code flow.
-  public let authorizationCodeServerMetadata: IdentityAndAccessManagementMetadata?
+  /// Per-grant authorization server metadata.
+  public let grantsMetadata: GrantsMetadata
 
-  //// Authorization server metadata for the pre-authorization code flow.
-  //// When different from authorizationCodeServerMetadata, the pre-auth flow
-  //// will use this server's token endpoint.
-  public let preAuthorizationCodeServerMetadata: IdentityAndAccessManagementMetadata?
-
-  //// Primary authorization server metadata, guaranteed to be non-nil.
-  //// This is set during initialization to whichever metadata is available,
-  //// preferring the authorization code server.
-  private let primaryAuthorizationServerMetadata: IdentityAndAccessManagementMetadata
-
-  //// Returns the authorization server metadata, preferring the authorization code server.
-  //// This property maintains backward compatibility with code that expects a single metadata.
+  /// Returns the primary authorization server metadata.
+  /// Maintains backward compatibility with code that expects a single metadata.
   public var authorizationServerMetadata: IdentityAndAccessManagementMetadata {
-    primaryAuthorizationServerMetadata
+    grantsMetadata.primary
   }
 
   public init(
@@ -46,21 +76,13 @@ public struct CredentialOffer: Sendable {
     credentialIssuerMetadata: CredentialIssuerMetadata,
     credentialConfigurationIdentifiers: [CredentialConfigurationIdentifier],
     grants: Grants? = nil,
-    authorizationCodeServerMetadata: IdentityAndAccessManagementMetadata?,
-    preAuthorizationCodeServerMetadata: IdentityAndAccessManagementMetadata?
+    grantsMetadata: GrantsMetadata
   ) throws {
     self.credentialIssuerIdentifier = credentialIssuerIdentifier
     self.credentialIssuerMetadata = credentialIssuerMetadata
     self.credentialConfigurationIdentifiers = credentialConfigurationIdentifiers
     self.grants = grants
-    self.authorizationCodeServerMetadata = authorizationCodeServerMetadata
-    self.preAuthorizationCodeServerMetadata = preAuthorizationCodeServerMetadata
-
-    // At least one authorization server metadata must be provided
-    guard let primary = authorizationCodeServerMetadata ?? preAuthorizationCodeServerMetadata else {
-      throw ValidationError.error(reason: "At least one authorization server metadata must be provided")
-    }
-    self.primaryAuthorizationServerMetadata = primary
+    self.grantsMetadata = grantsMetadata
 
     if credentialConfigurationIdentifiers.isEmpty {
       throw CredentialOfferRequestError.emptyCredentialsError
@@ -80,8 +102,7 @@ public struct CredentialOffer: Sendable {
       credentialIssuerMetadata: credentialIssuerMetadata,
       credentialConfigurationIdentifiers: credentialConfigurationIdentifiers,
       grants: grants,
-      authorizationCodeServerMetadata: authorizationServerMetadata,
-      preAuthorizationCodeServerMetadata: authorizationServerMetadata
+      grantsMetadata: GrantsMetadata(shared: authorizationServerMetadata)
     )
   }
 }

--- a/Sources/Issuers/Issuer.swift
+++ b/Sources/Issuers/Issuer.swift
@@ -139,10 +139,14 @@ public actor Issuer: IssuerType {
 
   public var deferredResponseEncryptionSpec: IssuanceResponseEncryptionSpec?
 
-  public let authorizationServerMetadata: IdentityAndAccessManagementMetadata
-  public let preAuthorizationServerMetadata: IdentityAndAccessManagementMetadata?
+  public let grantsMetadata: GrantsMetadata
   public let issuerMetadata: CredentialIssuerMetadata
   public let config: OpenId4VCIConfig
+
+  /// Returns the primary authorization server metadata for backward compatibility.
+  public var authorizationServerMetadata: IdentityAndAccessManagementMetadata {
+    grantsMetadata.primary
+  }
 
   private let authorizeIssuance: AuthorizeIssuanceType
   private let authorizer: AuthorizationServerClientType
@@ -187,26 +191,25 @@ public actor Issuer: IssuerType {
   }
   
   public init(
-    authorizationServerMetadata: IdentityAndAccessManagementMetadata,
-    preAuthorizationServerMetadata: IdentityAndAccessManagementMetadata? = nil,
+    grantsMetadata: GrantsMetadata,
     issuerMetadata: CredentialIssuerMetadata,
     config: OpenId4VCIConfig,
     dpopConstructor: DPoPConstructorType? = nil,
     session: Networking
   ) throws {
-    self.authorizationServerMetadata = authorizationServerMetadata
-    self.preAuthorizationServerMetadata = preAuthorizationServerMetadata
+    self.grantsMetadata = grantsMetadata
     self.issuerMetadata = issuerMetadata
     self.config = config
 
-    if let challengeEndpoint = authorizationServerMetadata.challengeEndpointURI {
+    let primaryMetadata = grantsMetadata.primary
+    if let challengeEndpoint = primaryMetadata.challengeEndpointURI {
       challenger = ChallengeEndpointClient(challengeEndpoint: challengeEndpoint)
     } else {
       challenger = nil
     }
 
     if config.requireDpop {
-      guard let dpopAlgs = authorizationServerMetadata.dpopSigningAlgValuesSupported,
+      guard let dpopAlgs = primaryMetadata.dpopSigningAlgValuesSupported,
             !dpopAlgs.isEmpty else {
         throw ValidationError.dpopRequired
       }
@@ -217,8 +220,7 @@ public actor Issuer: IssuerType {
       parPoster: Poster(session: session),
       tokenPoster: Poster(session: session),
       config: config,
-      authorizationServerMetadata: authorizationServerMetadata,
-      preAuthorizationServerMetadata: preAuthorizationServerMetadata,
+      grantsMetadata: grantsMetadata,
       credentialIssuerIdentifier: issuerMetadata.credentialIssuerIdentifier,
       dpopConstructor: config.requireDpop ? dpopConstructor : nil
     )
@@ -231,7 +233,7 @@ public actor Issuer: IssuerType {
     )
 
     try? config.client.ensureSupportedByAuthorizationServer(
-      self.authorizationServerMetadata
+      primaryMetadata
     )
 
     issuanceRequester = IssuanceRequester(
@@ -259,8 +261,7 @@ public actor Issuer: IssuerType {
   }
   
   public init(
-    authorizationServerMetadata: IdentityAndAccessManagementMetadata,
-    preAuthorizationServerMetadata: IdentityAndAccessManagementMetadata? = nil,
+    grantsMetadata: GrantsMetadata,
     issuerMetadata: CredentialIssuerMetadata,
     config: OpenId4VCIConfig,
     parPoster: PostingType = Poster(),
@@ -272,12 +273,12 @@ public actor Issuer: IssuerType {
     noncePoster: PostingType = Poster(),
     dpopConstructor: DPoPConstructorType? = nil
   ) throws {
-    self.authorizationServerMetadata = authorizationServerMetadata
-    self.preAuthorizationServerMetadata = preAuthorizationServerMetadata
+    self.grantsMetadata = grantsMetadata
     self.issuerMetadata = issuerMetadata
     self.config = config
 
-    if let challengeEndpoint = authorizationServerMetadata.challengeEndpointURI {
+    let primaryMetadata = grantsMetadata.primary
+    if let challengeEndpoint = primaryMetadata.challengeEndpointURI {
       challenger = ChallengeEndpointClient(
         poster: challengePoster,
         challengeEndpoint: challengeEndpoint
@@ -291,8 +292,7 @@ public actor Issuer: IssuerType {
       parPoster: parPoster,
       tokenPoster: tokenPoster,
       config: config,
-      authorizationServerMetadata: authorizationServerMetadata,
-      preAuthorizationServerMetadata: preAuthorizationServerMetadata,
+      grantsMetadata: grantsMetadata,
       credentialIssuerIdentifier: issuerMetadata.credentialIssuerIdentifier,
       dpopConstructor: dpopConstructor
     )
@@ -305,7 +305,7 @@ public actor Issuer: IssuerType {
     )
 
     try? config.client.ensureSupportedByAuthorizationServer(
-      self.authorizationServerMetadata
+      primaryMetadata
     )
 
     issuanceRequester = IssuanceRequester(
@@ -358,10 +358,8 @@ public actor Issuer: IssuerType {
       warnings = [:]
     }
 
-    // Use per-grant authorization server metadata if available
     let issuer = try Issuer(
-      authorizationServerMetadata: credentialOffer.authorizationServerMetadata,
-      preAuthorizationServerMetadata: credentialOffer.preAuthorizationCodeServerMetadata,
+      grantsMetadata: credentialOffer.grantsMetadata,
       issuerMetadata: credentialOffer.credentialIssuerMetadata,
       config: config,
       dpopConstructor: dpopConstructor,
@@ -784,14 +782,15 @@ public extension Issuer {
     deferredRequesterPoster: PostingType,
     config: OpenId4VCIConfig
   ) throws -> Issuer {
-    try Issuer(
-      authorizationServerMetadata: .oauth(
-        .init(
-          authorizationEndpoint: Constants.url,
-          tokenEndpoint: Constants.url,
-          pushedAuthorizationRequestEndpoint: Constants.url
-        )
-      ),
+    let placeholderMetadata: IdentityAndAccessManagementMetadata = .oauth(
+      .init(
+        authorizationEndpoint: Constants.url,
+        tokenEndpoint: Constants.url,
+        pushedAuthorizationRequestEndpoint: Constants.url
+      )
+    )
+    return try Issuer(
+      grantsMetadata: GrantsMetadata(shared: placeholderMetadata),
       issuerMetadata: .init(
         deferredCredentialEndpoint: deferredCredentialEndpoint,
         credentialRequestEncryption: credentialRequestEncryption

--- a/Sources/Issuers/Issuer.swift
+++ b/Sources/Issuers/Issuer.swift
@@ -136,13 +136,14 @@ public protocol IssuerType: RefreshAccessToken {
 }
 
 public actor Issuer: IssuerType {
-  
+
   public var deferredResponseEncryptionSpec: IssuanceResponseEncryptionSpec?
-  
+
   public let authorizationServerMetadata: IdentityAndAccessManagementMetadata
+  public let preAuthorizationServerMetadata: IdentityAndAccessManagementMetadata?
   public let issuerMetadata: CredentialIssuerMetadata
   public let config: OpenId4VCIConfig
-  
+
   private let authorizeIssuance: AuthorizeIssuanceType
   private let authorizer: AuthorizationServerClientType
   private let nonceEndpointClient: NonceEndpointClientType?
@@ -187,66 +188,69 @@ public actor Issuer: IssuerType {
   
   public init(
     authorizationServerMetadata: IdentityAndAccessManagementMetadata,
+    preAuthorizationServerMetadata: IdentityAndAccessManagementMetadata? = nil,
     issuerMetadata: CredentialIssuerMetadata,
     config: OpenId4VCIConfig,
     dpopConstructor: DPoPConstructorType? = nil,
     session: Networking
   ) throws {
     self.authorizationServerMetadata = authorizationServerMetadata
+    self.preAuthorizationServerMetadata = preAuthorizationServerMetadata
     self.issuerMetadata = issuerMetadata
     self.config = config
-    
+
     if let challengeEndpoint = authorizationServerMetadata.challengeEndpointURI {
       challenger = ChallengeEndpointClient(challengeEndpoint: challengeEndpoint)
     } else {
       challenger = nil
     }
-    
+
     if config.requireDpop {
       guard let dpopAlgs = authorizationServerMetadata.dpopSigningAlgValuesSupported,
             !dpopAlgs.isEmpty else {
         throw ValidationError.dpopRequired
       }
     }
-    
+
     authorizer = try AuthorizationServerClient(
       challenger: challenger,
       parPoster: Poster(session: session),
       tokenPoster: Poster(session: session),
       config: config,
       authorizationServerMetadata: authorizationServerMetadata,
+      preAuthorizationServerMetadata: preAuthorizationServerMetadata,
       credentialIssuerIdentifier: issuerMetadata.credentialIssuerIdentifier,
       dpopConstructor: config.requireDpop ? dpopConstructor : nil
     )
-    
+
     authorizeIssuance = AuthorizeIssuance(
       config: config,
       authorizer: authorizer,
       challenger: challenger,
       issuerMetadata: issuerMetadata
     )
-    
+
     try? config.client.ensureSupportedByAuthorizationServer(
       self.authorizationServerMetadata
     )
-    
+
     issuanceRequester = IssuanceRequester(
       issuerMetadata: issuerMetadata,
       poster: Poster(session: session),
       dpopConstructor: dpopConstructor
     )
-    
+
     deferredIssuanceRequester = IssuanceRequester(
       issuerMetadata: issuerMetadata,
       poster: Poster(session: session),
       dpopConstructor: dpopConstructor
     )
-    
+
     notifyIssuer = NotifyIssuer(
       issuerMetadata: issuerMetadata,
       poster: Poster(session: session)
     )
-    
+
     if let nonceEndpoint = issuerMetadata.nonceEndpoint {
       nonceEndpointClient = NonceEndpointClient(nonceEndpoint: nonceEndpoint)
     } else {
@@ -256,6 +260,7 @@ public actor Issuer: IssuerType {
   
   public init(
     authorizationServerMetadata: IdentityAndAccessManagementMetadata,
+    preAuthorizationServerMetadata: IdentityAndAccessManagementMetadata? = nil,
     issuerMetadata: CredentialIssuerMetadata,
     config: OpenId4VCIConfig,
     parPoster: PostingType = Poster(),
@@ -268,9 +273,10 @@ public actor Issuer: IssuerType {
     dpopConstructor: DPoPConstructorType? = nil
   ) throws {
     self.authorizationServerMetadata = authorizationServerMetadata
+    self.preAuthorizationServerMetadata = preAuthorizationServerMetadata
     self.issuerMetadata = issuerMetadata
     self.config = config
-    
+
     if let challengeEndpoint = authorizationServerMetadata.challengeEndpointURI {
       challenger = ChallengeEndpointClient(
         poster: challengePoster,
@@ -279,44 +285,45 @@ public actor Issuer: IssuerType {
     } else {
       challenger = nil
     }
-    
+
     authorizer = try AuthorizationServerClient(
       challenger: challenger,
       parPoster: parPoster,
       tokenPoster: tokenPoster,
       config: config,
       authorizationServerMetadata: authorizationServerMetadata,
+      preAuthorizationServerMetadata: preAuthorizationServerMetadata,
       credentialIssuerIdentifier: issuerMetadata.credentialIssuerIdentifier,
       dpopConstructor: dpopConstructor
     )
-    
+
     authorizeIssuance = AuthorizeIssuance(
       config: config,
       authorizer: authorizer,
       challenger: challenger,
       issuerMetadata: issuerMetadata
     )
-    
+
     try? config.client.ensureSupportedByAuthorizationServer(
       self.authorizationServerMetadata
     )
-    
+
     issuanceRequester = IssuanceRequester(
       issuerMetadata: issuerMetadata,
       poster: requesterPoster,
       dpopConstructor: dpopConstructor
     )
-    
+
     deferredIssuanceRequester = IssuanceRequester(
       issuerMetadata: issuerMetadata,
       poster: deferredRequesterPoster
     )
-    
+
     notifyIssuer = NotifyIssuer(
       issuerMetadata: issuerMetadata,
       poster: notificationPoster
     )
-    
+
     if let nonceEndpoint = issuerMetadata.nonceEndpoint {
       nonceEndpointClient = NonceEndpointClient(
         poster: noncePoster,
@@ -351,8 +358,10 @@ public actor Issuer: IssuerType {
       warnings = [:]
     }
 
+    // Use per-grant authorization server metadata if available
     let issuer = try Issuer(
       authorizationServerMetadata: credentialOffer.authorizationServerMetadata,
+      preAuthorizationServerMetadata: credentialOffer.preAuthorizationCodeServerMetadata,
       issuerMetadata: credentialOffer.credentialIssuerMetadata,
       config: config,
       dpopConstructor: dpopConstructor,

--- a/Sources/Main/Authorisers/AuthorizationServerClient.swift
+++ b/Sources/Main/Authorisers/AuthorizationServerClient.swift
@@ -195,11 +195,15 @@ internal actor AuthorizationServerClient: AuthorizationServerClientType {
   public let preAuthTokenEndpoint: URL
   public let redirectionURI: URL
   public let client: Client
-  public let authorizationServerMetadata: IdentityAndAccessManagementMetadata
-  public let preAuthorizationServerMetadata: IdentityAndAccessManagementMetadata?
+  public let grantsMetadata: GrantsMetadata
   public let credentialIssuerIdentifier: CredentialIssuerId
   public let dpopConstructor: DPoPConstructorType?
   public let challenger: ChallengeEndpointClientType?
+
+  /// Returns the primary authorization server metadata.
+  public var authorizationServerMetadata: IdentityAndAccessManagementMetadata {
+    grantsMetadata.primary
+  }
 
   static let responseType = "code"
   static let grantAuthorizationCode = "authorization_code"
@@ -207,17 +211,14 @@ internal actor AuthorizationServerClient: AuthorizationServerClientType {
 
   /// Initializes the authorization server client with support for per-grant authorization servers.
   /// - Parameters:
-  ///   - authorizationServerMetadata: Metadata for the authorization code flow (also used as fallback).
-  ///   - preAuthorizationServerMetadata: Optional metadata for the pre-authorization code flow.
-  ///     If nil, the authorizationServerMetadata is used for both flows.
+  ///   - grantsMetadata: Per-grant authorization server metadata.
   public init(
     service: AuthorisationServiceType = AuthorisationService(),
     challenger: ChallengeEndpointClientType?,
     parPoster: PostingType = Poster(),
     tokenPoster: PostingType = Poster(),
     config: OpenId4VCIConfig,
-    authorizationServerMetadata: IdentityAndAccessManagementMetadata,
-    preAuthorizationServerMetadata: IdentityAndAccessManagementMetadata? = nil,
+    grantsMetadata: GrantsMetadata,
     credentialIssuerIdentifier: CredentialIssuerId,
     dpopConstructor: DPoPConstructorType? = nil
   ) throws {
@@ -228,8 +229,7 @@ internal actor AuthorizationServerClient: AuthorizationServerClientType {
     self.tokenPoster = tokenPoster
     self.config = config
 
-    self.authorizationServerMetadata = authorizationServerMetadata
-    self.preAuthorizationServerMetadata = preAuthorizationServerMetadata
+    self.grantsMetadata = grantsMetadata
     self.credentialIssuerIdentifier = credentialIssuerIdentifier
 
     self.redirectionURI = config.authFlowRedirectionURI
@@ -237,8 +237,9 @@ internal actor AuthorizationServerClient: AuthorizationServerClientType {
 
     self.dpopConstructor = dpopConstructor
 
-    // Extract endpoints from authorization code flow's server metadata
-    switch authorizationServerMetadata {
+    // Extract endpoints from authorization code flow's server metadata (or primary if auth code not available)
+    let primaryMetadata = grantsMetadata.primary
+    switch primaryMetadata {
     case .oidc(let data):
 
       if let tokenEndpoint = data.tokenEndpoint, let url = URL(string: tokenEndpoint) {
@@ -281,20 +282,20 @@ internal actor AuthorizationServerClient: AuthorizationServerClientType {
     }
 
     // Extract token endpoint from pre-authorization code flow's server metadata (if different)
-    if let preAuthMetadata = preAuthorizationServerMetadata {
+    if let preAuthMetadata = grantsMetadata.preAuthorizationCode {
       switch preAuthMetadata {
       case .oidc(let data):
         if let tokenEndpoint = data.tokenEndpoint, let url = URL(string: tokenEndpoint) {
           self.preAuthTokenEndpoint = url
         } else {
-          // Fall back to auth code flow's token endpoint
+          // Fall back to primary token endpoint
           self.preAuthTokenEndpoint = self.tokenEndpoint
         }
       case .oauth(let data):
         if let tokenEndpoint = data.tokenEndpoint, let url = URL(string: tokenEndpoint) {
           self.preAuthTokenEndpoint = url
         } else {
-          // Fall back to auth code flow's token endpoint
+          // Fall back to primary token endpoint
           self.preAuthTokenEndpoint = self.tokenEndpoint
         }
       }
@@ -819,7 +820,7 @@ internal actor AuthorizationServerClient: AuthorizationServerClientType {
       )
 
       // Use the pre-authorization server's metadata for issuer ID (if available)
-      let preAuthServerIssuer = preAuthorizationServerMetadata?.issuer ?? authorizationServerMetadata.issuer
+      let preAuthServerIssuer = grantsMetadata.preAuthorizationCode?.issuer ?? authorizationServerMetadata.issuer
 
       do {
         let clientAttestation = try await generateClientAttestationIfNeeded(

--- a/Sources/Main/Authorisers/AuthorizationServerClient.swift
+++ b/Sources/Main/Authorisers/AuthorizationServerClient.swift
@@ -184,7 +184,7 @@ protocol AuthorizationServerClientType: Sendable {
 }
 
 internal actor AuthorizationServerClient: AuthorizationServerClientType {
-  
+
   public let config: OpenId4VCIConfig
   public let service: AuthorisationServiceType
   public let parPoster: PostingType
@@ -192,17 +192,24 @@ internal actor AuthorizationServerClient: AuthorizationServerClientType {
   public let parEndpoint: URL?
   public let authorizationEndpoint: URL
   public let tokenEndpoint: URL
+  public let preAuthTokenEndpoint: URL
   public let redirectionURI: URL
   public let client: Client
   public let authorizationServerMetadata: IdentityAndAccessManagementMetadata
+  public let preAuthorizationServerMetadata: IdentityAndAccessManagementMetadata?
   public let credentialIssuerIdentifier: CredentialIssuerId
   public let dpopConstructor: DPoPConstructorType?
   public let challenger: ChallengeEndpointClientType?
-  
+
   static let responseType = "code"
   static let grantAuthorizationCode = "authorization_code"
   static let grantPreauthorizationCode = "urn:ietf:params:oauth:grant-type:pre-authorized_code"
-  
+
+  /// Initializes the authorization server client with support for per-grant authorization servers.
+  /// - Parameters:
+  ///   - authorizationServerMetadata: Metadata for the authorization code flow (also used as fallback).
+  ///   - preAuthorizationServerMetadata: Optional metadata for the pre-authorization code flow.
+  ///     If nil, the authorizationServerMetadata is used for both flows.
   public init(
     service: AuthorisationServiceType = AuthorisationService(),
     challenger: ChallengeEndpointClientType?,
@@ -210,64 +217,90 @@ internal actor AuthorizationServerClient: AuthorizationServerClientType {
     tokenPoster: PostingType = Poster(),
     config: OpenId4VCIConfig,
     authorizationServerMetadata: IdentityAndAccessManagementMetadata,
+    preAuthorizationServerMetadata: IdentityAndAccessManagementMetadata? = nil,
     credentialIssuerIdentifier: CredentialIssuerId,
     dpopConstructor: DPoPConstructorType? = nil
   ) throws {
     self.service = service
     self.challenger = challenger
-    
+
     self.parPoster = parPoster
     self.tokenPoster = tokenPoster
     self.config = config
-    
+
     self.authorizationServerMetadata = authorizationServerMetadata
+    self.preAuthorizationServerMetadata = preAuthorizationServerMetadata
     self.credentialIssuerIdentifier = credentialIssuerIdentifier
-    
+
     self.redirectionURI = config.authFlowRedirectionURI
     self.client = config.client
-    
+
     self.dpopConstructor = dpopConstructor
-    
+
+    // Extract endpoints from authorization code flow's server metadata
     switch authorizationServerMetadata {
     case .oidc(let data):
-      
+
       if let tokenEndpoint = data.tokenEndpoint, let url = URL(string: tokenEndpoint) {
         self.tokenEndpoint = url
       } else {
         throw ValidationError.error(reason: "Invalid token endpoint")
       }
-      
+
       if let authorizationEndpoint = data.authorizationEndpoint, let url = URL(string: authorizationEndpoint) {
         self.authorizationEndpoint = url
       } else {
         throw ValidationError.error(reason: "Invalid authorization endpoint")
       }
-      
+
       if let pushedAuthorizationRequestEndpoint = data.pushedAuthorizationRequestEndpoint, let url = URL(string: pushedAuthorizationRequestEndpoint) {
         self.parEndpoint = url
       } else {
         self.parEndpoint = nil
       }
-      
+
     case .oauth(let data):
-      
+
       if let tokenEndpoint = data.tokenEndpoint, let url = URL(string: tokenEndpoint) {
         self.tokenEndpoint = url
       } else {
         throw ValidationError.error(reason: "Invalid token endpoint")
       }
-      
+
       if let authorizationEndpoint = data.authorizationEndpoint, let url = URL(string: authorizationEndpoint) {
         self.authorizationEndpoint = url
       } else {
         throw ValidationError.error(reason: "In valid authorization endpoint")
       }
-      
+
       if let pushedAuthorizationRequestEndpoint = data.pushedAuthorizationRequestEndpoint, let url = URL(string: pushedAuthorizationRequestEndpoint) {
         self.parEndpoint = url
       } else {
         self.parEndpoint = nil
       }
+    }
+
+    // Extract token endpoint from pre-authorization code flow's server metadata (if different)
+    if let preAuthMetadata = preAuthorizationServerMetadata {
+      switch preAuthMetadata {
+      case .oidc(let data):
+        if let tokenEndpoint = data.tokenEndpoint, let url = URL(string: tokenEndpoint) {
+          self.preAuthTokenEndpoint = url
+        } else {
+          // Fall back to auth code flow's token endpoint
+          self.preAuthTokenEndpoint = self.tokenEndpoint
+        }
+      case .oauth(let data):
+        if let tokenEndpoint = data.tokenEndpoint, let url = URL(string: tokenEndpoint) {
+          self.preAuthTokenEndpoint = url
+        } else {
+          // Fall back to auth code flow's token endpoint
+          self.preAuthTokenEndpoint = self.tokenEndpoint
+        }
+      }
+    } else {
+      // No separate pre-auth metadata, use the same token endpoint
+      self.preAuthTokenEndpoint = self.tokenEndpoint
     }
   }
   
@@ -784,12 +817,15 @@ internal actor AuthorizationServerClient: AuthorizationServerClientType {
         transactionCode: transactionCode,
         identifiers: identifiers
       )
-      
+
+      // Use the pre-authorization server's metadata for issuer ID (if available)
+      let preAuthServerIssuer = preAuthorizationServerMetadata?.issuer ?? authorizationServerMetadata.issuer
+
       do {
         let clientAttestation = try await generateClientAttestationIfNeeded(
           clock: Clock(),
           authServerId: URL(
-            string: authorizationServerMetadata.issuer ?? ""
+            string: preAuthServerIssuer ?? ""
           ),
           challenge: challenge
         )
@@ -797,15 +833,16 @@ internal actor AuthorizationServerClient: AuthorizationServerClientType {
         let clientAttestationHeaders = clientAttestationHeaders(
           clientAttestation: clientAttestation
         )
-        
+
+        // Use the pre-authorization token endpoint
         let tokenHeaders = try await tokenEndPointHeaders(
-          url: tokenEndpoint,
+          url: preAuthTokenEndpoint,
           dpopNonce: dpopNonce
         )
-        
+
         let response: ResponseWithHeaders<AccessTokenRequestResponse> = try await service.formPost(
           poster: tokenPoster,
-          url: tokenEndpoint,
+          url: preAuthTokenEndpoint,
           headers: clientAttestationHeaders + tokenHeaders,
           parameters: parameters.toDictionary().convertToDictionaryOfStrings()
         )

--- a/Sources/Main/Resolvers/CredentialOffer/CredentialOfferRequestResolver.swift
+++ b/Sources/Main/Resolvers/CredentialOffer/CredentialOfferRequestResolver.swift
@@ -91,9 +91,9 @@ public actor CredentialOfferRequestResolver {
         }
 
         // Resolve per-grant authorization server metadata
-        let perGrantMetadata: (authCodeMetadata: IdentityAndAccessManagementMetadata?, preAuthCodeMetadata: IdentityAndAccessManagementMetadata?)
+        let grantsMetadata: GrantsMetadata
         do {
-          perGrantMetadata = try await resolvePerGrantAuthorizationServers(
+          grantsMetadata = try await resolveGrantsMetadata(
             grants: credentialOfferRequestObject.grants,
             availableServers: credentialIssuerMetadata.authorizationServers
           )
@@ -101,15 +101,10 @@ public actor CredentialOfferRequestResolver {
           return .failure(error)
         }
 
-        guard perGrantMetadata.authCodeMetadata != nil || perGrantMetadata.preAuthCodeMetadata != nil else {
-          return .failure(ValidationError.error(reason: "Invalid authorization metadata"))
-        }
-
         let domain = try toDomain(
           credentialOfferRequestObject: credentialOfferRequestObject,
           credentialIssuerMetadata: credentialIssuerMetadata,
-          authorizationCodeServerMetadata: perGrantMetadata.authCodeMetadata,
-          preAuthorizationCodeServerMetadata: perGrantMetadata.preAuthCodeMetadata
+          grantsMetadata: grantsMetadata
         )
         return .success(domain)
 
@@ -126,9 +121,9 @@ public actor CredentialOfferRequestResolver {
           }
 
           // Resolve per-grant authorization server metadata
-          let perGrantMetadata: (authCodeMetadata: IdentityAndAccessManagementMetadata?, preAuthCodeMetadata: IdentityAndAccessManagementMetadata?)
+          let grantsMetadata: GrantsMetadata
           do {
-            perGrantMetadata = try await resolvePerGrantAuthorizationServers(
+            grantsMetadata = try await resolveGrantsMetadata(
               grants: credentialOfferRequestObject.grants,
               availableServers: credentialIssuerMetadata.authorizationServers
             )
@@ -136,15 +131,10 @@ public actor CredentialOfferRequestResolver {
             return .failure(error)
           }
 
-          guard perGrantMetadata.authCodeMetadata != nil || perGrantMetadata.preAuthCodeMetadata != nil else {
-            return .failure(ValidationError.error(reason: "Invalid authorization metadata"))
-          }
-
           let domain = try toDomain(
             credentialOfferRequestObject: credentialOfferRequestObject,
             credentialIssuerMetadata: credentialIssuerMetadata,
-            authorizationCodeServerMetadata: perGrantMetadata.authCodeMetadata,
-            preAuthorizationCodeServerMetadata: perGrantMetadata.preAuthCodeMetadata
+            grantsMetadata: grantsMetadata
           )
           return .success(domain)
         }
@@ -217,11 +207,11 @@ public actor CredentialOfferRequestResolver {
   }
 
   /// Resolves authorization server metadata for both grants when they specify different servers.
-  /// Returns metadata for both the authorization code and pre-authorization code flows.
-  private func resolvePerGrantAuthorizationServers(
+  /// Returns a `GrantsMetadata` containing metadata for both the authorization code and pre-authorization code flows.
+  private func resolveGrantsMetadata(
     grants: GrantsDTO?,
     availableServers: [URL]?
-  ) async throws -> (authCodeMetadata: IdentityAndAccessManagementMetadata?, preAuthCodeMetadata: IdentityAndAccessManagementMetadata?) {
+  ) async throws -> GrantsMetadata {
     let serverHints = getAuthorizationServersFromGrants(grants)
 
     var authCodeMetadata: IdentityAndAccessManagementMetadata? = nil
@@ -257,8 +247,7 @@ public actor CredentialOfferRequestResolver {
       let defaultResult = selectAuthorizationServer(hint: nil, availableServers: availableServers)
       if case .success(let defaultServer) = defaultResult {
         let defaultMetadata = try await authorizationServerMetadataResolver.resolve(url: defaultServer).get()
-        authCodeMetadata = defaultMetadata
-        preAuthCodeMetadata = defaultMetadata
+        return GrantsMetadata(shared: defaultMetadata)
       } else if case .failure(let error) = defaultResult {
         throw error
       }
@@ -279,14 +268,16 @@ public actor CredentialOfferRequestResolver {
       }
     }
 
-    return (authCodeMetadata, preAuthCodeMetadata)
+    return try GrantsMetadata(
+      authorizationCode: authCodeMetadata,
+      preAuthorizationCode: preAuthCodeMetadata
+    )
   }
 
   func toDomain(
     credentialOfferRequestObject: CredentialOfferRequestObject,
     credentialIssuerMetadata: CredentialIssuerMetadata?,
-    authorizationCodeServerMetadata: IdentityAndAccessManagementMetadata?,
-    preAuthorizationCodeServerMetadata: IdentityAndAccessManagementMetadata?
+    grantsMetadata: GrantsMetadata
   ) throws -> CredentialOffer {
 
     guard let credentialIssuerMetadata = credentialIssuerMetadata else {
@@ -302,8 +293,7 @@ public actor CredentialOfferRequestResolver {
         credentialIssuerMetadata: credentialIssuerMetadata,
         credentialConfigurationIdentifiers: credentialConfigurationIdentifiers,
         grants: grants,
-        authorizationCodeServerMetadata: authorizationCodeServerMetadata,
-        preAuthorizationCodeServerMetadata: preAuthorizationCodeServerMetadata
+        grantsMetadata: grantsMetadata
       )
     } catch {
       throw ValidationError.error(reason: error.localizedDescription)
@@ -319,8 +309,7 @@ public actor CredentialOfferRequestResolver {
     try toDomain(
       credentialOfferRequestObject: credentialOfferRequestObject,
       credentialIssuerMetadata: credentialIssuerMetadata,
-      authorizationCodeServerMetadata: authorizationServerMetadata,
-      preAuthorizationCodeServerMetadata: authorizationServerMetadata
+      grantsMetadata: GrantsMetadata(shared: authorizationServerMetadata)
     )
   }
 }

--- a/Sources/Main/Resolvers/CredentialOffer/CredentialOfferRequestResolver.swift
+++ b/Sources/Main/Resolvers/CredentialOffer/CredentialOfferRequestResolver.swift
@@ -81,7 +81,7 @@ public actor CredentialOfferRequestResolver {
         else {
           return .failure(ValidationError.error(reason: "Unable to parse credential offer request"))
         }
-        
+
         let credentialIssuerId = try CredentialIssuerId(credentialOfferRequestObject.credentialIssuer)
         guard let credentialIssuerMetadata = try? await credentialIssuerMetadataResolver.resolve(
           source: .credentialIssuer(credentialIssuerId),
@@ -90,27 +90,26 @@ public actor CredentialOfferRequestResolver {
           return .failure(ValidationError.error(reason: "Invalid credential metadata"))
         }
 
-        let authServerHint = getAuthorizationServerFromGrants(credentialOfferRequestObject.grants)
-        let authorizationServerResult = selectAuthorizationServer(
-          hint: authServerHint,
-          availableServers: credentialIssuerMetadata.authorizationServers
-        )
-
-        guard case .success(let authorizationServer) = authorizationServerResult else {
-          if case .failure(let error) = authorizationServerResult {
-            return .failure(error)
-          }
-          return .failure(ValidationError.error(reason: "Invalid authorization metadata"))
+        // Resolve per-grant authorization server metadata
+        let perGrantMetadata: (authCodeMetadata: IdentityAndAccessManagementMetadata?, preAuthCodeMetadata: IdentityAndAccessManagementMetadata?)
+        do {
+          perGrantMetadata = try await resolvePerGrantAuthorizationServers(
+            grants: credentialOfferRequestObject.grants,
+            availableServers: credentialIssuerMetadata.authorizationServers
+          )
+        } catch {
+          return .failure(error)
         }
 
-        guard let authorizationServerMetadata = try? await authorizationServerMetadataResolver.resolve(url: authorizationServer).get() else {
+        guard perGrantMetadata.authCodeMetadata != nil || perGrantMetadata.preAuthCodeMetadata != nil else {
           return .failure(ValidationError.error(reason: "Invalid authorization metadata"))
         }
 
         let domain = try toDomain(
           credentialOfferRequestObject: credentialOfferRequestObject,
           credentialIssuerMetadata: credentialIssuerMetadata,
-          authorizationServerMetadata: authorizationServerMetadata
+          authorizationCodeServerMetadata: perGrantMetadata.authCodeMetadata,
+          preAuthorizationCodeServerMetadata: perGrantMetadata.preAuthCodeMetadata
         )
         return .success(domain)
 
@@ -126,27 +125,26 @@ public actor CredentialOfferRequestResolver {
             return .failure(ValidationError.error(reason: "Invalid credential metadata"))
           }
 
-          let authServerHint = getAuthorizationServerFromGrants(credentialOfferRequestObject.grants)
-          let authorizationServerResult = selectAuthorizationServer(
-            hint: authServerHint,
-            availableServers: credentialIssuerMetadata.authorizationServers
-          )
-
-          guard case .success(let authorizationServer) = authorizationServerResult else {
-            if case .failure(let error) = authorizationServerResult {
-              return .failure(error)
-            }
-            return .failure(ValidationError.error(reason: "Invalid authorization metadata"))
+          // Resolve per-grant authorization server metadata
+          let perGrantMetadata: (authCodeMetadata: IdentityAndAccessManagementMetadata?, preAuthCodeMetadata: IdentityAndAccessManagementMetadata?)
+          do {
+            perGrantMetadata = try await resolvePerGrantAuthorizationServers(
+              grants: credentialOfferRequestObject.grants,
+              availableServers: credentialIssuerMetadata.authorizationServers
+            )
+          } catch {
+            return .failure(error)
           }
 
-          guard let authorizationServerMetadata = try? await authorizationServerMetadataResolver.resolve(url: authorizationServer).get() else {
+          guard perGrantMetadata.authCodeMetadata != nil || perGrantMetadata.preAuthCodeMetadata != nil else {
             return .failure(ValidationError.error(reason: "Invalid authorization metadata"))
           }
 
           let domain = try toDomain(
             credentialOfferRequestObject: credentialOfferRequestObject,
             credentialIssuerMetadata: credentialIssuerMetadata,
-            authorizationServerMetadata: authorizationServerMetadata
+            authorizationCodeServerMetadata: perGrantMetadata.authCodeMetadata,
+            preAuthorizationCodeServerMetadata: perGrantMetadata.preAuthCodeMetadata
           )
           return .success(domain)
         }
@@ -157,26 +155,36 @@ public actor CredentialOfferRequestResolver {
     }
   }
   
-  /// Extracts the authorization server URL from the grants if specified in the credential offer.
-  /// Checks both authorization code and pre-authorization code grants as per the specification.
-  private func getAuthorizationServerFromGrants(_ grants: GrantsDTO?) -> URL? {
-    guard let grants = grants else { return nil }
+  /// Extracts the authorization server URLs from both grants if specified in the credential offer.
+  /// Returns separate URLs for the authorization code and pre-authorization code grants.
+  private func getAuthorizationServersFromGrants(_ grants: GrantsDTO?) -> (authCode: URL?, preAuthCode: URL?) {
+    guard let grants = grants else { return (nil, nil) }
 
-    // Check authorization code grant first
+    var authCodeServer: URL? = nil
+    var preAuthCodeServer: URL? = nil
+
+    // Extract authorization code grant's server
     if let authServer = grants.authorizationCode?.authorizationServer,
        !authServer.isEmpty,
        let url = URL(string: authServer) {
-      return url
+      authCodeServer = url
     }
 
-    // Check pre-authorization code grant
+    // Extract pre-authorization code grant's server
     if let authServer = grants.preAuthorizationCode?.authorizationServer,
        !authServer.isEmpty,
        let url = URL(string: authServer) {
-      return url
+      preAuthCodeServer = url
     }
 
-    return nil
+    return (authCodeServer, preAuthCodeServer)
+  }
+
+  /// Legacy method for backward compatibility - returns a single authorization server hint.
+  /// Prefers authorization code grant's server, falls back to pre-authorization code grant's server.
+  private func getAuthorizationServerFromGrants(_ grants: GrantsDTO?) -> URL? {
+    let servers = getAuthorizationServersFromGrants(grants)
+    return servers.authCode ?? servers.preAuthCode
   }
 
   /// Selects the authorization server based on the hint from the credential offer.
@@ -208,16 +216,83 @@ public actor CredentialOfferRequestResolver {
     ))
   }
 
+  /// Resolves authorization server metadata for both grants when they specify different servers.
+  /// Returns metadata for both the authorization code and pre-authorization code flows.
+  private func resolvePerGrantAuthorizationServers(
+    grants: GrantsDTO?,
+    availableServers: [URL]?
+  ) async throws -> (authCodeMetadata: IdentityAndAccessManagementMetadata?, preAuthCodeMetadata: IdentityAndAccessManagementMetadata?) {
+    let serverHints = getAuthorizationServersFromGrants(grants)
+
+    var authCodeMetadata: IdentityAndAccessManagementMetadata? = nil
+    var preAuthCodeMetadata: IdentityAndAccessManagementMetadata? = nil
+
+    // Resolve authorization code grant's server if specified
+    if let authCodeHint = serverHints.authCode {
+      let selectedResult = selectAuthorizationServer(hint: authCodeHint, availableServers: availableServers)
+      if case .success(let selectedServer) = selectedResult {
+        authCodeMetadata = try await authorizationServerMetadataResolver.resolve(url: selectedServer).get()
+      } else if case .failure(let error) = selectedResult {
+        throw error
+      }
+    }
+
+    // Resolve pre-authorization code grant's server if specified
+    if let preAuthCodeHint = serverHints.preAuthCode {
+      // If same as auth code server, reuse the metadata
+      if preAuthCodeHint == serverHints.authCode, let existingMetadata = authCodeMetadata {
+        preAuthCodeMetadata = existingMetadata
+      } else {
+        let selectedResult = selectAuthorizationServer(hint: preAuthCodeHint, availableServers: availableServers)
+        if case .success(let selectedServer) = selectedResult {
+          preAuthCodeMetadata = try await authorizationServerMetadataResolver.resolve(url: selectedServer).get()
+        } else if case .failure(let error) = selectedResult {
+          throw error
+        }
+      }
+    }
+
+    // If neither grant specifies a server, use the default (first available)
+    if authCodeMetadata == nil && preAuthCodeMetadata == nil {
+      let defaultResult = selectAuthorizationServer(hint: nil, availableServers: availableServers)
+      if case .success(let defaultServer) = defaultResult {
+        let defaultMetadata = try await authorizationServerMetadataResolver.resolve(url: defaultServer).get()
+        authCodeMetadata = defaultMetadata
+        preAuthCodeMetadata = defaultMetadata
+      } else if case .failure(let error) = defaultResult {
+        throw error
+      }
+    }
+
+    // If only one grant specifies a server, use default for the other
+    if authCodeMetadata == nil && preAuthCodeMetadata != nil {
+      // Auth code grant doesn't specify a server, use default
+      let defaultResult = selectAuthorizationServer(hint: nil, availableServers: availableServers)
+      if case .success(let defaultServer) = defaultResult {
+        authCodeMetadata = try await authorizationServerMetadataResolver.resolve(url: defaultServer).get()
+      }
+    } else if preAuthCodeMetadata == nil && authCodeMetadata != nil {
+      // Pre-auth code grant doesn't specify a server, use default
+      let defaultResult = selectAuthorizationServer(hint: nil, availableServers: availableServers)
+      if case .success(let defaultServer) = defaultResult {
+        preAuthCodeMetadata = try await authorizationServerMetadataResolver.resolve(url: defaultServer).get()
+      }
+    }
+
+    return (authCodeMetadata, preAuthCodeMetadata)
+  }
+
   func toDomain(
     credentialOfferRequestObject: CredentialOfferRequestObject,
     credentialIssuerMetadata: CredentialIssuerMetadata?,
-    authorizationServerMetadata: IdentityAndAccessManagementMetadata
+    authorizationCodeServerMetadata: IdentityAndAccessManagementMetadata?,
+    preAuthorizationCodeServerMetadata: IdentityAndAccessManagementMetadata?
   ) throws -> CredentialOffer {
-    
+
     guard let credentialIssuerMetadata = credentialIssuerMetadata else {
       throw ValidationError.error(reason: "Invalid to fetch credential offer request by reference")
     }
-    
+
     do {
       let credentialIssuerId = credentialIssuerMetadata.credentialIssuerIdentifier
       let credentialConfigurationIdentifiers: [CredentialConfigurationIdentifier] = credentialOfferRequestObject.credentialConfigurationIds.compactMap { try? CredentialConfigurationIdentifier(value: $0.stringValue) }
@@ -227,10 +302,25 @@ public actor CredentialOfferRequestResolver {
         credentialIssuerMetadata: credentialIssuerMetadata,
         credentialConfigurationIdentifiers: credentialConfigurationIdentifiers,
         grants: grants,
-        authorizationServerMetadata: authorizationServerMetadata
+        authorizationCodeServerMetadata: authorizationCodeServerMetadata,
+        preAuthorizationCodeServerMetadata: preAuthorizationCodeServerMetadata
       )
     } catch {
       throw ValidationError.error(reason: error.localizedDescription)
     }
+  }
+
+  /// Legacy toDomain for backward compatibility
+  func toDomain(
+    credentialOfferRequestObject: CredentialOfferRequestObject,
+    credentialIssuerMetadata: CredentialIssuerMetadata?,
+    authorizationServerMetadata: IdentityAndAccessManagementMetadata
+  ) throws -> CredentialOffer {
+    try toDomain(
+      credentialOfferRequestObject: credentialOfferRequestObject,
+      credentialIssuerMetadata: credentialIssuerMetadata,
+      authorizationCodeServerMetadata: authorizationServerMetadata,
+      preAuthorizationCodeServerMetadata: authorizationServerMetadata
+    )
   }
 }

--- a/Sources/Resources/europa/credential_offer_with_different_auth_servers_per_grant.json
+++ b/Sources/Resources/europa/credential_offer_with_different_auth_servers_per_grant.json
@@ -1,0 +1,21 @@
+{
+  "credential_issuer": "https://credential-issuer.example.com",
+  "credential_configuration_ids": [
+    "UniversityDegree_JWT",
+    "MobileDrivingLicense_msoMdoc"
+  ],
+  "grants": {
+    "authorization_code": {
+      "issuer_state": "eyJhbGciOiJSU0EtFYUaBy",
+      "authorization_server": "https://example.com/realms/pid-issuer-realm"
+    },
+    "urn:ietf:params:oauth:grant-type:pre-authorized_code": {
+      "pre-authorized_code": "SplxlOBeZQQYbYS6WxSbIA",
+      "authorization_server": "https://auth-server-two.example.com",
+      "tx_code": {
+        "input_mode": "numeric",
+        "length": 6
+      }
+    }
+  }
+}

--- a/Sources/Resources/europa/oidc_authorization_server_metadata_second.json
+++ b/Sources/Resources/europa/oidc_authorization_server_metadata_second.json
@@ -1,0 +1,38 @@
+{
+  "issuer": "https://auth-server-two.example.com",
+  "authorization_endpoint": "https://auth-server-two.example.com/protocol/openid-connect/auth",
+  "token_endpoint": "https://auth-server-two.example.com/protocol/openid-connect/token",
+  "introspection_endpoint": "https://auth-server-two.example.com/protocol/openid-connect/token/introspect",
+  "userinfo_endpoint": "https://auth-server-two.example.com/protocol/openid-connect/userinfo",
+  "end_session_endpoint": "https://auth-server-two.example.com/protocol/openid-connect/logout",
+  "frontchannel_logout_session_supported": true,
+  "frontchannel_logout_supported": true,
+  "jwks_uri": "https://auth-server-two.example.com/protocol/openid-connect/certs",
+  "grant_types_supported": [
+    "authorization_code",
+    "urn:ietf:params:oauth:grant-type:pre-authorized_code",
+    "refresh_token"
+  ],
+  "response_types_supported": [
+    "code"
+  ],
+  "subject_types_supported": [
+    "public"
+  ],
+  "id_token_signing_alg_values_supported": [
+    "ES256",
+    "RS256"
+  ],
+  "token_endpoint_auth_methods_supported": [
+    "private_key_jwt",
+    "client_secret_basic"
+  ],
+  "code_challenge_methods_supported": [
+    "S256"
+  ],
+  "dpop_signing_alg_values_supported": [
+    "ES256",
+    "RS256"
+  ],
+  "pushed_authorization_request_endpoint": "https://auth-server-two.example.com/protocol/openid-connect/ext/par/request"
+}

--- a/Tests/AttestationBased/KeyAttestationTests.swift
+++ b/Tests/AttestationBased/KeyAttestationTests.swift
@@ -517,7 +517,7 @@ class KeyAttestationTests: XCTestCase {
     let offer = try XCTUnwrap(offerOptional)
     let spec = data.spec
     let issuer = try Issuer(
-      authorizationServerMetadata: offer.authorizationServerMetadata,
+      grantsMetadata: offer.grantsMetadata,
       issuerMetadata: offer.credentialIssuerMetadata,
       config: config,
       parPoster: Poster(session: NetworkingMock(path: "pushed_authorization_request_response", extension: "json")),
@@ -597,7 +597,7 @@ extension KeyAttestationTests {
     
     let offer = await TestsConstants.createMockCredentialOfferopenidKeyAttestationRequired()!
     let issuer = try Issuer(
-      authorizationServerMetadata: offer.authorizationServerMetadata,
+      grantsMetadata: offer.grantsMetadata,
       issuerMetadata: offer.credentialIssuerMetadata,
       config: config,
       parPoster: Poster(

--- a/Tests/Helpers/Wallet.swift
+++ b/Tests/Helpers/Wallet.swift
@@ -105,7 +105,7 @@ extension Wallet {
     
     let issuerMetadata = offer.credentialIssuerMetadata
     let issuer = try Issuer(
-      authorizationServerMetadata: offer.authorizationServerMetadata,
+      grantsMetadata: offer.grantsMetadata,
       issuerMetadata: issuerMetadata,
       config: config,
       parPoster: Poster(session: self.session),
@@ -148,7 +148,7 @@ extension Wallet {
   ) async throws -> Credential {
     
     let issuer = try Issuer(
-      authorizationServerMetadata: offer.authorizationServerMetadata,
+      grantsMetadata: offer.grantsMetadata,
       issuerMetadata: offer.credentialIssuerMetadata,
       config: config,
       dpopConstructor: dpopConstructor(
@@ -284,7 +284,7 @@ extension Wallet {
     }
     
     let issuer = try Issuer(
-      authorizationServerMetadata: offer.authorizationServerMetadata,
+      grantsMetadata: offer.grantsMetadata,
       issuerMetadata: offer.credentialIssuerMetadata,
       config: config,
       parPoster: Poster(session: self.session),
@@ -321,7 +321,7 @@ extension Wallet {
     }
     
     let issuer = try Issuer(
-      authorizationServerMetadata: offer.authorizationServerMetadata,
+      grantsMetadata: offer.grantsMetadata,
       issuerMetadata: offer.credentialIssuerMetadata,
       config: config,
       parPoster: Poster(session: self.session),

--- a/Tests/Issuance/IssuanceAuthorizationTest.swift
+++ b/Tests/Issuance/IssuanceAuthorizationTest.swift
@@ -37,7 +37,7 @@ class IssuanceAuthorizationTest: XCTestCase {
     
     // When
     let issuer = try Issuer(
-      authorizationServerMetadata: offer.authorizationServerMetadata,
+      grantsMetadata: offer.grantsMetadata,
       issuerMetadata: offer.credentialIssuerMetadata,
       config: config,
       parPoster: Poster(
@@ -73,7 +73,7 @@ class IssuanceAuthorizationTest: XCTestCase {
     
     // When
     let issuer = try Issuer(
-      authorizationServerMetadata: offer.authorizationServerMetadata,
+      grantsMetadata: offer.grantsMetadata,
       issuerMetadata: offer.credentialIssuerMetadata,
       config: config,
       parPoster: Poster(
@@ -109,7 +109,7 @@ class IssuanceAuthorizationTest: XCTestCase {
     
     // When
     let issuer = try Issuer(
-      authorizationServerMetadata: offer.authorizationServerMetadata,
+      grantsMetadata: offer.grantsMetadata,
       issuerMetadata: offer.credentialIssuerMetadata,
       config: config,
       parPoster: Poster(
@@ -154,7 +154,7 @@ class IssuanceAuthorizationTest: XCTestCase {
     
     // When
     let issuer = try Issuer(
-      authorizationServerMetadata: offer.authorizationServerMetadata,
+      grantsMetadata: offer.grantsMetadata,
       issuerMetadata: offer.credentialIssuerMetadata,
       config: config,
       parPoster: Poster(
@@ -198,7 +198,7 @@ class IssuanceAuthorizationTest: XCTestCase {
     
     // When
     let issuer = try Issuer(
-      authorizationServerMetadata: offer.authorizationServerMetadata,
+      grantsMetadata: offer.grantsMetadata,
       issuerMetadata: offer.credentialIssuerMetadata,
       config: config,
       parPoster: Poster(
@@ -241,7 +241,7 @@ class IssuanceAuthorizationTest: XCTestCase {
     
     // When
     let issuer = try Issuer(
-      authorizationServerMetadata: offer.authorizationServerMetadata,
+      grantsMetadata: offer.grantsMetadata,
       issuerMetadata: offer.credentialIssuerMetadata,
       config: config,
       parPoster: Poster(
@@ -320,7 +320,7 @@ class IssuanceAuthorizationTest: XCTestCase {
     let offer: CredentialOffer = try resolution.get()
     let issuerMetadata = offer.credentialIssuerMetadata
     let issuer = try Issuer(
-      authorizationServerMetadata: offer.authorizationServerMetadata,
+      grantsMetadata: offer.grantsMetadata,
       issuerMetadata: issuerMetadata,
       config: config,
       dpopConstructor: dpopConstructor(
@@ -461,7 +461,7 @@ class IssuanceAuthorizationTest: XCTestCase {
     let offer: CredentialOffer = try resolution.get()
     let issuerMetadata = offer.credentialIssuerMetadata
     let issuer = try Issuer(
-      authorizationServerMetadata: offer.authorizationServerMetadata,
+      grantsMetadata: offer.grantsMetadata,
       issuerMetadata: issuerMetadata,
       config: attestationConfig,
       dpopConstructor: dpopConstructor(
@@ -543,7 +543,7 @@ class IssuanceAuthorizationTest: XCTestCase {
     let offer: CredentialOffer = try resolution.get()
     let issuerMetadata = offer.credentialIssuerMetadata
     let issuer = try Issuer(
-      authorizationServerMetadata: offer.authorizationServerMetadata,
+      grantsMetadata: offer.grantsMetadata,
       issuerMetadata: issuerMetadata,
       config: config,
       dpopConstructor: dpopConstructor(
@@ -667,7 +667,7 @@ class IssuanceAuthorizationTest: XCTestCase {
     let offer: CredentialOffer = try resolution.get()
     let issuerMetadata = offer.credentialIssuerMetadata
     let issuer = try Issuer(
-      authorizationServerMetadata: offer.authorizationServerMetadata,
+      grantsMetadata: offer.grantsMetadata,
       issuerMetadata: issuerMetadata,
       config: config,
       dpopConstructor: dpopConstructor(

--- a/Tests/Issuance/IssuanceBatchRequestTest.swift
+++ b/Tests/Issuance/IssuanceBatchRequestTest.swift
@@ -58,7 +58,7 @@ class IssuanceBatchRequestTest: XCTestCase {
     
     // When
     let issuer = try Issuer(
-      authorizationServerMetadata: offer.authorizationServerMetadata,
+      grantsMetadata: offer.grantsMetadata,
       issuerMetadata: offer.credentialIssuerMetadata,
       config: config,
       parPoster: Poster(

--- a/Tests/Issuance/IssuanceDeferredRequestTest.swift
+++ b/Tests/Issuance/IssuanceDeferredRequestTest.swift
@@ -56,7 +56,7 @@ class IssuanceDeferredRequestTest: XCTestCase {
     
     // When
     let issuer = try Issuer(
-      authorizationServerMetadata: offer.authorizationServerMetadata,
+      grantsMetadata: offer.grantsMetadata,
       issuerMetadata: offer.credentialIssuerMetadata,
       config: config,
       parPoster: Poster(

--- a/Tests/Issuance/IssuanceEncryptionTest.swift
+++ b/Tests/Issuance/IssuanceEncryptionTest.swift
@@ -224,7 +224,7 @@ extension IssuanceEncryptionTest {
     }
 
     let issuer = try Issuer(
-      authorizationServerMetadata: offer.authorizationServerMetadata,
+      grantsMetadata: offer.grantsMetadata,
       issuerMetadata: offer.credentialIssuerMetadata,
       config: config,
       parPoster: Poster(
@@ -271,7 +271,7 @@ extension IssuanceEncryptionTest {
     }
 
     let issuer = try Issuer(
-      authorizationServerMetadata: offer.authorizationServerMetadata,
+      grantsMetadata: offer.grantsMetadata,
       issuerMetadata: offer.credentialIssuerMetadata,
       config: config,
       parPoster: Poster(

--- a/Tests/Issuance/IssuanceNotificationTest.swift
+++ b/Tests/Issuance/IssuanceNotificationTest.swift
@@ -57,7 +57,7 @@ class IssuanceNotificationTest: XCTestCase {
     
     // When
     let issuer = try Issuer(
-      authorizationServerMetadata: offer.authorizationServerMetadata,
+      grantsMetadata: offer.grantsMetadata,
       issuerMetadata: offer.credentialIssuerMetadata,
       config: config,
       parPoster: Poster(
@@ -174,7 +174,7 @@ class IssuanceNotificationTest: XCTestCase {
     
     // When
     let issuer = try Issuer(
-      authorizationServerMetadata: offer.authorizationServerMetadata,
+      grantsMetadata: offer.grantsMetadata,
       issuerMetadata: offer.credentialIssuerMetadata,
       config: config,
       parPoster: Poster(

--- a/Tests/Issuance/IssuanceRefreshTokenTest.swift
+++ b/Tests/Issuance/IssuanceRefreshTokenTest.swift
@@ -54,7 +54,7 @@ class IssuanceRefreshTokenTest: XCTestCase {
 
     // Create issuer with mock token endpoint
     let issuer = try Issuer(
-      authorizationServerMetadata: offer.authorizationServerMetadata,
+      grantsMetadata: offer.grantsMetadata,
       issuerMetadata: offer.credentialIssuerMetadata,
       config: config,
       tokenPoster: Poster(
@@ -111,7 +111,7 @@ class IssuanceRefreshTokenTest: XCTestCase {
     )
 
     let issuer = try Issuer(
-      authorizationServerMetadata: offer.authorizationServerMetadata,
+      grantsMetadata: offer.grantsMetadata,
       issuerMetadata: offer.credentialIssuerMetadata,
       config: config
     )
@@ -160,7 +160,7 @@ class IssuanceRefreshTokenTest: XCTestCase {
     )
 
     let issuer = try Issuer(
-      authorizationServerMetadata: offer.authorizationServerMetadata,
+      grantsMetadata: offer.grantsMetadata,
       issuerMetadata: offer.credentialIssuerMetadata,
       config: config,
       tokenPoster: Poster(

--- a/Tests/Issuance/IssuanceSingleRequestTest.swift
+++ b/Tests/Issuance/IssuanceSingleRequestTest.swift
@@ -57,7 +57,7 @@ class IssuanceSingleRequestTest: XCTestCase {
     
     // When
     let issuer = try Issuer(
-      authorizationServerMetadata: offer.authorizationServerMetadata,
+      grantsMetadata: offer.grantsMetadata,
       issuerMetadata: offer.credentialIssuerMetadata,
       config: config,
       parPoster: Poster(
@@ -163,7 +163,7 @@ class IssuanceSingleRequestTest: XCTestCase {
     
     // When
     let issuer = try Issuer(
-      authorizationServerMetadata: offer.authorizationServerMetadata,
+      grantsMetadata: offer.grantsMetadata,
       issuerMetadata: offer.credentialIssuerMetadata,
       config: config,
       parPoster: Poster(
@@ -274,7 +274,7 @@ class IssuanceSingleRequestTest: XCTestCase {
     
     // When
     let issuer = try Issuer(
-      authorizationServerMetadata: offer.authorizationServerMetadata,
+      grantsMetadata: offer.grantsMetadata,
       issuerMetadata: offer.credentialIssuerMetadata,
       config: config,
       parPoster: Poster(

--- a/Tests/Mocks/NetworkingMock.swift
+++ b/Tests/Mocks/NetworkingMock.swift
@@ -19,12 +19,12 @@ import XCTest
 @testable import OpenID4VCI
 
 final class NetworkingMock: Networking {
-  
+
   let path: String
   let `extension`: String
   let statusCode: Int
   let headers: [String: String]
-  
+
   init(
     path: String,
     `extension`: String,
@@ -36,7 +36,7 @@ final class NetworkingMock: Networking {
     self.statusCode = statusCode
     self.headers = headers
   }
-  
+
   func data(
     from url: URL
   ) async throws -> (Data, URLResponse) {
@@ -52,10 +52,106 @@ final class NetworkingMock: Networking {
     )
     return try (result.get(), response!)
   }
-  
+
   func data(
     for request: URLRequest
   ) async throws -> (Data, URLResponse) {
     return try await data(from: URL(string: "https://www.example.com")!)
+  }
+}
+
+/// A networking mock that routes different URL patterns to different resource files.
+/// Useful for testing scenarios where multiple different endpoints need to return different data.
+final class RoutingNetworkingMock: Networking {
+
+  struct Route {
+    let urlPattern: String
+    let path: String
+    let `extension`: String
+    let statusCode: Int
+    let headers: [String: String]
+
+    init(
+      urlPattern: String,
+      path: String,
+      extension: String,
+      statusCode: Int = 200,
+      headers: [String: String] = [:]
+    ) {
+      self.urlPattern = urlPattern
+      self.path = path
+      self.extension = `extension`
+      self.statusCode = statusCode
+      self.headers = headers
+    }
+  }
+
+  let routes: [Route]
+  let fallbackPath: String
+  let fallbackExtension: String
+
+  init(
+    routes: [Route],
+    fallbackPath: String = "test",
+    fallbackExtension: String = "json"
+  ) {
+    self.routes = routes
+    self.fallbackPath = fallbackPath
+    self.fallbackExtension = fallbackExtension
+  }
+
+  func data(
+    from url: URL
+  ) async throws -> (Data, URLResponse) {
+    let urlString = url.absoluteString
+
+    // Find matching route
+    let matchedRoute = routes.first { route in
+      urlString.contains(route.urlPattern)
+    }
+
+    let resourcePath: String
+    let resourceExtension: String
+    let statusCode: Int
+    let headers: [String: String]
+
+    if let route = matchedRoute {
+      resourcePath = route.path
+      resourceExtension = route.extension
+      statusCode = route.statusCode
+      headers = route.headers
+    } else {
+      resourcePath = fallbackPath
+      resourceExtension = fallbackExtension
+      statusCode = 200
+      headers = [:]
+    }
+
+    guard let filePath = Bundle.module.path(forResource: resourcePath, ofType: resourceExtension) else {
+      throw NSError(domain: "NetworkingMock", code: 404, userInfo: [
+        NSLocalizedDescriptionKey: "Resource not found: \(resourcePath).\(resourceExtension)"
+      ])
+    }
+
+    let fileURL = URL(fileURLWithPath: filePath)
+    let data = try Data(contentsOf: fileURL)
+    let response = HTTPURLResponse(
+      url: url,
+      statusCode: statusCode,
+      httpVersion: nil,
+      headerFields: headers
+    )!
+    return (data, response)
+  }
+
+  func data(
+    for request: URLRequest
+  ) async throws -> (Data, URLResponse) {
+    guard let url = request.url else {
+      throw NSError(domain: "NetworkingMock", code: 400, userInfo: [
+        NSLocalizedDescriptionKey: "Request has no URL"
+      ])
+    }
+    return try await data(from: url)
   }
 }

--- a/Tests/Resolver/CredentialOfferResolverTests.swift
+++ b/Tests/Resolver/CredentialOfferResolverTests.swift
@@ -645,4 +645,251 @@ class CredentialOfferResolverTests: XCTestCase {
       XCTFail("Expected success but got failure: \(error.localizedDescription)")
     }
   }
+
+  // MARK: - Per-Grant Authorization Server Tests
+
+  func testResolvesCredentialOfferWithDifferentAuthServersPerGrant() async throws {
+    // Given: A credential offer where authorization_code and pre-authorized_code
+    // grants specify DIFFERENT authorization servers
+    let credentialIssuerMetadataResolver = CredentialIssuerMetadataResolver(
+      fetcher: MetadataFetcher(
+        rawFetcher: RawDataFetcher(
+          session: NetworkingMock(
+            path: "credential_issuer_metadata_multiple_auth_servers",
+            extension: "json",
+            headers: ["Content-Type": "application/json"]
+        ))))
+
+    // Use routing mock to return different metadata for each auth server
+    let routingMock = RoutingNetworkingMock(routes: [
+      .init(
+        urlPattern: "example.com/realms/pid-issuer-realm",
+        path: "oidc_authorization_server_metadata",
+        extension: "json"
+      ),
+      .init(
+        urlPattern: "auth-server-two.example.com",
+        path: "oidc_authorization_server_metadata_second",
+        extension: "json"
+      )
+    ])
+
+    let authorizationServerMetadataResolver = AuthorizationServerMetadataResolver(
+      oidcFetcher: Fetcher<OIDCProviderMetadata>(session: routingMock),
+      oauthFetcher: Fetcher<AuthorizationServerMetadata>(session: routingMock)
+    )
+
+    let credentialOfferRequestResolver = CredentialOfferRequestResolver(
+      fetcher: Fetcher<CredentialOfferRequestObject>(session: NetworkingMock(
+        path: "credential_offer_with_different_auth_servers_per_grant",
+        extension: "json"
+      )),
+      credentialIssuerMetadataResolver: credentialIssuerMetadataResolver,
+      authorizationServerMetadataResolver: authorizationServerMetadataResolver
+    )
+
+    // When
+    let result = await credentialOfferRequestResolver.resolve(
+      source: .fetchByReference(url: .stub()),
+      policy: .ignoreSigned
+    )
+
+    // Then
+    switch result {
+    case .success(let credentialOffer):
+      // Verify it's a .both grant
+      guard case .both(let authCode, let preAuthCode) = credentialOffer.grants else {
+        XCTFail("Expected .both grants but got: \(String(describing: credentialOffer.grants))")
+        return
+      }
+
+      // Verify the grants have different authorization servers
+      XCTAssertEqual(
+        authCode.authorizationServer?.absoluteString,
+        "https://example.com/realms/pid-issuer-realm"
+      )
+      XCTAssertEqual(
+        preAuthCode.authorizationServer?.absoluteString,
+        "https://auth-server-two.example.com"
+      )
+
+      // Verify per-grant metadata was resolved
+      XCTAssertNotNil(credentialOffer.authorizationCodeServerMetadata)
+      XCTAssertNotNil(credentialOffer.preAuthorizationCodeServerMetadata)
+
+      // Verify the auth code server metadata points to the first server
+      XCTAssertEqual(
+        credentialOffer.authorizationCodeServerMetadata?.issuer,
+        nil
+      )
+
+      // Verify the pre-auth code server metadata points to the second server
+      XCTAssertEqual(
+        credentialOffer.preAuthorizationCodeServerMetadata?.issuer,
+        "https://auth-server-two.example.com"
+      )
+
+      // Verify the issuers (and thus token endpoints) are different
+      XCTAssertNotEqual(
+        credentialOffer.authorizationCodeServerMetadata?.issuer,
+        credentialOffer.preAuthorizationCodeServerMetadata?.issuer,
+        "Issuers should be different for different auth servers"
+      )
+
+      // Verify backward compatibility - authorizationServerMetadata should return the auth code one
+      XCTAssertEqual(
+        credentialOffer.authorizationServerMetadata.issuer,
+        nil
+      )
+
+    case .failure(let error):
+      XCTFail("Expected success but got failure: \(error.localizedDescription)")
+    }
+  }
+
+  func testCredentialOfferWithSameAuthServerForBothGrantsSharesMetadata() async throws {
+    // Given: A credential offer where both grants specify the same authorization server
+    let credentialIssuerMetadataResolver = CredentialIssuerMetadataResolver(
+      fetcher: createMetadataFetcher()
+    )
+
+    let authorizationServerMetadataResolver = AuthorizationServerMetadataResolver(
+      oidcFetcher: Fetcher<OIDCProviderMetadata>(session: NetworkingMock(
+        path: "oidc_authorization_server_metadata",
+        extension: "json"
+      )),
+      oauthFetcher: Fetcher<AuthorizationServerMetadata>(session: NetworkingMock(
+        path: "oauth_authorization_server_metadata",
+        extension: "json"
+      ))
+    )
+
+    let credentialOfferRequestResolver = CredentialOfferRequestResolver(
+      fetcher: Fetcher<CredentialOfferRequestObject>(session: NetworkingMock(
+        path: "credential_offer_with_auth_server_hint",
+        extension: "json"
+      )),
+      credentialIssuerMetadataResolver: credentialIssuerMetadataResolver,
+      authorizationServerMetadataResolver: authorizationServerMetadataResolver
+    )
+
+    // When
+    let result = await credentialOfferRequestResolver.resolve(
+      source: .fetchByReference(url: .stub()),
+      policy: .ignoreSigned
+    )
+
+    // Then
+    switch result {
+    case .success(let credentialOffer):
+      // Both metadata should be available and have the same issuer
+      XCTAssertNotNil(credentialOffer.authorizationCodeServerMetadata)
+      XCTAssertNotNil(credentialOffer.preAuthorizationCodeServerMetadata)
+
+      XCTAssertEqual(
+        credentialOffer.authorizationCodeServerMetadata?.issuer,
+        credentialOffer.preAuthorizationCodeServerMetadata?.issuer
+      )
+
+    case .failure(let error):
+      XCTFail("Expected success but got failure: \(error.localizedDescription)")
+    }
+  }
+
+  func testCredentialOfferInitializerWithPerGrantMetadata() throws {
+    // Given: Different metadata for each grant
+    let authCodeMetadata = IdentityAndAccessManagementMetadata.oauth(
+      AuthorizationServerMetadata(
+        issuer: "https://auth-server-one.example.com",
+        authorizationEndpoint: "https://auth-server-one.example.com/auth",
+        tokenEndpoint: "https://auth-server-one.example.com/token"
+      )
+    )
+
+    let preAuthCodeMetadata = IdentityAndAccessManagementMetadata.oauth(
+      AuthorizationServerMetadata(
+        issuer: "https://auth-server-two.example.com",
+        authorizationEndpoint: "https://auth-server-two.example.com/auth",
+        tokenEndpoint: "https://auth-server-two.example.com/token"
+      )
+    )
+
+    let issuerMetadata = try CredentialIssuerMetadata(
+      deferredCredentialEndpoint: nil,
+      credentialRequestEncryption: nil
+    )
+
+    // When: Creating a CredentialOffer with different per-grant metadata
+    let credentialOffer = try CredentialOffer(
+      credentialIssuerIdentifier: CredentialIssuerId("https://issuer.example.com"),
+      credentialIssuerMetadata: issuerMetadata,
+      credentialConfigurationIdentifiers: [try CredentialConfigurationIdentifier(value: "TestCredential")],
+      grants: .both(
+        try Grants.AuthorizationCode(issuerState: nil, authorizationServer: URL(string: "https://auth-server-one.example.com")),
+        Grants.PreAuthorizedCode(preAuthorizedCode: "code123", txCode: nil, authorizationServer: URL(string: "https://auth-server-two.example.com"))
+      ),
+      authorizationCodeServerMetadata: authCodeMetadata,
+      preAuthorizationCodeServerMetadata: preAuthCodeMetadata
+    )
+
+    // Then: Verify metadata is correctly stored
+    XCTAssertEqual(credentialOffer.authorizationCodeServerMetadata?.issuer, "https://auth-server-one.example.com")
+    XCTAssertEqual(credentialOffer.preAuthorizationCodeServerMetadata?.issuer, "https://auth-server-two.example.com")
+
+    // Backward compatible property should return auth code metadata
+    XCTAssertEqual(credentialOffer.authorizationServerMetadata.issuer, "https://auth-server-one.example.com")
+  }
+
+  func testCredentialOfferInitializerWithSingleMetadataBackwardCompatibility() throws {
+    // Given: Single metadata (old API)
+    let singleMetadata = IdentityAndAccessManagementMetadata.oauth(
+      AuthorizationServerMetadata(
+        issuer: "https://auth-server.example.com",
+        authorizationEndpoint: "https://auth-server.example.com/auth",
+        tokenEndpoint: "https://auth-server.example.com/token"
+      )
+    )
+
+    let issuerMetadata = try CredentialIssuerMetadata(
+      deferredCredentialEndpoint: nil,
+      credentialRequestEncryption: nil
+    )
+
+    // When: Using the backward-compatible initializer
+    let credentialOffer = try CredentialOffer(
+      credentialIssuerIdentifier: CredentialIssuerId("https://issuer.example.com"),
+      credentialIssuerMetadata: issuerMetadata,
+      credentialConfigurationIdentifiers: [try CredentialConfigurationIdentifier(value: "TestCredential")],
+      grants: nil,
+      authorizationServerMetadata: singleMetadata
+    )
+
+    // Then: Both per-grant metadata should be set to the same value
+    XCTAssertEqual(credentialOffer.authorizationCodeServerMetadata?.issuer, "https://auth-server.example.com")
+    XCTAssertEqual(credentialOffer.preAuthorizationCodeServerMetadata?.issuer, "https://auth-server.example.com")
+    XCTAssertEqual(credentialOffer.authorizationServerMetadata.issuer, "https://auth-server.example.com")
+  }
+
+  func testCredentialOfferRequiresAtLeastOneMetadata() throws {
+    // Given: No metadata provided
+    let issuerMetadata = try CredentialIssuerMetadata(
+      deferredCredentialEndpoint: nil,
+      credentialRequestEncryption: nil
+    )
+
+    // When/Then: Should throw an error
+    XCTAssertThrowsError(try CredentialOffer(
+      credentialIssuerIdentifier: CredentialIssuerId("https://issuer.example.com"),
+      credentialIssuerMetadata: issuerMetadata,
+      credentialConfigurationIdentifiers: [try CredentialConfigurationIdentifier(value: "TestCredential")],
+      grants: nil,
+      authorizationCodeServerMetadata: nil,
+      preAuthorizationCodeServerMetadata: nil
+    )) { error in
+      XCTAssertTrue(
+        error.localizedDescription.contains("authorization server metadata"),
+        "Error should mention missing metadata"
+      )
+    }
+  }
 }

--- a/Tests/Resolver/CredentialOfferResolverTests.swift
+++ b/Tests/Resolver/CredentialOfferResolverTests.swift
@@ -714,25 +714,25 @@ class CredentialOfferResolverTests: XCTestCase {
       )
 
       // Verify per-grant metadata was resolved
-      XCTAssertNotNil(credentialOffer.authorizationCodeServerMetadata)
-      XCTAssertNotNil(credentialOffer.preAuthorizationCodeServerMetadata)
+      XCTAssertNotNil(credentialOffer.grantsMetadata.authorizationCode)
+      XCTAssertNotNil(credentialOffer.grantsMetadata.preAuthorizationCode)
 
       // Verify the auth code server metadata points to the first server
       XCTAssertEqual(
-        credentialOffer.authorizationCodeServerMetadata?.issuer,
+        credentialOffer.grantsMetadata.authorizationCode?.issuer,
         nil
       )
 
       // Verify the pre-auth code server metadata points to the second server
       XCTAssertEqual(
-        credentialOffer.preAuthorizationCodeServerMetadata?.issuer,
+        credentialOffer.grantsMetadata.preAuthorizationCode?.issuer,
         "https://auth-server-two.example.com"
       )
 
       // Verify the issuers (and thus token endpoints) are different
       XCTAssertNotEqual(
-        credentialOffer.authorizationCodeServerMetadata?.issuer,
-        credentialOffer.preAuthorizationCodeServerMetadata?.issuer,
+        credentialOffer.grantsMetadata.authorizationCode?.issuer,
+        credentialOffer.grantsMetadata.preAuthorizationCode?.issuer,
         "Issuers should be different for different auth servers"
       )
 
@@ -783,12 +783,12 @@ class CredentialOfferResolverTests: XCTestCase {
     switch result {
     case .success(let credentialOffer):
       // Both metadata should be available and have the same issuer
-      XCTAssertNotNil(credentialOffer.authorizationCodeServerMetadata)
-      XCTAssertNotNil(credentialOffer.preAuthorizationCodeServerMetadata)
+      XCTAssertNotNil(credentialOffer.grantsMetadata.authorizationCode)
+      XCTAssertNotNil(credentialOffer.grantsMetadata.preAuthorizationCode)
 
       XCTAssertEqual(
-        credentialOffer.authorizationCodeServerMetadata?.issuer,
-        credentialOffer.preAuthorizationCodeServerMetadata?.issuer
+        credentialOffer.grantsMetadata.authorizationCode?.issuer,
+        credentialOffer.grantsMetadata.preAuthorizationCode?.issuer
       )
 
     case .failure(let error):
@@ -828,13 +828,15 @@ class CredentialOfferResolverTests: XCTestCase {
         try Grants.AuthorizationCode(issuerState: nil, authorizationServer: URL(string: "https://auth-server-one.example.com")),
         Grants.PreAuthorizedCode(preAuthorizedCode: "code123", txCode: nil, authorizationServer: URL(string: "https://auth-server-two.example.com"))
       ),
-      authorizationCodeServerMetadata: authCodeMetadata,
-      preAuthorizationCodeServerMetadata: preAuthCodeMetadata
+      grantsMetadata: try GrantsMetadata(
+        authorizationCode: authCodeMetadata,
+        preAuthorizationCode: preAuthCodeMetadata
+      )
     )
 
     // Then: Verify metadata is correctly stored
-    XCTAssertEqual(credentialOffer.authorizationCodeServerMetadata?.issuer, "https://auth-server-one.example.com")
-    XCTAssertEqual(credentialOffer.preAuthorizationCodeServerMetadata?.issuer, "https://auth-server-two.example.com")
+    XCTAssertEqual(credentialOffer.grantsMetadata.authorizationCode?.issuer, "https://auth-server-one.example.com")
+    XCTAssertEqual(credentialOffer.grantsMetadata.preAuthorizationCode?.issuer, "https://auth-server-two.example.com")
 
     // Backward compatible property should return auth code metadata
     XCTAssertEqual(credentialOffer.authorizationServerMetadata.issuer, "https://auth-server-one.example.com")
@@ -865,8 +867,8 @@ class CredentialOfferResolverTests: XCTestCase {
     )
 
     // Then: Both per-grant metadata should be set to the same value
-    XCTAssertEqual(credentialOffer.authorizationCodeServerMetadata?.issuer, "https://auth-server.example.com")
-    XCTAssertEqual(credentialOffer.preAuthorizationCodeServerMetadata?.issuer, "https://auth-server.example.com")
+    XCTAssertEqual(credentialOffer.grantsMetadata.authorizationCode?.issuer, "https://auth-server.example.com")
+    XCTAssertEqual(credentialOffer.grantsMetadata.preAuthorizationCode?.issuer, "https://auth-server.example.com")
     XCTAssertEqual(credentialOffer.authorizationServerMetadata.issuer, "https://auth-server.example.com")
   }
 
@@ -877,14 +879,10 @@ class CredentialOfferResolverTests: XCTestCase {
       credentialRequestEncryption: nil
     )
 
-    // When/Then: Should throw an error
-    XCTAssertThrowsError(try CredentialOffer(
-      credentialIssuerIdentifier: CredentialIssuerId("https://issuer.example.com"),
-      credentialIssuerMetadata: issuerMetadata,
-      credentialConfigurationIdentifiers: [try CredentialConfigurationIdentifier(value: "TestCredential")],
-      grants: nil,
-      authorizationCodeServerMetadata: nil,
-      preAuthorizationCodeServerMetadata: nil
+    // When/Then: Should throw an error when creating GrantsMetadata with no metadata
+    XCTAssertThrowsError(try GrantsMetadata(
+      authorizationCode: nil,
+      preAuthorizationCode: nil
     )) { error in
       XCTAssertTrue(
         error.localizedDescription.contains("authorization server metadata"),


### PR DESCRIPTION
# Description of change

Addresses #314 

## Per-Grant Authorization Server Support

When a credential offer specifies different authorization servers for `authorization_code` and `pre-authorized_code` grants, the library now correctly routes token requests to the appropriate server.                                                         
 
```                                                                                                                             
{                                                                                                                              
  "grants": {                                                                                                                  
    "authorization_code": { "authorization_server": "https://auth-server-A.example" },                                         
      "pre-authorized_code": {                                                                                                   
         "pre-authorized_code": "SECRET",                                                                                         
         "authorization_server": "https://auth-server-B.example"                                                                  
      }                                                                                                                          
   }                                                                                                                            
}                                                                                                                              
```

The resolved `CredentialOffer` now contains a `GrantsMetadata` property that holds per-grant authorization server metadata:        
                               
```                                                                                                 
offer.grantsMetadata.authorizationCode    // metadata for auth code flow                                                       
offer.grantsMetadata.preAuthorizationCode // metadata for pre-auth flow                                                        
offer.grantsMetadata.primary              // primary (prefers auth code)                                                       
offer.authorizationServerMetadata         // backward compatible, returns primary 
```

*Endpoint routing is automatic*. The library selects the correct token endpoint based on which flow you use:                     
  
```                                                                                                                               
// Auth code flow ~> uses auth-server-A's token endpoint                                                                        
let authorized = try await issuer.authorizeWithAuthorizationCode(...)                                                          
                                                                                                                                 
// Pre-auth flow ~> uses auth-server-B's token endpoint                                                                         
let authorized = try await issuer.authorizeWithPreAuthorizationCode(...)                                                       
```
                                                                                                                            
*No changes required* if you use `Issuer.make()`:                                                                                  
 
```                                                                                                                    
let result = try await Issuer.make(credentialOffer: offer, config: config, session: urlSession)                                
let issuer = result.issuer                                                                                                     
```

Just call the appropriate flow method, routing is handled automatically.                                                                                                                                                                                     
If creating Issuer manually, pass grantsMetadata:                                                                              
  
```                                                                                                                               
let issuer = try Issuer(                                                                                                       
  grantsMetadata: offer.grantsMetadata,  // instead of authorizationServerMetadata                                             
  issuerMetadata: offer.credentialIssuerMetadata,                                                                              
  ...                                                                                                                          
)   
```

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [ ] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes