### PR TITLE
Reject credential offers with different authorization servers in both grants

### DIFF
--- a/Sources/Entities/Types/Grants.swift
+++ b/Sources/Entities/Types/Grants.swift
@@ -68,6 +68,17 @@ extension GrantsDTO {
   func toDomain() throws -> Grants {
     if let authorizationCode = authorizationCode,
        let preAuthorizationCode = preAuthorizationCode {
+
+      // CredentialOfferRequestResolver resolves the metadata of the first Authorization Server.
+      // To avoid issues, require AuthorizationCode and PreAuthorizedCode use the same Authorization Server.
+      if let authServer = authorizationCode.authorizationServer,
+         let preAuthServer = preAuthorizationCode.authorizationServer,
+         !authServer.isEmpty,
+         !preAuthServer.isEmpty,
+         authServer != preAuthServer {
+        throw CredentialOfferRequestValidationError.invalidGrants
+      }
+
       return .both(
         try Grants.AuthorizationCode(
           issuerState: authorizationCode.issuerState,

--- a/Sources/Resources/europa/credential_offer_with_different_auth_servers.json
+++ b/Sources/Resources/europa/credential_offer_with_different_auth_servers.json
@@ -1,0 +1,21 @@
+{
+  "credential_issuer": "https://credential-issuer.example.com",
+  "credential_configuration_ids": [
+    "UniversityDegree_JWT"
+  ],
+  "grants": {
+    "authorization_code": {
+      "issuer_state": "eyJhbGciOiJSU0EtFYUaBy",
+      "authorization_server": "https://example.com/realms/pid-issuer-realm"
+    },
+    "urn:ietf:params:oauth:grant-type:pre-authorized_code": {
+      "pre-authorized_code": "123456",
+      "tx_code": {
+        "length": 6,
+        "input_mode": "numeric",
+        "description": "Please enter the code"
+      },
+      "authorization_server": "https://auth-server-two.example.com"
+    }
+  }
+}

--- a/Tests/Resolver/CredentialOfferResolverTests.swift
+++ b/Tests/Resolver/CredentialOfferResolverTests.swift
@@ -645,4 +645,58 @@ class CredentialOfferResolverTests: XCTestCase {
       XCTFail("Expected success but got failure: \(error.localizedDescription)")
     }
   }
+
+  func testFailsWhenBothGrantsHaveDifferentAuthorizationServers() async throws {
+    // Given: A credential offer with both grants specifying different authorization servers
+    let credentialIssuerMetadataResolver = CredentialIssuerMetadataResolver(
+      fetcher: MetadataFetcher(
+        rawFetcher: RawDataFetcher(
+          session: NetworkingMock(
+            path: "credential_issuer_metadata_multiple_auth_servers",
+            extension: "json",
+            headers: ["Content-Type": "application/json"]
+        ))))
+
+    let authorizationServerMetadataResolver = AuthorizationServerMetadataResolver(
+      oidcFetcher: Fetcher<OIDCProviderMetadata>(session: NetworkingMock(
+        path: "oidc_authorization_server_metadata",
+        extension: "json"
+      )),
+      oauthFetcher: Fetcher<AuthorizationServerMetadata>(session: NetworkingMock(
+        path: "oauth_authorization_server_metadata",
+        extension: "json"
+      ))
+    )
+
+    let credentialOfferRequestResolver = CredentialOfferRequestResolver(
+      fetcher: Fetcher<CredentialOfferRequestObject>(session: NetworkingMock(
+        path: "credential_offer_with_different_auth_servers",
+        extension: "json"
+      )),
+      credentialIssuerMetadataResolver: credentialIssuerMetadataResolver,
+      authorizationServerMetadataResolver: authorizationServerMetadataResolver
+    )
+
+    // When
+    let result = await credentialOfferRequestResolver.resolve(
+      source: .fetchByReference(url: .stub()),
+      policy: .ignoreSigned
+    )
+
+    // Then
+    switch result {
+    case .success:
+      XCTFail("Expected failure when both grants have different authorization servers")
+
+    case .failure(let error):
+      // The error is wrapped in ValidationError, check that it mentions invalidGrants
+      let errorDescription = error.localizedDescription
+      XCTAssertTrue(
+        errorDescription.contains("CredentialOfferRequestValidationError") ||
+        errorDescription.contains("invalidGrants") ||
+        errorDescription.contains("error 4"),
+        "Error should be related to invalidGrants: \(errorDescription)"
+      )
+    }
+  }
 }


### PR DESCRIPTION
Rejects credential offers where `Grants.both` specifies different authorization servers for `authorizationCode` and            
  `preAuthorizedCode`.                                                                                                           
                                                                                                                                 
  The `CredentialOfferRequestResolver` resolves metadata for only the first authorization server. When both grants reference     
  different servers, this could route requests to the wrong token endpoint.
  
  Addresses #314