### PR TITLE
Fix: Bind Issuer & Authorization Server metadata to their discovery URLs. 

### DIFF
--- a/Sources/Entities/Errors/CredentialIssuerMetadataError.swift
+++ b/Sources/Entities/Errors/CredentialIssuerMetadataError.swift
@@ -20,6 +20,7 @@ public enum CredentialIssuerMetadataError: Error {
   case nonParseableCredentialIssuerMetadata(cause: Error)
   
   case invalidCredentialIssuerId
+  case issuerMismatch(expected: String, actual: String)
   case credentialResponseAsymmetricEncryptionAlgorithmsRequired
   case credentialRequestEncryptionMustExistIfCredentialResponseEncryptionExists
   case unsupportedRequestEncryptionMethods

--- a/Sources/Main/Resolvers/CredentialOffer/AuthorizationServerMetadataResolver.swift
+++ b/Sources/Main/Resolvers/CredentialOffer/AuthorizationServerMetadataResolver.swift
@@ -54,20 +54,20 @@ public actor AuthorizationServerMetadataResolver: AuthorizationServerMetadataRes
   public func resolve(
     url: URL
   ) async -> Result<IdentityAndAccessManagementMetadata, Error> {
-    
+
     if let oauth = await fetchAuthorizationServerMetadata(
       fetcher: oauthFetcher,
       url: url
     ) {
       return .success(.oauth(oauth))
-      
+
     } else if let oidc = await fetchOIDCProviderMetadata(
       fetcher: oidcFetcher,
       url: url
     ) {
       return .success(.oidc(oidc))
     }
-    
+
     return .failure(ValidationError.error(reason: "Unable to fetch metadata"))
   }
   
@@ -87,7 +87,10 @@ public actor AuthorizationServerMetadataResolver: AuthorizationServerMetadataRes
       return nil
     }
 
-    return try? await fetcher.fetch(url: insertedUrl).get()
+    guard let metadata = try? await fetcher.fetch(url: insertedUrl).get() else {
+      return nil
+    }
+    return isIssuerBoundToDiscoveryURL(metadata.issuer, discoveryURL: url) ? metadata : nil
   }
 
   private func fetchAuthorizationServerMetadata(
@@ -106,7 +109,21 @@ public actor AuthorizationServerMetadataResolver: AuthorizationServerMetadataRes
       return nil
     }
 
-    return try? await fetcher.fetch(url: insertedUrl).get()
+    guard let metadata = try? await fetcher.fetch(url: insertedUrl).get() else {
+      return nil
+    }
+    return isIssuerBoundToDiscoveryURL(metadata.issuer, discoveryURL: url) ? metadata : nil
+  }
+
+  // RFC 8414 §3.3 (OAuth) / OpenID Discovery (OIDC): the metadata `issuer` MUST equal the URL
+  // used to retrieve it. A branch that returns metadata failing this check is treated as
+  // "no usable metadata from this well-known" so the other branch can still be tried; if both
+  // branches fail, the caller sees a single unable-to-fetch error. This prevents a malicious AS
+  // from declaring an arbitrary issuer and receiving client-attestation PoPs audienced to
+  // another, honest server.
+  private func isIssuerBoundToDiscoveryURL(_ metadataIssuer: String?, discoveryURL: URL) -> Bool {
+    guard let metadataIssuer, !metadataIssuer.isEmpty else { return false }
+    return metadataIssuer == discoveryURL.absoluteString
   }
 }
 

--- a/Sources/Main/Resolvers/CredentialOffer/AuthorizationServerMetadataResolver.swift
+++ b/Sources/Main/Resolvers/CredentialOffer/AuthorizationServerMetadataResolver.swift
@@ -54,20 +54,20 @@ public actor AuthorizationServerMetadataResolver: AuthorizationServerMetadataRes
   public func resolve(
     url: URL
   ) async -> Result<IdentityAndAccessManagementMetadata, Error> {
-
+    
     if let oauth = await fetchAuthorizationServerMetadata(
       fetcher: oauthFetcher,
       url: url
     ) {
       return .success(.oauth(oauth))
-
+      
     } else if let oidc = await fetchOIDCProviderMetadata(
       fetcher: oidcFetcher,
       url: url
     ) {
       return .success(.oidc(oidc))
     }
-
+    
     return .failure(ValidationError.error(reason: "Unable to fetch metadata"))
   }
   
@@ -115,12 +115,7 @@ public actor AuthorizationServerMetadataResolver: AuthorizationServerMetadataRes
     return isIssuerBoundToDiscoveryURL(metadata.issuer, discoveryURL: url) ? metadata : nil
   }
 
-  // RFC 8414 §3.3 (OAuth) / OpenID Discovery (OIDC): the metadata `issuer` MUST equal the URL
-  // used to retrieve it. A branch that returns metadata failing this check is treated as
-  // "no usable metadata from this well-known" so the other branch can still be tried; if both
-  // branches fail, the caller sees a single unable-to-fetch error. This prevents a malicious AS
-  // from declaring an arbitrary issuer and receiving client-attestation PoPs audienced to
-  // another, honest server.
+  
   private func isIssuerBoundToDiscoveryURL(_ metadataIssuer: String?, discoveryURL: URL) -> Bool {
     guard let metadataIssuer, !metadataIssuer.isEmpty else { return false }
     return metadataIssuer == discoveryURL.absoluteString

--- a/Sources/Main/Resolvers/CredentialOffer/CredentialIssuerMetadataResolver.swift
+++ b/Sources/Main/Resolvers/CredentialOffer/CredentialIssuerMetadataResolver.swift
@@ -72,20 +72,20 @@ public actor CredentialIssuerMetadataResolver: CredentialIssuerMetadataType {
         issuerId: issuerId
       )
       
-      // Validate on success
+      // OpenID4VCI: the fetched metadata's credential_issuer MUST be identical to the identifier
+      // the wallet used to discover it — full URL, not just hostname. A hostname-only check lets
+      // a tenant on a shared host serve metadata claiming a sibling tenant's identity.
       if case .success(let metadata) = result {
-        
-        guard
-          let requestHost = wellKnownURL.host,
-          let issuerHost = metadata.credentialIssuerIdentifier.url.host,
-          requestHost.caseInsensitiveCompare(issuerHost) == .orderedSame
-        else {
-          throw ValidationError.error(
-            reason: "Issuer domain does not match metadata issuer"
+        let expected = issuerId.url.absoluteString
+        let actual = metadata.credentialIssuerIdentifier.url.absoluteString
+        guard expected == actual else {
+          throw CredentialIssuerMetadataError.issuerMismatch(
+            expected: expected,
+            actual: actual
           )
         }
       }
-      
+
       return result
     }
   }

--- a/Sources/Main/Resolvers/CredentialOffer/CredentialIssuerMetadataResolver.swift
+++ b/Sources/Main/Resolvers/CredentialOffer/CredentialIssuerMetadataResolver.swift
@@ -72,9 +72,6 @@ public actor CredentialIssuerMetadataResolver: CredentialIssuerMetadataType {
         issuerId: issuerId
       )
       
-      // OpenID4VCI: the fetched metadata's credential_issuer MUST be identical to the identifier
-      // the wallet used to discover it — full URL, not just hostname. A hostname-only check lets
-      // a tenant on a shared host serve metadata claiming a sibling tenant's identity.
       if case .success(let metadata) = result {
         let expected = issuerId.url.absoluteString
         let actual = metadata.credentialIssuerIdentifier.url.absoluteString

--- a/Sources/Main/Resolvers/CredentialOffer/CredentialOfferRequestResolver.swift
+++ b/Sources/Main/Resolvers/CredentialOffer/CredentialOfferRequestResolver.swift
@@ -109,6 +109,7 @@ public actor CredentialOfferRequestResolver {
 
         let domain = try toDomain(
           credentialOfferRequestObject: credentialOfferRequestObject,
+          credentialIssuerId: credentialIssuerId,
           credentialIssuerMetadata: credentialIssuerMetadata,
           authorizationServerMetadata: authorizationServerMetadata
         )
@@ -145,6 +146,7 @@ public actor CredentialOfferRequestResolver {
 
           let domain = try toDomain(
             credentialOfferRequestObject: credentialOfferRequestObject,
+            credentialIssuerId: credentialIssuerId,
             credentialIssuerMetadata: credentialIssuerMetadata,
             authorizationServerMetadata: authorizationServerMetadata
           )
@@ -210,16 +212,19 @@ public actor CredentialOfferRequestResolver {
 
   func toDomain(
     credentialOfferRequestObject: CredentialOfferRequestObject,
+    credentialIssuerId: CredentialIssuerId,
     credentialIssuerMetadata: CredentialIssuerMetadata?,
     authorizationServerMetadata: IdentityAndAccessManagementMetadata
   ) throws -> CredentialOffer {
-    
+
     guard let credentialIssuerMetadata = credentialIssuerMetadata else {
       throw ValidationError.error(reason: "Invalid to fetch credential offer request by reference")
     }
-    
+
+    // Use the identifier that came in with the offer, not the one echoed back in the metadata.
+    // The resolver has already verified they are equal (full-URL match); preserving the offer's
+    // value keeps the trust anchor at the source that supplied it.
     do {
-      let credentialIssuerId = credentialIssuerMetadata.credentialIssuerIdentifier
       let credentialConfigurationIdentifiers: [CredentialConfigurationIdentifier] = credentialOfferRequestObject.credentialConfigurationIds.compactMap { try? CredentialConfigurationIdentifier(value: $0.stringValue) }
       let grants = try credentialOfferRequestObject.grants?.toDomain()
       return try .init(

--- a/Sources/Main/Resolvers/CredentialOffer/CredentialOfferRequestResolver.swift
+++ b/Sources/Main/Resolvers/CredentialOffer/CredentialOfferRequestResolver.swift
@@ -216,14 +216,11 @@ public actor CredentialOfferRequestResolver {
     credentialIssuerMetadata: CredentialIssuerMetadata?,
     authorizationServerMetadata: IdentityAndAccessManagementMetadata
   ) throws -> CredentialOffer {
-
+    
     guard let credentialIssuerMetadata = credentialIssuerMetadata else {
       throw ValidationError.error(reason: "Invalid to fetch credential offer request by reference")
     }
-
-    // Use the identifier that came in with the offer, not the one echoed back in the metadata.
-    // The resolver has already verified they are equal (full-URL match); preserving the offer's
-    // value keeps the trust anchor at the source that supplied it.
+    
     do {
       let credentialConfigurationIdentifiers: [CredentialConfigurationIdentifier] = credentialOfferRequestObject.credentialConfigurationIds.compactMap { try? CredentialConfigurationIdentifier(value: $0.stringValue) }
       let grants = try credentialOfferRequestObject.grants?.toDomain()

--- a/Sources/Resources/europa/oauth_authorization_server_metadata_two.json
+++ b/Sources/Resources/europa/oauth_authorization_server_metadata_two.json
@@ -1,0 +1,28 @@
+{
+  "issuer": "https://auth-server-two.example.com",
+  "authorization_endpoint": "https://auth-server-two.example.com/protocol/openid-connect/auth",
+  "token_endpoint": "https://auth-server-two.example.com/protocol/openid-connect/token",
+  "jwks_uri": "https://auth-server-two.example.com/protocol/openid-connect/certs",
+  "grant_types_supported": [
+    "authorization_code",
+    "refresh_token"
+  ],
+  "response_types_supported": [
+    "code"
+  ],
+  "response_modes_supported": [
+    "query"
+  ],
+  "token_endpoint_auth_methods_supported": [
+    "private_key_jwt"
+  ],
+  "code_challenge_methods_supported": [
+    "S256"
+  ],
+  "dpop_signing_alg_values_supported": [
+    "ES256"
+  ],
+  "require_pushed_authorization_requests": false,
+  "pushed_authorization_request_endpoint": "https://auth-server-two.example.com/par",
+  "authorization_response_iss_parameter_supported": true
+}

--- a/Sources/Resources/europa/oidc_authorization_server_metadata_auth_server_example.json
+++ b/Sources/Resources/europa/oidc_authorization_server_metadata_auth_server_example.json
@@ -1,0 +1,37 @@
+{
+  "issuer": "https://auth-server.example.com",
+  "authorization_endpoint": "https://auth-server.example.com/protocol/openid-connect/auth",
+  "token_endpoint": "https://auth-server.example.com/protocol/openid-connect/token",
+  "jwks_uri": "https://auth-server.example.com/protocol/openid-connect/certs",
+  "grant_types_supported": [
+    "authorization_code",
+    "refresh_token",
+    "urn:ietf:params:oauth:grant-type:pre-authorized_code"
+  ],
+  "response_types_supported": [
+    "code"
+  ],
+  "subject_types_supported": [
+    "public"
+  ],
+  "id_token_signing_alg_values_supported": [
+    "RS256",
+    "ES256"
+  ],
+  "response_modes_supported": [
+    "query"
+  ],
+  "token_endpoint_auth_methods_supported": [
+    "private_key_jwt"
+  ],
+  "code_challenge_methods_supported": [
+    "S256"
+  ],
+  "dpop_signing_alg_values_supported": [
+    "ES256",
+    "RS256"
+  ],
+  "require_pushed_authorization_requests": false,
+  "pushed_authorization_request_endpoint": "https://auth-server.example.com/par",
+  "authorization_response_iss_parameter_supported": true
+}

--- a/Tests/Constants/TestsConstants.swift
+++ b/Tests/Constants/TestsConstants.swift
@@ -278,10 +278,10 @@ struct TestsConstants {
         extension: "json",
         headers: ["Content-type": "application/json"]
       ))))
-    
+
     let authorizationServerMetadataResolver = AuthorizationServerMetadataResolver(
       oidcFetcher: Fetcher<OIDCProviderMetadata>(session: NetworkingMock(
-        path: "oidc_authorization_server_metadata",
+        path: "oidc_authorization_server_metadata_auth_server_example",
         extension: "json"
       )),
       oauthFetcher: Fetcher<AuthorizationServerMetadata>()
@@ -309,10 +309,10 @@ struct TestsConstants {
         extension: "json",
         headers: ["Content-type": "application/json"]
       ))))
-    
+
     let authorizationServerMetadataResolver = AuthorizationServerMetadataResolver(
       oidcFetcher: Fetcher<OIDCProviderMetadata>(session: NetworkingMock(
-        path: "oidc_authorization_server_metadata",
+        path: "oidc_authorization_server_metadata_auth_server_example",
         extension: "json"
       ))
     )
@@ -344,7 +344,7 @@ struct TestsConstants {
 
     let authorizationServerMetadataResolver = AuthorizationServerMetadataResolver(
       oidcFetcher: Fetcher<OIDCProviderMetadata>(session: NetworkingMock(
-        path: "oidc_authorization_server_metadata",
+        path: "oidc_authorization_server_metadata_auth_server_example",
         extension: "json"
       ))
     )
@@ -371,10 +371,10 @@ struct TestsConstants {
         extension: "json",
         headers: ["Content-type": "application/json"]
       ))))
-    
+
     let authorizationServerMetadataResolver = AuthorizationServerMetadataResolver(
       oidcFetcher: Fetcher<OIDCProviderMetadata>(session: NetworkingMock(
-        path: "oidc_authorization_server_metadata",
+        path: "oidc_authorization_server_metadata_auth_server_example",
         extension: "json"
       )),
       oauthFetcher: Fetcher<AuthorizationServerMetadata>()

--- a/Tests/Resolver/CredentialOfferResolverTests.swift
+++ b/Tests/Resolver/CredentialOfferResolverTests.swift
@@ -496,8 +496,6 @@ class CredentialOfferResolverTests: XCTestCase {
 
   func testSelectsSecondAuthServerWhenHintedInMultipleServers() async throws {
     // Given: Metadata with multiple auth servers and offer hints at the second one.
-    // The oauth fixture used here advertises `issuer: https://auth-server-two.example.com`
-    // so that the RFC 8414 issuer==discovery-URL check accepts it.
     let credentialIssuerMetadataResolver = CredentialIssuerMetadataResolver(
       fetcher: MetadataFetcher(
         rawFetcher: RawDataFetcher(
@@ -701,10 +699,8 @@ class CredentialOfferResolverTests: XCTestCase {
       )
     }
   }
-
-  // The metadata fixture claims `credential_issuer: https://credential-issuer.example.com`.
-  // Asking for a sibling tenant path on the same host must fail: hostname alone is not enough
-  // to bind the metadata to the requested identifier.
+  
+  
   func testRejectsMetadataWhoseCredentialIssuerDoesNotMatchRequestedIssuer() async throws {
     let credentialIssuerMetadataResolver = CredentialIssuerMetadataResolver(
       fetcher: createMetadataFetcher())
@@ -729,9 +725,7 @@ class CredentialOfferResolverTests: XCTestCase {
     }
   }
 
-  // RFC 8414 §3.3: authorization server metadata whose `issuer` differs from the URL used
-  // to retrieve it must be unusable. The mock OAuth fixture advertises pid-issuer-realm;
-  // fetching against a different URL must be rejected.
+
   func testRejectsAuthorizationServerMetadataWithMismatchedIssuer() async throws {
     let resolver = AuthorizationServerMetadataResolver(
       oidcFetcher: Fetcher<OIDCProviderMetadata>(session: NetworkingMock(

--- a/Tests/Resolver/CredentialOfferResolverTests.swift
+++ b/Tests/Resolver/CredentialOfferResolverTests.swift
@@ -495,7 +495,9 @@ class CredentialOfferResolverTests: XCTestCase {
   }
 
   func testSelectsSecondAuthServerWhenHintedInMultipleServers() async throws {
-    // Given: Metadata with multiple auth servers and offer hints at the second one
+    // Given: Metadata with multiple auth servers and offer hints at the second one.
+    // The oauth fixture used here advertises `issuer: https://auth-server-two.example.com`
+    // so that the RFC 8414 issuer==discovery-URL check accepts it.
     let credentialIssuerMetadataResolver = CredentialIssuerMetadataResolver(
       fetcher: MetadataFetcher(
         rawFetcher: RawDataFetcher(
@@ -511,7 +513,7 @@ class CredentialOfferResolverTests: XCTestCase {
         extension: "json"
       )),
       oauthFetcher: Fetcher<AuthorizationServerMetadata>(session: NetworkingMock(
-        path: "oauth_authorization_server_metadata",
+        path: "oauth_authorization_server_metadata_two",
         extension: "json"
       ))
     )

--- a/Tests/Resolver/CredentialOfferResolverTests.swift
+++ b/Tests/Resolver/CredentialOfferResolverTests.swift
@@ -701,4 +701,58 @@ class CredentialOfferResolverTests: XCTestCase {
       )
     }
   }
+
+  // The metadata fixture claims `credential_issuer: https://credential-issuer.example.com`.
+  // Asking for a sibling tenant path on the same host must fail: hostname alone is not enough
+  // to bind the metadata to the requested identifier.
+  func testRejectsMetadataWhoseCredentialIssuerDoesNotMatchRequestedIssuer() async throws {
+    let credentialIssuerMetadataResolver = CredentialIssuerMetadataResolver(
+      fetcher: createMetadataFetcher())
+
+    do {
+      _ = try await credentialIssuerMetadataResolver.resolve(
+        source: .credentialIssuer(
+          try .init("https://credential-issuer.example.com/tenant-a")
+        ),
+        policy: .ignoreSigned
+      )
+      XCTFail("Expected mismatch to be rejected")
+    } catch let error as CredentialIssuerMetadataError {
+      guard case .issuerMismatch(let expected, let actual) = error else {
+        XCTFail("Expected issuerMismatch error, got \(error)")
+        return
+      }
+      XCTAssertEqual(expected, "https://credential-issuer.example.com/tenant-a")
+      XCTAssertEqual(actual, "https://credential-issuer.example.com")
+    } catch {
+      XCTFail("Unexpected error type: \(error)")
+    }
+  }
+
+  // RFC 8414 §3.3: authorization server metadata whose `issuer` differs from the URL used
+  // to retrieve it must be unusable. The mock OAuth fixture advertises pid-issuer-realm;
+  // fetching against a different URL must be rejected.
+  func testRejectsAuthorizationServerMetadataWithMismatchedIssuer() async throws {
+    let resolver = AuthorizationServerMetadataResolver(
+      oidcFetcher: Fetcher<OIDCProviderMetadata>(session: NetworkingMock(
+        path: "oidc_authorization_server_metadata",
+        extension: "json"
+      )),
+      oauthFetcher: Fetcher<AuthorizationServerMetadata>(session: NetworkingMock(
+        path: "oauth_authorization_server_metadata",
+        extension: "json"
+      ))
+    )
+
+    let result = await resolver.resolve(
+      url: URL(string: "https://different-authorization-server.example.com")!
+    )
+
+    switch result {
+    case .success:
+      XCTFail("Expected mismatched issuer to be rejected")
+    case .failure:
+      XCTAssertTrue(true)
+    }
+  }
 }


### PR DESCRIPTION
# Description of change
Addresses #322 , #323 , #324 , #325 

Closes four security findings that all stem from weak or missing binding between an identifier the wallet trusts and the URL the corresponding metadata was fetched from.
  
  ## Changes
  
  - **`CredentialIssuerMetadataResolver`** — full-URL comparison between the
    requested `CredentialIssuerId` and the metadata's `credential_issuer`
    (was hostname-only).
  - **`CredentialOfferRequestResolver`** — the identifier that came in with the
    offer is preserved into `CredentialOffer` instead of the value echoed back
    by the metadata.
  - **`AuthorizationServerMetadataResolver`** — RFC 8414 §3.3 enforced: metadata
    whose `issuer` doesn't equal the discovery URL is treated as unusable; if
    OAuth fails, OIDC is still tried (existing fallback preserved).
  
  The primary client-attestation relay attack chain is closed transitively by
  the RFC 8414 fix — an AS can no longer masquerade as another.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes