### PR TITLE
Fix: Propagate encryption metadata decode errors instead of swallowing

### DIFF
--- a/Sources/Entities/CredentialIssuer/CredentialIssuerMetadata.swift
+++ b/Sources/Entities/CredentialIssuer/CredentialIssuerMetadata.swift
@@ -141,15 +141,15 @@ public struct CredentialIssuerMetadata: Decodable, Equatable, Sendable {
       forKey: .notificationEndpoint
     )
     
-    credentialResponseEncryption = (try? container.decode(
+    credentialResponseEncryption = try container.decodeIfPresent(
       CredentialResponseEncryption.self,
       forKey: .credentialResponseEncryption
-    )) ?? .notSupported
-    
-    credentialRequestEncryption = (try? container.decode(
+    ) ?? .notSupported
+
+    credentialRequestEncryption = try container.decodeIfPresent(
       CredentialRequestEncryption.self,
       forKey: .credentialRequestEncryption
-    )) ?? .notSupported
+    ) ?? .notSupported
     
     // If issuer supports and requires credential response encryption then it must advertise its request encryption capabilities
     if !credentialResponseEncryption.notSupported, credentialResponseEncryption.required {

--- a/Sources/Entities/Encryption/CredentialRequestEncryption.swift
+++ b/Sources/Entities/Encryption/CredentialRequestEncryption.swift
@@ -48,7 +48,7 @@ public enum CredentialRequestEncryption: Decodable, Sendable {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     
     let encryptionRequired = (try? container.decode(Bool.self, forKey: .encryptionRequired)) ?? false
-    let jwkWrappers = try? container.decodeIfPresent(JWKSet.self, forKey: .jwks)
+    let jwkWrappers = try container.decodeIfPresent(JWKSet.self, forKey: .jwks)
     let jwks = jwkWrappers?.keys.map(\.key) ?? []
     let encryptionMethodsSupported = try? container.decode([JOSEEncryptionMethod].self, forKey: .encryptionMethodsSupported)
     let compressionMethodsSupported = try? container.decode([CompressionAlgorithm].self, forKey: .compressionMethodsSupported)

--- a/Tests/Entities/CredentialIssuerMetadataEncryptionDecodeTests.swift
+++ b/Tests/Entities/CredentialIssuerMetadataEncryptionDecodeTests.swift
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Foundation
+import XCTest
+
+@testable import OpenID4VCI
+
+/// Locks in the invariant that a present-but-invalid encryption block on the
+/// credential-issuer metadata surfaces its decode error to the caller instead
+/// of silently downgrading to `.notSupported`.
+final class CredentialIssuerMetadataEncryptionDecodeTests: XCTestCase {
+
+  private func decodeMetadata(_ json: String) throws -> CredentialIssuerMetadata {
+    try JSONDecoder().decode(
+      CredentialIssuerMetadata.self,
+      from: Data(json.utf8)
+    )
+  }
+
+  // A response encryption block that requires encryption but advertises neither algorithms nor
+  // methods must fail loudly; previously the nested throw was swallowed by `try?` and turned
+  // into `.notSupported`.
+  func testResponseEncryptionRequiredWithoutAlgorithmsSurfacesError() {
+    let json = """
+    {
+      "credential_issuer": "https://issuer.example.com",
+      "credential_endpoint": "https://issuer.example.com/credentials",
+      "credential_response_encryption": {
+        "encryption_required": true
+      }
+    }
+    """
+
+    XCTAssertThrowsError(try decodeMetadata(json))
+  }
+
+  // Same shape on the request side: `encryption_required: true` with no JWKS and no methods
+  // must propagate the decode error rather than silently mark the request path as unsupported.
+  func testRequestEncryptionRequiredWithoutJWKSSurfacesError() {
+    let json = """
+    {
+      "credential_issuer": "https://issuer.example.com",
+      "credential_endpoint": "https://issuer.example.com/credentials",
+      "credential_request_encryption": {
+        "encryption_required": true
+      }
+    }
+    """
+
+    XCTAssertThrowsError(try decodeMetadata(json))
+  }
+
+  // A JWK whose `kty` is neither RSA nor EC (X25519 / OKP is valid per RFC 8037 but not
+  // handled by the current wallet decoder) must not silently empty the JWK list. The decode
+  // error should reach the caller instead.
+  func testRequestEncryptionWithUnsupportedJWKTypeSurfacesError() {
+    let json = """
+    {
+      "credential_issuer": "https://issuer.example.com",
+      "credential_endpoint": "https://issuer.example.com/credentials",
+      "credential_request_encryption": {
+        "encryption_required": false,
+        "jwks": {
+          "keys": [
+            {
+              "kty": "OKP",
+              "crv": "X25519",
+              "kid": "okp-1",
+              "x": "MKrJ8UeKlXpBH7RRxOgnihcpwZfcyaK1Rr5s6yiTG0Q"
+            }
+          ]
+        },
+        "enc_values_supported": ["A128GCM"]
+      }
+    }
+    """
+
+    XCTAssertThrowsError(try decodeMetadata(json))
+  }
+
+  // A missing encryption block must still default to `.notSupported` (unchanged behavior).
+  func testMissingEncryptionBlocksDefaultToNotSupported() throws {
+    let json = """
+    {
+      "credential_issuer": "https://issuer.example.com",
+      "credential_endpoint": "https://issuer.example.com/credentials"
+    }
+    """
+
+    let metadata = try decodeMetadata(json)
+    XCTAssertTrue(metadata.credentialResponseEncryption.notSupported)
+    XCTAssertTrue(metadata.credentialRequestEncryption?.notSupported ?? false)
+  }
+}


### PR DESCRIPTION
# Description of change


Closes three security findings that all stem from the same pattern: `try? ... ?? .notSupported` on the credential-issuer metadata's encryption blocks silently turned every deliberate decoder throw (required encryption with no algorithms, unsupported enc method, unrecognised JWK type) into "this issuer supports no encryption".
  
  ## Changes
  
  - **`CredentialIssuerMetadata.init(from:)`** — outer `try?` swapped for
    `decodeIfPresent`. A missing block still defaults to `.notSupported`; a
    present-but-invalid block surfaces its decode error.
  - **`CredentialRequestEncryption.init(from:)`** — inner `try?` on the JWK
    set removed. An unsupported recipient JWK type (for example X25519 / OKP)
    no longer silently empties the key list.
  
Dedicated errors `unsupportedRequestEncryptionMethods` and `unsupportedResponseEncryptionMethods` become reachable again.


Addresses #331 , #332 , and partially the #333.  
"Adding X25519 / OKP recipient key support" and "Decoupling request and response encryption" are left for future PRs


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes